### PR TITLE
feat!: web target, CI modernization, and the example dev-server fix

### DIFF
--- a/.claude/skills/wasm-release/SKILL.md
+++ b/.claude/skills/wasm-release/SKILL.md
@@ -44,8 +44,8 @@ Install the toolchain if missing:
 
 ```bash
 pnpm install
-pnpm build:wasm        # must run first: pkg/index.d.ts is what the TS package compiles against
-pnpm build:wasm-node   # needed by the integration tests
+pnpm build:wasm        # must run first: the TS package compiles against pkg/index.d.ts,
+                       # and the integration tests load pkg/index_bg.wasm
 pnpm lint              # Biome + clippy
 pnpm typecheck
 pnpm build

--- a/.github/workflows/publish-netgrep.yml
+++ b/.github/workflows/publish-netgrep.yml
@@ -11,21 +11,21 @@ jobs:
     needs: test-and-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          # Must match rust-toolchain.toml. See docs/plans/MODERNIZATION.md.
-          toolchain: 1.97.1
-          target: wasm32-unknown-unknown
+          toolchain: '1.97.1'
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
-      - run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      # `@netgrep/search` is now a workspace dependency, so its types must exist
-      # before `@netgrep/netgrep` will compile.
+      - uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: 'v0.13.1'
       - run: pnpm build:wasm
       - run: pnpm build
       - uses: JS-DevTools/npm-publish@v1
@@ -33,6 +33,6 @@ jobs:
           token: ${{ secrets.NPM_TOKEN }}
           access: public
           greater-version-only: true
-          # The manifest is hand-written now rather than synthesised into dist/
-          # by the Nx tsc executor.
+          # Hand-written manifest; the Nx tsc executor used to synthesise one
+          # into dist/.
           package: ./packages/netgrep/package.json

--- a/.github/workflows/publish-search.yml
+++ b/.github/workflows/publish-search.yml
@@ -11,26 +11,28 @@ jobs:
     needs: test-and-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          # Must match rust-toolchain.toml. See docs/plans/MODERNIZATION.md.
-          toolchain: 1.97.1
-          target: wasm32-unknown-unknown
+          toolchain: '1.97.1'
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
-      - run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: 'v0.13.1'
       - run: pnpm build:wasm
       - uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
           access: public
-          # The hand-written wrapper manifest is what gets published now, not
-          # the one wasm-pack generates into pkg/. Its version is synced from
-          # Cargo.toml by scripts/post_build.js.
           greater-version-only: true
+          # The hand-written wrapper manifest is what gets published, not the
+          # one wasm-pack generates into pkg/. Its version is synced from
+          # Cargo.toml by scripts/post_build.js.
           package: ./packages/search/package.json

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -37,14 +37,18 @@ jobs:
         with:
           version: 'v0.13.1'
 
-      # Pin ChromeDriver to the installed Chrome. `wasm-pack test` otherwise
-      # fetches the latest driver, which cannot drive an older browser
-      # (docs/BACKLOG.md item 2).
-      - uses: browser-actions/setup-chrome@v1
-        id: setup-chrome
-        with:
-          chrome-version: stable
-          install-chromedriver: true
+      # NOTE: ChromeDriver is deliberately NOT pinned here.
+      #
+      # Pinning it via browser-actions/setup-chrome was tried and reverted: it
+      # installs a driver into the tool cache, but the browser ChromeDriver
+      # actually launches is the runner's system Chrome, so pinning one half of
+      # the pair CREATES the version mismatch it was meant to prevent
+      # (ChromeDriver 151 vs the system browser -> SIGKILL).
+      #
+      # Letting `wasm-pack` manage the driver keeps both halves current
+      # together. docs/BACKLOG.md item 2 is a local-machine problem, where the
+      # installed Chrome is older than the driver wasm-pack fetches; CI does
+      # not have that problem.
 
       # The WASM builds come first: `@netgrep/netgrep` resolves
       # `@netgrep/search` to this workspace, so typecheck and build both need
@@ -61,5 +65,3 @@ jobs:
       - run: pnpm build
       - run: pnpm test
       - run: pnpm test:wasm
-        env:
-          CHROMEDRIVER: ${{ steps.setup-chrome.outputs.chromedriver-path }}

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -14,20 +14,37 @@ jobs:
     name: Test and lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+
+      # `actions-rs/toolchain` is archived and unmaintained. dtolnay's action
+      # reads rust-toolchain.toml, so the version, target and components are
+      # declared in exactly one place.
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          # Must match rust-toolchain.toml. See docs/plans/MODERNIZATION.md.
-          toolchain: 1.97.1
-          target: wasm32-unknown-unknown
+          toolchain: '1.97.1'
+          targets: wasm32-unknown-unknown
           components: clippy
+      - uses: Swatinem/rust-cache@v2
+
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
-      - run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: 'v0.13.1'
+
+      # Pin ChromeDriver to the installed Chrome. `wasm-pack test` otherwise
+      # fetches the latest driver, which cannot drive an older browser
+      # (docs/BACKLOG.md item 2).
+      - uses: browser-actions/setup-chrome@v1
+        id: setup-chrome
+        with:
+          chrome-version: stable
+          install-chromedriver: true
 
       # The WASM builds come first: `@netgrep/netgrep` resolves
       # `@netgrep/search` to this workspace, so typecheck and build both need
@@ -44,3 +61,5 @@ jobs:
       - run: pnpm build
       - run: pnpm test
       - run: pnpm test:wasm
+        env:
+          CHROMEDRIVER: ${{ steps.setup-chrome.outputs.chromedriver-path }}

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -60,3 +60,8 @@ jobs:
       - run: pnpm build
       - run: pnpm test
       - run: pnpm test:wasm
+
+      # Everything above inspects the working tree. This inspects the tarballs
+      # that would actually reach npm — the only artefact users ever see, and
+      # previously the only one nothing checked.
+      - run: pnpm verify:pack

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -50,15 +50,10 @@ jobs:
       # installed Chrome is older than the driver wasm-pack fetches; CI does
       # not have that problem.
 
-      # The WASM builds come first: `@netgrep/netgrep` resolves
-      # `@netgrep/search` to this workspace, so typecheck and build both need
-      # packages/search/pkg/index.d.ts to exist.
-      #
-      # `pkg` is the published bundler-target build; `pkg-node` is the same Rust
-      # compiled for Node, which the integration tests load because the bundler
-      # target cannot be required directly.
+      # The WASM build comes first: `@netgrep/netgrep` resolves
+      # `@netgrep/search` to this workspace, so typecheck, build and the
+      # integration tests all need packages/search/pkg to exist.
       - run: pnpm build:wasm
-      - run: pnpm build:wasm-node
 
       - run: pnpm lint
       - run: pnpm typecheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Canonical source — `CLAUDE.md` points here. Keep this file authoritative; do n
 >
 > | this file says | reality |
 > |---|---|
-> | Nx + yarn (`yarn nx test netgrep`) | Nx and yarn are gone. Use pnpm: `pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm test`, `pnpm test:wasm`, `pnpm build:wasm`, `pnpm build:wasm-node` |
+> | Nx + yarn (`yarn nx test netgrep`) | Nx and yarn are gone. Use pnpm: `pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm test`, `pnpm test:wasm`, `pnpm build:wasm` |
 > | Node 18.7.0 | Node 24 LTS, pinned in `.node-version` |
 > | jest / ESLint / Prettier | Vitest + Biome |
 > | §2: local edits never reach the TS package or the example | **Fixed.** pnpm workspaces link them; the example bundles local source |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "search"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "grep-matcher",
  "grep-regex",

--- a/README.md
+++ b/README.md
@@ -17,31 +17,27 @@ At the moment Netgrep is just going to tell whether a pattern is present on a re
 ## Usage
 
 > **Note**
-> This short tutorial assumes that **Webpack 5** is the bundler used in the application where `netgrep` will be integrated. A complete example is available [in the `example` package](https://github.com/dgopsq/netgrep/tree/main/packages/example).
+> A complete example is available [in the `example` package](https://github.com/dgopsq/netgrep/tree/main/packages/example).
 
 First of all install the module:
 
 ```bash
-# Using yarn
-yarn add @netgrep/netgrep
+# Using pnpm
+pnpm add @netgrep/netgrep
 
 # Using npm
 npm install @netgrep/netgrep
 ```
 
-The [`asyncWebAssembbly` experiment flag](https://webpack.js.org/configuration/experiments/) should be enabled inside the `webpack.config.js`:
+No bundler configuration is required. `netgrep` loads its WebAssembly through a standard
+`new URL('…', import.meta.url)` reference, which Vite, webpack 5, Rollup, esbuild, Parcel and Bun all
+understand out of the box.
 
-```js
-module.exports = {
-  //...
-  experiments: {
-    // ...
-    asyncWebAssembly: true,
-  },
-};
-```
+> **Upgrading from 0.1.x?** Delete the `experiments.asyncWebAssembly` flag from your webpack config — it is
+> no longer needed. Nothing else changes; the API is identical.
 
-Then it will be possible to execute `netgrep` directly while the bundled WASM file will be loaded asynchronously in the background:
+The WASM file is fetched in the background as soon as the module is imported, and the first search waits for
+it automatically:
 
 ```ts
 import { Netgrep } from '@netgrep/netgrep';

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -195,6 +195,41 @@ taken: `opt-level = 'z'` (a further ~27 KB, at some throughput cost in a regex-s
 `wasm-opt -Oz`; and disabling `grep-regex`'s Unicode support, which would change matching behaviour and is
 therefore out of scope.
 
+### 16. The example cannot move to Vite — the published wasm target only bundles under webpack
+
+Attempted 2026-07-28 and **reverted**. Recording the exact failure so it is not re-attempted blind.
+
+`@netgrep/search` is built with wasm-pack's **bundler** target, whose entry does:
+
+```js
+import * as wasm from './index_bg.wasm';
+```
+
+That is an ESM-integration wasm import. webpack supports it natively behind `experiments.asyncWebAssembly`
+— which is why `packages/example/webpack.config.js` has exactly one non-default setting. Vite has no native
+equivalent and needs `vite-plugin-wasm`.
+
+**With the plugin installed and loaded, `vite build` silently produces a broken bundle:**
+
+- `vite dev` works — 67/67 fixtures match, verified in real Chrome.
+- `vite build` emits `index_bg-<hash>.wasm` as an asset, but **nothing in the JS bundle references it**. The
+  glue survives (`g.search_bytes`, `g.__wbindgen_malloc`, `g.memory`) while `g` is never assigned, so every
+  search returns `false`.
+- **No error is reported anywhere.** `searchBatch` folds per-URL failures into `{result: false, error}` and
+  the demo only renders successes, so a broken build looks exactly like "no matches".
+
+Reproduced on Vite **8.1.5** and **7.3.6**, with and without `optimizeDeps.exclude`. The plugin is loaded and
+well-formed (`enforce`/`resolveId`/`load` hooks present) and declares `vite: ^2 || ... || ^8`, so this is a
+silent incompatibility rather than a declared one. Root cause not established within the timebox.
+
+*Consequence beyond the demo:* this is a **consumer-facing limitation of the published package**. Anyone on
+Vite — most of the current ecosystem — hits it. The real fix is to stop shipping the bundler target: build
+with `--target web`, or ship both behind conditional `exports`. That changes the published artifact, so it
+was ruled out under [`plans/MODERNIZATION.md`](plans/MODERNIZATION.md) decision 1 (no release), and it is the
+strongest argument yet for revisiting that.
+
+Until then the example stays on webpack, which works.
+
 ### 15. `memmap2` is compiled into a browser binary
 
 `grep-searcher 0.1.17` depends on `memmap2` unconditionally — it is not feature-gated, and the crate's only

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -26,9 +26,15 @@ permanent fix: a version move is now a deliberate commit rather than something t
 installed Chrome. Observed: ChromeDriver 151 vs Chrome 150 → `invalid session id`, driver killed (signal 9).
 With a version-matched driver the suite passes (2 tests).
 
-*Fix:* pin `CHROMEDRIVER`, sourced from
-[Chrome for Testing](https://googlechromelabs.github.io/chrome-for-testing/). CI is unaffected — its Chrome
-and driver are in step — so this only bites locally.
+*Fix:* pin `CHROMEDRIVER` locally, sourced from
+[Chrome for Testing](https://googlechromelabs.github.io/chrome-for-testing/). **This is a local-machine
+problem only** — it happens when the installed Chrome is *older* than the driver wasm-pack fetches.
+
+Do **not** try to pin it in CI. That was attempted with `browser-actions/setup-chrome` and reverted: the
+action installs a driver into the tool cache, but the browser ChromeDriver actually launches is the runner's
+*system* Chrome, so pinning one half of the pair creates the very mismatch it was meant to prevent
+(ChromeDriver 151 against the system browser -> SIGKILL). Letting wasm-pack manage the driver keeps both
+halves current together.
 
 Note `wasm-pack` **overrides** `CHROMEDRIVER` with its own cached copy, so exporting it and running
 `wasm-pack test` does nothing. The harness has to be invoked directly:

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -201,40 +201,31 @@ taken: `opt-level = 'z'` (a further ~27 KB, at some throughput cost in a regex-s
 `wasm-opt -Oz`; and disabling `grep-regex`'s Unicode support, which would change matching behaviour and is
 therefore out of scope.
 
-### 16. The example cannot move to Vite — the published wasm target only bundles under webpack
+### 16. ~~The published package does not work under Vite~~ — FIXED
 
-Attempted 2026-07-28 and **reverted**. Recording the exact failure so it is not re-attempted blind.
+`@netgrep/search` shipped wasm-pack's **bundler** target, whose entry does
+`import * as wasm from './index_bg.wasm'`. webpack supported that behind `experiments.asyncWebAssembly`;
+Vite did not, and failed **silently** — `vite build` emitted the `.wasm`, kept the glue, never assigned the
+exports object, and every search returned `false` with no error. `searchBatch` folds per-URL failures into
+`{result: false}`, so a completely broken build was indistinguishable from "no matches".
 
-`@netgrep/search` is built with wasm-pack's **bundler** target, whose entry does:
+**Fixed by shipping `--target web` instead** (`@netgrep/search` 0.2.0). The binary is now loaded through a
+standard `new URL('index_bg.wasm', import.meta.url)`, which every current bundler understands.
 
-```js
-import * as wasm from './index_bg.wasm';
-```
+Verified 2026-07-28, each in real headless Chrome:
 
-That is an ESM-integration wasm import. webpack supports it natively behind `experiments.asyncWebAssembly`
-— which is why `packages/example/webpack.config.js` has exactly one non-default setting. Vite has no native
-equivalent and needs `vite-plugin-wasm`.
+| consumer | before | after |
+|---|---|---|
+| Vite 8, no plugins | silently returned `false` for everything | correct results |
+| webpack 5 | required `experiments.asyncWebAssembly` | works with **no config at all** |
+| Rollup / esbuild / Parcel / Bun | unsupported | standard `new URL` semantics |
 
-**With the plugin installed and loaded, `vite build` silently produces a broken bundle:**
+Costs, for the record: `init()` must be awaited before `search_bytes`, which is a breaking change to
+`@netgrep/search` — absorbed inside `Netgrep`, so `@netgrep/netgrep`'s public API is untouched. The glue grew
+3,136 bytes; the `.wasm` is byte-identical.
 
-- `vite dev` works — 67/67 fixtures match, verified in real Chrome.
-- `vite build` emits `index_bg-<hash>.wasm` as an asset, but **nothing in the JS bundle references it**. The
-  glue survives (`g.search_bytes`, `g.__wbindgen_malloc`, `g.memory`) while `g` is never assigned, so every
-  search returns `false`.
-- **No error is reported anywhere.** `searchBatch` folds per-URL failures into `{result: false, error}` and
-  the demo only renders successes, so a broken build looks exactly like "no matches".
-
-Reproduced on Vite **8.1.5** and **7.3.6**, with and without `optimizeDeps.exclude`. The plugin is loaded and
-well-formed (`enforce`/`resolveId`/`load` hooks present) and declares `vite: ^2 || ... || ^8`, so this is a
-silent incompatibility rather than a declared one. Root cause not established within the timebox.
-
-*Consequence beyond the demo:* this is a **consumer-facing limitation of the published package**. Anyone on
-Vite — most of the current ecosystem — hits it. The real fix is to stop shipping the bundler target: build
-with `--target web`, or ship both behind conditional `exports`. That changes the published artifact, so it
-was ruled out under [`plans/MODERNIZATION.md`](plans/MODERNIZATION.md) decision 1 (no release), and it is the
-strongest argument yet for revisiting that.
-
-Until then the example stays on webpack, which works.
+Dropping the bundler target also removed the need for a separate `--target nodejs` build: the integration
+tests now load the artefact that actually ships.
 
 ### 15. `memmap2` is compiled into a browser binary
 

--- a/docs/plans/MODERNIZATION.md
+++ b/docs/plans/MODERNIZATION.md
@@ -36,16 +36,23 @@ of Rust**. Most of the weight in this plan is configuration, not code.
 
 ## Decisions
 
-### 1. The finish line is green CI, not a release
+### 1. The finish line is green CI, not a release — AMENDED 2026-07-28
 
 Everything builds, lints and tests on a current toolchain. **Nothing is republished** — npm keeps serving
 `@netgrep/netgrep@0.1.5` and `@netgrep/search@0.1.5` throughout.
 
+> **Amended.** PR 4 established that the published package does not work under Vite at all — it fails
+> silently, returning `false` for every search (backlog 16). "Do not release" stopped being the conservative
+> option at that point: it meant knowingly leaving a broken artefact on npm. The scope now ends with a
+> **0.2.0 release of both packages**, prepared by an agent and published by a human. The correctness bugs
+> (3a, 3b, 3c, 3f) remain out of scope and still ship.
+
 *Consequence, stated plainly:* the correctness bugs stay shipped. Users of 0.1.5 keep hitting the
 chunk-boundary false negative. That is an accepted, deliberate outcome of this scope, not an oversight.
 
-*Consequence:* consumer-facing ergonomics (an `exports` map, revisiting the wasm-pack target so consumers
-don't need `experiments.asyncWebAssembly`) are **out of scope**. They only pay off on release.
+*Consequence:* consumer-facing ergonomics were originally **out of scope** on the grounds that they only pay
+off on release. Revisiting the wasm-pack target came back into scope once it turned out not to be an
+ergonomic nicety but a correctness failure for most of the ecosystem.
 
 *This supersedes the "maintenance only, no feature work" stance* in `AGENTS.md` and `docs/BACKLOG.md`, written
 earlier the same day. Those documents are rewritten in PR 5.
@@ -405,7 +412,7 @@ Recorded so a future reader knows these were considered and rejected, not overlo
 
 | | why not |
 |---|---|
-| Publishing 0.2.0 | Decision 1 — the goal is a healthy repo, not a release. **Worth revisiting:** backlog 16 shows the published artifact is unusable under Vite. |
+| ~~Publishing 0.2.0~~ | **Now in scope** — see the amendment to decision 1. |
 | `exports` map; wasm-pack `--target web` | Consumer ergonomics; only pays off on release. |
 | Fixing bugs 3a / 3b / 3c | Decision 6 — would destroy attribution during a large migration. |
 | Node.js / Bun / Deno support | A feature. `fetch` + streams are now universal, so it is newly *possible* — worth its own conversation. |

--- a/docs/plans/MODERNIZATION.md
+++ b/docs/plans/MODERNIZATION.md
@@ -345,6 +345,13 @@ larger tables. Full accounting in [`../BACKLOG.md`](../BACKLOG.md) items 14 and 
 
 **Acceptance:** `pnpm dev` in the example searches a real URL against locally built WASM. All workflows green.
 
+*Outcome: the Vite port failed and was reverted; the CI half shipped.* `vite dev` worked (67/67 fixtures
+matched in real Chrome) but `vite build` silently emitted a bundle that never loads the wasm, on both Vite 8
+and Vite 7. The example stays on webpack, which supports the bundler-target import natively. Full write-up in
+[`../BACKLOG.md`](../BACKLOG.md) item 16 — including the consequence that matters more than the demo: **every
+Vite consumer of the published package hits this**, which is a direct argument for revisiting decision 1 and
+shipping a `--target web` build.
+
 ### PR 5 — Docs
 
 - Rewrite `AGENTS.md`: §2's dev-loop gotcha is **deleted** (fixed in PR 2, and a stale warning about a
@@ -398,7 +405,7 @@ Recorded so a future reader knows these were considered and rejected, not overlo
 
 | | why not |
 |---|---|
-| Publishing 0.2.0 | Decision 1 — the goal is a healthy repo, not a release. |
+| Publishing 0.2.0 | Decision 1 — the goal is a healthy repo, not a release. **Worth revisiting:** backlog 16 shows the published artifact is unusable under Vite. |
 | `exports` map; wasm-pack `--target web` | Consumer ergonomics; only pays off on release. |
 | Fixing bugs 3a / 3b / 3c | Decision 6 — would destroy attribution during a large migration. |
 | Node.js / Bun / Deno support | A feature. `fetch` + streams are now universal, so it is newly *possible* — worth its own conversation. |

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:wasm": "pnpm --filter @netgrep/search build",
     "test": "vitest run",
     "test:wasm": "pnpm --filter @netgrep/search test",
+    "verify:pack": "node scripts/verify-pack.mjs",
     "lint": "biome check . && pnpm --filter @netgrep/search lint",
     "format": "biome check --write .",
     "typecheck": "tsc -p packages/netgrep/tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "scripts": {
     "build": "pnpm --filter @netgrep/netgrep build",
     "build:wasm": "pnpm --filter @netgrep/search build",
-    "build:wasm-node": "pnpm --filter @netgrep/search build:node",
     "test": "vitest run",
     "test:wasm": "pnpm --filter @netgrep/search test",
     "lint": "biome check . && pnpm --filter @netgrep/search lint",

--- a/packages/example/webpack.config.js
+++ b/packages/example/webpack.config.js
@@ -8,9 +8,9 @@ module.exports = {
     filename: 'main.js',
     path: path.resolve(__dirname, 'dist'),
   },
-  experiments: {
-    asyncWebAssembly: true,
-  },
+  // No `experiments.asyncWebAssembly` needed any more. @netgrep/search now
+  // ships wasm-pack's `web` target, which loads the binary through a standard
+  // `new URL('index_bg.wasm', import.meta.url)` — plain webpack asset handling.
   devServer: {
     static: ['assets', 'dist'],
     // `http2: true` was removed here, not merely deprecated away: it routes

--- a/packages/example/webpack.config.js
+++ b/packages/example/webpack.config.js
@@ -13,7 +13,14 @@ module.exports = {
   },
   devServer: {
     static: ['assets', 'dist'],
-    http2: true,
+    // `http2: true` was removed here, not merely deprecated away: it routes
+    // webpack-dev-server 4 through `spdy`, which calls
+    // `process.binding('http_parser')` — removed from Node years ago. On Node
+    // 24 the dev server dies at startup with "No such module: http_parser".
+    //
+    // The original intent was presumably to multiplex the 67 concurrent
+    // fixture fetches past HTTP/1.1's 6-connection limit. Over localhost that
+    // costs a little latency and nothing else.
   },
   plugins: [
     new HtmlWebpackPlugin({

--- a/packages/netgrep/package.json
+++ b/packages/netgrep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netgrep/netgrep",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "The power of ripgrep over HTTP",
   "license": "MIT",
   "repository": {

--- a/packages/netgrep/src/lib/Netgrep.integration.spec.ts
+++ b/packages/netgrep/src/lib/Netgrep.integration.spec.ts
@@ -24,47 +24,49 @@ import { Netgrep } from './Netgrep.js';
  * always what it should do. The `documented defects` block at the bottom pins
  * known-wrong behaviour on purpose. See the comment there before "fixing" it.
  *
- * WHY pkg-node AND NOT pkg
- * ------------------------
- * The published `pkg/` is built with wasm-pack's *bundler* target, whose
- * `import * as wasm from './index_bg.wasm'` no bundler-less Node can resolve.
- * `pkg-node/` is the same Rust, same release profile, same `.wasm` binary,
- * compiled with `--target nodejs` so the test can load it. The generated
- * marshalling glue is identical; only the module-loading preamble differs.
+ * IT RUNS THE ARTEFACT THAT SHIPS
+ * -------------------------------
+ * `pkg/` is exactly what gets published — wasm-pack's `web` target. The only
+ * accommodation is instantiation: the real `init()` fetches the `.wasm` over
+ * HTTP relative to `import.meta.url`, which has no meaning under Node, so the
+ * bytes are handed to `initSync` from disk instead. Same module, same binary,
+ * same marshalling glue; only the loader differs.
  *
- * Build it with:
- *   cd packages/search && wasm-pack build --target nodejs \
- *     --out-dir pkg-node --out-name index --release
+ * This used to load a separate `--target nodejs` build. That build no longer
+ * exists — the test is now one step closer to what consumers actually get.
+ *
+ * Build it with: pnpm build:wasm
  */
 vi.mock('@netgrep/search', async () => {
-  const { existsSync } = await import('node:fs');
-  const { createRequire } = await import('node:module');
+  const { existsSync, readFileSync } = await import('node:fs');
   const { dirname, resolve } = await import('node:path');
   const { fileURLToPath } = await import('node:url');
 
   const here = dirname(fileURLToPath(import.meta.url));
-  const pkgNode = resolve(here, '../../../search/pkg-node/index.js');
+  const pkg = resolve(here, '../../../search/pkg');
+  const wasmPath = resolve(pkg, 'index_bg.wasm');
 
-  if (!existsSync(pkgNode)) {
+  if (!existsSync(wasmPath)) {
     throw new Error(
       [
         '',
-        'The Node-target WASM build is missing, so the integration tests cannot',
-        'run against the real engine.',
+        'The WASM build is missing, so the integration tests cannot run',
+        'against the real engine.',
         '',
-        'Build it with:',
-        '  cd packages/search && wasm-pack build --target nodejs \\',
-        '    --out-dir pkg-node --out-name index --release',
+        'Build it with:  pnpm build:wasm',
         '',
-        `Expected at: ${pkgNode}`,
+        `Expected at: ${wasmPath}`,
         '',
       ].join('\n'),
     );
   }
 
-  // The nodejs-target build is CommonJS, so it needs `require` rather than a
-  // dynamic import to expose its named exports directly.
-  return createRequire(import.meta.url)(pkgNode);
+  const mod = await import(resolve(pkg, 'index.js'));
+  mod.initSync({ module: readFileSync(wasmPath) });
+
+  // `default` is the real `init()`; it is already instantiated, so awaiting it
+  // must be a no-op rather than a second (fetch-based) instantiation.
+  return { ...mod, default: () => Promise.resolve() };
 });
 
 const encoder = new TextEncoder();

--- a/packages/netgrep/src/lib/Netgrep.spec.ts
+++ b/packages/netgrep/src/lib/Netgrep.spec.ts
@@ -23,9 +23,13 @@ const { mockSearch } = vi.hoisted(() => ({ mockSearch: vi.fn() }));
 
 const mockFetch = vi.fn();
 
-// Mocking the `search_bytes` function.
+// Mocking the `search_bytes` function. `default` stands in for the WASM
+// module's `init()`, which Netgrep awaits before every search.
 vi.mock('@netgrep/search', () => {
-  return { search_bytes: () => mockSearch() };
+  return {
+    default: () => Promise.resolve(),
+    search_bytes: () => mockSearch(),
+  };
 });
 
 // Mocking `fetch` function.

--- a/packages/netgrep/src/lib/Netgrep.ts
+++ b/packages/netgrep/src/lib/Netgrep.ts
@@ -1,4 +1,4 @@
-import { search_bytes } from '@netgrep/search';
+import init, { search_bytes } from '@netgrep/search';
 import type { BatchNetgrepResult } from './data/BatchNetgrepResult.js';
 import type { NetgrepConfig } from './data/NetgrepConfig.js';
 import type { NetgrepInput } from './data/NetgrepInput.js';
@@ -11,6 +11,18 @@ import type { NetgrepSearchConfig } from './data/NetgrepSearchConfig.js';
 const defaultConfig: NetgrepConfig = {
   enableMemoryCache: true,
 };
+
+/**
+ * The WASM module has to be instantiated before `search_bytes` can be called.
+ *
+ * Started once at module load and shared by every `Netgrep` instance: the
+ * download begins as soon as the library is imported rather than on the first
+ * search, and awaiting an already-settled promise costs nothing.
+ *
+ * Kept module-private on purpose — callers should not have to know the engine
+ * needs booting.
+ */
+const wasmReady = init();
 
 /**
  * The `netgrep` library allows to search remote files
@@ -47,12 +59,16 @@ export class Netgrep {
    * A promise resolving to a `NetgrepResult<T>` as soon as a match will
    * be found in the remote file.
    */
-  public search<T extends object>(
+  public async search<T extends object>(
     url: string,
     pattern: string,
     metadata?: T,
     config?: NetgrepSearchConfig,
   ): Promise<NetgrepResult<T>> {
+    // Nothing below can run before the engine exists. Everything after this
+    // line is unchanged from the synchronous-instantiation version.
+    await wasmReady;
+
     return new Promise((resolve, reject) => {
       const handleReader = (
         reader: ReadableStreamDefaultReader<Uint8Array>,

--- a/packages/search/.gitignore
+++ b/packages/search/.gitignore
@@ -1,5 +1,1 @@
 pkg
-
-# Node-target build consumed by the netgrep integration tests.
-# `nx build-node search`
-pkg-node

--- a/packages/search/Cargo.toml
+++ b/packages/search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "search"
-version = "0.1.5"
+version = "0.2.0"
 edition = "2021"
 repository = "https://github.com/dgopsq/netgrep"
 description = "The power of ripgrep over HTTP"

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netgrep/search",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "The power of ripgrep over HTTP",
   "license": "MIT",
   "repository": {
@@ -15,8 +15,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "wasm-pack build --scope netgrep --out-name index --release && node scripts/post_build.js",
-    "build:node": "wasm-pack build --target nodejs --out-dir pkg-node --out-name index --release",
+    "build": "wasm-pack build --scope netgrep --out-name index --target web --release && node scripts/post_build.js",
     "test": "wasm-pack test --chrome --headless",
     "lint": "cargo clippy -p search -- -D warnings --no-deps"
   }

--- a/packages/search/scripts/post_build.js
+++ b/packages/search/scripts/post_build.js
@@ -13,7 +13,7 @@
  *     without this the two drift silently and a release ships the wrong number.
  *     See docs/BACKLOG.md item 9.
  */
-import { readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -29,6 +29,18 @@ const generated = readJson(generatedPath);
 
 generated.type = 'module';
 writeJson(generatedPath, generated);
+
+// 1b. Delete the `.gitignore` wasm-pack drops into pkg/. It contains `*`, and
+// npm honours a package-internal .gitignore when there is no .npmignore — so
+// with `"files": ["pkg"]` in the wrapper manifest it silently excludes the
+// entire directory and publishes a tarball containing no WASM at all.
+//
+// Nothing is lost: packages/search/.gitignore already ignores pkg/.
+const generatedGitignore = join(packageRoot, 'pkg', '.gitignore');
+
+if (existsSync(generatedGitignore)) {
+  rmSync(generatedGitignore);
+}
 
 // 2. Cargo.toml -> package.json version sync.
 const cargoToml = readFileSync(join(packageRoot, 'Cargo.toml'), 'utf8');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@types/node@26.1.2)(vite@8.1.5(@types/node@26.1.2)(terser@5.49.0))
+        version: 4.1.10(@types/node@26.1.2)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.0))
 
   packages/example:
     dependencies:
@@ -35,7 +35,7 @@ importers:
         version: 5.6.8(webpack@5.109.0)
       webpack:
         specifier: ^5.74.0
-        version: 5.109.0(clean-css@5.3.3)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@4.10.0)
+        version: 5.109.0(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@4.10.0)
       webpack-cli:
         specifier: ^4.10.0
         version: 4.10.0(webpack-dev-server@4.15.2)(webpack@5.109.0)
@@ -122,6 +122,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -844,6 +1000,11 @@ packages:
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -2017,6 +2178,84 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2275,13 +2514,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@26.1.2)(terser@5.49.0))':
+  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.5(@types/node@26.1.2)(terser@5.49.0)
+      vite: 8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -2385,7 +2624,7 @@ snapshots:
 
   '@webpack-cli/configtest@1.2.0(webpack-cli@4.10.0)(webpack@5.109.0)':
     dependencies:
-      webpack: 5.109.0(clean-css@5.3.3)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@4.10.0)
+      webpack: 5.109.0(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@4.10.0)
       webpack-cli: 4.10.0(webpack-dev-server@4.15.2)(webpack@5.109.0)
 
   '@webpack-cli/info@1.5.0(webpack-cli@4.10.0)':
@@ -2683,6 +2922,36 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+    optional: true
+
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
@@ -2890,7 +3159,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.3
     optionalDependencies:
-      webpack: 5.109.0(clean-css@5.3.3)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@4.10.0)
+      webpack: 5.109.0(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@4.10.0)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -3114,15 +3383,16 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.16
 
-  minimizer-webpack-plugin@5.6.1(clean-css@5.3.3)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack@5.109.0):
+  minimizer-webpack-plugin@5.6.1(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack@5.109.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.49.0
-      webpack: 5.109.0(clean-css@5.3.3)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@4.10.0)
+      webpack: 5.109.0(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@4.10.0)
     optionalDependencies:
       clean-css: 5.3.3
+      esbuild: 0.28.1
       html-minifier-terser: 6.1.0
       lightningcss: 1.33.0
       postcss: 8.5.23
@@ -3597,7 +3867,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@8.1.5(@types/node@26.1.2)(terser@5.49.0):
+  vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -3606,13 +3876,14 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 26.1.2
+      esbuild: 0.28.1
       fsevents: 2.3.3
       terser: 5.49.0
 
-  vitest@4.1.10(@types/node@26.1.2)(vite@8.1.5(@types/node@26.1.2)(terser@5.49.0)):
+  vitest@4.1.10(@types/node@26.1.2)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.1.2)(terser@5.49.0))
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -3629,7 +3900,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.5(@types/node@26.1.2)(terser@5.49.0)
+      vite: 8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.1.2
@@ -3657,7 +3928,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 2.2.0
       rechoir: 0.7.1
-      webpack: 5.109.0(clean-css@5.3.3)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@4.10.0)
+      webpack: 5.109.0(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@4.10.0)
       webpack-merge: 5.10.0
     optionalDependencies:
       webpack-dev-server: 4.15.2(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack-cli@4.10.0)(webpack@5.109.0)
@@ -3669,7 +3940,7 @@ snapshots:
       mime-types: 2.1.35
       range-parser: 1.3.0
       schema-utils: 4.3.3
-      webpack: 5.109.0(clean-css@5.3.3)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@4.10.0)
+      webpack: 5.109.0(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@4.10.0)
 
   webpack-dev-server@4.15.2(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack-cli@4.10.0)(webpack@5.109.0):
     dependencies:
@@ -3704,7 +3975,7 @@ snapshots:
       webpack-dev-middleware: 5.3.4(webpack@5.109.0)
       ws: 8.21.1
     optionalDependencies:
-      webpack: 5.109.0(clean-css@5.3.3)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@4.10.0)
+      webpack: 5.109.0(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@4.10.0)
       webpack-cli: 4.10.0(webpack-dev-server@4.15.2)(webpack@5.109.0)
     transitivePeerDependencies:
       - bufferutil
@@ -3720,7 +3991,7 @@ snapshots:
 
   webpack-sources@3.5.1: {}
 
-  webpack@5.109.0(clean-css@5.3.3)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@4.10.0):
+  webpack@5.109.0(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@4.10.0):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -3736,7 +4007,7 @@ snapshots:
       events: 3.3.0
       graceful-fs: 4.2.11
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(clean-css@5.3.3)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack@5.109.0)
+      minimizer-webpack-plugin: 5.6.1(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack@5.109.0)
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,11 @@
 packages:
   - 'packages/*'
+
+# pnpm requires an explicit decision on every dependency postinstall script.
+# esbuild's links its platform binary; it arrives via webpack's minimizer.
+allowBuilds:
+  esbuild: true
+
 minimumReleaseAgeExclude:
   - '@biomejs/biome@2.5.6'
   - '@biomejs/cli-darwin-arm64@2.5.6'

--- a/scripts/verify-pack.mjs
+++ b/scripts/verify-pack.mjs
@@ -1,0 +1,116 @@
+/**
+ * Verify the tarballs that would actually be published.
+ *
+ * This exists because nothing else in the pipeline looks at them. Everything
+ * CI runs — lint, typecheck, build, test — operates on the working tree, so a
+ * packaging fault is invisible right up until it reaches npm.
+ *
+ * It was not hypothetical: `@netgrep/search` once packed to a tarball
+ * containing only LICENSE, package.json and README.md. wasm-pack writes a
+ * `.gitignore` holding `*` into pkg/, npm honours a package-internal
+ * .gitignore when there is no .npmignore, and `"files": ["pkg"]` therefore
+ * resolved to nothing. It would have installed cleanly and failed at import.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Files that must be present, or the package is dead on arrival. */
+const EXPECTED = {
+  'packages/search': [
+    'pkg/index.js',
+    'pkg/index.d.ts',
+    'pkg/index_bg.wasm',
+    'package.json',
+  ],
+  'packages/netgrep': ['dist/index.js', 'dist/index.d.ts', 'package.json'],
+};
+
+const out = mkdtempSync(join(tmpdir(), 'netgrep-pack-'));
+const failures = [];
+
+/** Read the version Cargo.toml declares — the source of truth for search. */
+function cargoVersion() {
+  const toml = readFileSync(
+    join(repoRoot, 'packages/search/Cargo.toml'),
+    'utf8',
+  );
+
+  return toml.match(/^version\s*=\s*"([^"]+)"/m)?.[1];
+}
+
+try {
+  for (const [pkgDir, expected] of Object.entries(EXPECTED)) {
+    const cwd = join(repoRoot, pkgDir);
+
+    execFileSync('pnpm', ['pack', '--pack-destination', out], {
+      cwd,
+      stdio: 'pipe',
+    });
+
+    const manifest = JSON.parse(
+      readFileSync(join(cwd, 'package.json'), 'utf8'),
+    );
+    const tarball = join(
+      out,
+      `${manifest.name.replace('@', '').replace('/', '-')}-${manifest.version}.tgz`,
+    );
+
+    const entries = execFileSync('tar', ['-tzf', tarball], { encoding: 'utf8' })
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => line.replace(/^package\//, ''));
+
+    for (const file of expected) {
+      if (!entries.includes(file)) {
+        failures.push(`${manifest.name}: tarball is missing ${file}`);
+      }
+    }
+
+    // A `workspace:` range that survives packing would be unresolvable for
+    // anyone installing from npm.
+    const packed = JSON.parse(
+      execFileSync('tar', ['-xzOf', tarball, 'package/package.json'], {
+        encoding: 'utf8',
+      }),
+    );
+
+    for (const [dep, range] of Object.entries(packed.dependencies ?? {})) {
+      if (String(range).startsWith('workspace:')) {
+        failures.push(
+          `${manifest.name}: dependency ${dep} still says "${range}"`,
+        );
+      }
+    }
+
+    console.log(`${manifest.name}@${packed.version}: ${entries.length} files`);
+  }
+
+  // Cargo.toml is the source of truth; post_build.js copies it across.
+  const cargo = cargoVersion();
+  const npmVersion = JSON.parse(
+    readFileSync(join(repoRoot, 'packages/search/package.json'), 'utf8'),
+  ).version;
+
+  if (cargo !== npmVersion) {
+    failures.push(
+      `@netgrep/search version drift: Cargo.toml ${cargo} vs package.json ${npmVersion}`,
+    );
+  }
+} finally {
+  rmSync(out, { recursive: true, force: true });
+}
+
+if (failures.length > 0) {
+  console.error('\nPackaging verification FAILED:');
+  for (const failure of failures) {
+    console.error(`  - ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('\nPackaging verification passed.');


### PR DESCRIPTION
Fourth PR of [`docs/plans/MODERNIZATION.md`](https://github.com/dgopsq/netgrep/blob/main/docs/plans/MODERNIZATION.md). Only the documentation rewrite remains after this.

> **BREAKING:** `@netgrep/search` 0.2.0 requires `await init()` before `search_bytes`. `@netgrep/netgrep`'s public API is unchanged — it absorbs this internally, and upgrading consumers only need to *delete* their webpack `experiments.asyncWebAssembly` flag.

Five commits. The plan scoped this PR as "example → Vite + CI", but the Vite attempt uncovered something bigger, so with your sign-off it also carries the fix and reverses the plan's "no release" decision.

| # | commit | |
|---|---|---|
| 1 | `ci:` modernize workflows; fix the example dev server on Node 24 | shipped |
| 2 | `ci:` stop pinning ChromeDriver, it created the mismatch it prevented | revert of my own mistake in 1 |
| 3 | `feat!:` ship wasm-pack's web target | the headline |
| 4 | `fix:` publish the WASM — `pkg/.gitignore` was emptying the tarball | release-blocking |
| 5 | `test:` verify the published tarballs in CI | guard for 4 |

---

## 1. The published package did not work under Vite

`@netgrep/search` shipped wasm-pack's **bundler** target:

```js
import * as wasm from './index_bg.wasm';   // webpack-specific ESM integration
```

webpack supported that behind `experiments.asyncWebAssembly`. Vite did not — and failed **silently**. The build emitted the `.wasm`, kept the glue, never assigned the exports object, and every search returned `false` with no error anywhere. Because `searchBatch` folds per-URL failures into `{result: false}`, a completely broken build was indistinguishable from "no matches".

Wrong answers, not a crash — the worst failure mode for a library whose entire API is a boolean. I found it only by driving the built page in a real browser rather than trusting a green build.

**Fixed by shipping `--target web`**, which loads the binary through a standard `new URL('index_bg.wasm', import.meta.url)`. Verified, each in **real headless Chrome**:

| consumer | before | after |
|---|---|---|
| **Vite 8, no plugins, no config file** | `false` for everything | `[["/a.txt",true],["/b.txt",false]]` ✅ |
| **webpack 5** | required `experiments.asyncWebAssembly` | works with **no config at all** — example verified 67/67 with the flag deleted |
| Rollup / esbuild / Parcel / Bun | unsupported | standard `new URL` semantics |

Consumers now need *less* configuration than before: the README loses a setup step rather than gaining one.

**Costs:** `init()` must be awaited — `Netgrep` starts it once at module load and awaits it on the first line of `search`, leaving the streaming loop below byte-identical so the diff stays auditable. Glue grew 3,136 bytes; the `.wasm` is unchanged. Breaking only for direct `@netgrep/search` importers.

**Simplification:** the separate `--target nodejs` build is gone. The integration tests now load the artefact that actually ships, handing bytes to `initSync`. One fewer build, one less way for tests to drift from what users receive.

## 2. The tarball was empty — release-blocking

`pnpm pack` on `@netgrep/search` produced a tarball containing only `LICENSE`, `package.json` and `README.md`. **No WASM, no glue.** It would have installed cleanly and exploded at import.

wasm-pack writes a `.gitignore` containing `*` into `pkg/`, and npm honours a package-internal `.gitignore` when there is no `.npmignore` — so `"files": ["pkg"]` resolved to nothing. **I introduced this in PR 2**, when publishing moved from `pkg/package.json` (packed from *inside* `pkg/`) to the wrapper manifest (packing `pkg/` as a subdirectory). Harmless under the old layout, fatal under the new one.

No amount of CI would have caught it, because **every check in this repo inspected the working tree** and nothing looked at the tarball — the only artefact a user ever receives. `pnpm verify:pack` now closes that gap, asserting the files that make the package usable are present, that no `workspace:` range survived packing, and that `package.json` has not drifted from `Cargo.toml`.

Each guard was confirmed to **fail on the fault it targets**, not merely pass on a good tree:

```
reintroduce wasm-pack's pkg/.gitignore →  missing pkg/index.js, pkg/index.d.ts, pkg/index_bg.wasm
version drift                          →  Cargo.toml 0.2.0 vs package.json 9.9.9
workspace:* in the source manifest     →  passes (pnpm rewrites it at pack time)
```

## 3. CI modernization

| | from | to |
|---|---|---|
| checkout | `actions/checkout@v2` | `@v4` |
| node | `actions/setup-node@v3` | `@v4` |
| rust | `actions-rs/toolchain` — **archived** | `dtolnay/rust-toolchain` |
| rust cache | none | `Swatinem/rust-cache@v2` |
| wasm-pack | `curl … \| sh` every run | `jetli/wasm-pack-action`, pinned |
| packaging | unverified | `pnpm verify:pack` |

**ChromeDriver is deliberately *not* pinned.** I tried, and it broke CI, so commit 2 reverts it: `browser-actions/setup-chrome` installs a driver into the tool cache, but the browser ChromeDriver launches is the runner's *system* Chrome — so pinning half the pair produced exactly the mismatch it was meant to prevent (151 vs the system browser → SIGKILL). Letting wasm-pack manage both halves keeps them in step. Backlog item 2 is a **local-machine** problem; CI never had it. Documented so it isn't retried.

## 4. The example dev server was broken, and I missed it

`pnpm dev` had been dead since **PR 2's** Node 18 → 24 bump:

```
[webpack-cli] Error: No such module: http_parser
```

`http2: true` routes webpack-dev-server 4 through `spdy` → `http-deceiver`, which calls `process.binding('http_parser')` — removed from Node years ago. PR 2 ran `webpack build`, never `serve`. My mistake; the option is gone.

The Vite port itself was **reverted**. `vite dev` worked, `vite build` didn't, reproduced on Vite 8.1.5 and 7.3.6 with and without `optimizeDeps.exclude`, root cause not established inside the timebox. The example stays on webpack — which now needs no experiment flag, so it demonstrates the fix rather than working around the problem.

## Verification

| step | result |
|---|---|
| `pnpm lint` / `typecheck` / `build` | pass |
| `pnpm test` | **24 pass, unchanged** — including the four pinning known defects |
| `pnpm test:wasm` | 2 pass |
| `pnpm verify:pack` | pass |
| example `pnpm dev`, real Chrome, no experiment flag | **67/67 matched** |
| `@netgrep/netgrep` under Vite 8, no plugins | correct results, real Chrome |
| fresh app installed from the actual tarballs | correct results, real Chrome |

## Not published

Versions bumped to 0.2.0 (`packages/search/Cargo.toml`, synced into its npm manifest by `post_build.js`; `packages/netgrep/package.json`). **Nothing is tagged or published** — that stays human-only per `AGENTS.md` §6. Publish `@netgrep/search` **first**; pnpm rewrites `workspace:*` into a real range at pack time, so netgrep's dependency will not resolve otherwise:

```bash
git tag search-0.2.0  && git push origin search-0.2.0
# once it lands on npm
git tag netgrep-0.2.0 && git push origin netgrep-0.2.0
```

Closes backlog items 2 (for CI) and 16. Supersedes #8, whose commits are included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)