### PR TITLE
feat!: ship wasm-pack's web target so the package works outside webpack

### DIFF
--- a/.claude/skills/wasm-release/SKILL.md
+++ b/.claude/skills/wasm-release/SKILL.md
@@ -44,8 +44,8 @@ Install the toolchain if missing:
 
 ```bash
 pnpm install
-pnpm build:wasm        # must run first: pkg/index.d.ts is what the TS package compiles against
-pnpm build:wasm-node   # needed by the integration tests
+pnpm build:wasm        # must run first: the TS package compiles against pkg/index.d.ts,
+                       # and the integration tests load pkg/index_bg.wasm
 pnpm lint              # Biome + clippy
 pnpm typecheck
 pnpm build

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -60,3 +60,8 @@ jobs:
       - run: pnpm build
       - run: pnpm test
       - run: pnpm test:wasm
+
+      # Everything above inspects the working tree. This inspects the tarballs
+      # that would actually reach npm — the only artefact users ever see, and
+      # previously the only one nothing checked.
+      - run: pnpm verify:pack

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -50,15 +50,10 @@ jobs:
       # installed Chrome is older than the driver wasm-pack fetches; CI does
       # not have that problem.
 
-      # The WASM builds come first: `@netgrep/netgrep` resolves
-      # `@netgrep/search` to this workspace, so typecheck and build both need
-      # packages/search/pkg/index.d.ts to exist.
-      #
-      # `pkg` is the published bundler-target build; `pkg-node` is the same Rust
-      # compiled for Node, which the integration tests load because the bundler
-      # target cannot be required directly.
+      # The WASM build comes first: `@netgrep/netgrep` resolves
+      # `@netgrep/search` to this workspace, so typecheck, build and the
+      # integration tests all need packages/search/pkg to exist.
       - run: pnpm build:wasm
-      - run: pnpm build:wasm-node
 
       - run: pnpm lint
       - run: pnpm typecheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Canonical source — `CLAUDE.md` points here. Keep this file authoritative; do n
 >
 > | this file says | reality |
 > |---|---|
-> | Nx + yarn (`yarn nx test netgrep`) | Nx and yarn are gone. Use pnpm: `pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm test`, `pnpm test:wasm`, `pnpm build:wasm`, `pnpm build:wasm-node` |
+> | Nx + yarn (`yarn nx test netgrep`) | Nx and yarn are gone. Use pnpm: `pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm test`, `pnpm test:wasm`, `pnpm build:wasm` |
 > | Node 18.7.0 | Node 24 LTS, pinned in `.node-version` |
 > | jest / ESLint / Prettier | Vitest + Biome |
 > | §2: local edits never reach the TS package or the example | **Fixed.** pnpm workspaces link them; the example bundles local source |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "search"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "grep-matcher",
  "grep-regex",

--- a/README.md
+++ b/README.md
@@ -17,31 +17,27 @@ At the moment Netgrep is just going to tell whether a pattern is present on a re
 ## Usage
 
 > **Note**
-> This short tutorial assumes that **Webpack 5** is the bundler used in the application where `netgrep` will be integrated. A complete example is available [in the `example` package](https://github.com/dgopsq/netgrep/tree/main/packages/example).
+> A complete example is available [in the `example` package](https://github.com/dgopsq/netgrep/tree/main/packages/example).
 
 First of all install the module:
 
 ```bash
-# Using yarn
-yarn add @netgrep/netgrep
+# Using pnpm
+pnpm add @netgrep/netgrep
 
 # Using npm
 npm install @netgrep/netgrep
 ```
 
-The [`asyncWebAssembbly` experiment flag](https://webpack.js.org/configuration/experiments/) should be enabled inside the `webpack.config.js`:
+No bundler configuration is required. `netgrep` loads its WebAssembly through a standard
+`new URL('…', import.meta.url)` reference, which Vite, webpack 5, Rollup, esbuild, Parcel and Bun all
+understand out of the box.
 
-```js
-module.exports = {
-  //...
-  experiments: {
-    // ...
-    asyncWebAssembly: true,
-  },
-};
-```
+> **Upgrading from 0.1.x?** Delete the `experiments.asyncWebAssembly` flag from your webpack config — it is
+> no longer needed. Nothing else changes; the API is identical.
 
-Then it will be possible to execute `netgrep` directly while the bundled WASM file will be loaded asynchronously in the background:
+The WASM file is fetched in the background as soon as the module is imported, and the first search waits for
+it automatically:
 
 ```ts
 import { Netgrep } from '@netgrep/netgrep';

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -201,40 +201,31 @@ taken: `opt-level = 'z'` (a further ~27 KB, at some throughput cost in a regex-s
 `wasm-opt -Oz`; and disabling `grep-regex`'s Unicode support, which would change matching behaviour and is
 therefore out of scope.
 
-### 16. The example cannot move to Vite — the published wasm target only bundles under webpack
+### 16. ~~The published package does not work under Vite~~ — FIXED
 
-Attempted 2026-07-28 and **reverted**. Recording the exact failure so it is not re-attempted blind.
+`@netgrep/search` shipped wasm-pack's **bundler** target, whose entry does
+`import * as wasm from './index_bg.wasm'`. webpack supported that behind `experiments.asyncWebAssembly`;
+Vite did not, and failed **silently** — `vite build` emitted the `.wasm`, kept the glue, never assigned the
+exports object, and every search returned `false` with no error. `searchBatch` folds per-URL failures into
+`{result: false}`, so a completely broken build was indistinguishable from "no matches".
 
-`@netgrep/search` is built with wasm-pack's **bundler** target, whose entry does:
+**Fixed by shipping `--target web` instead** (`@netgrep/search` 0.2.0). The binary is now loaded through a
+standard `new URL('index_bg.wasm', import.meta.url)`, which every current bundler understands.
 
-```js
-import * as wasm from './index_bg.wasm';
-```
+Verified 2026-07-28, each in real headless Chrome:
 
-That is an ESM-integration wasm import. webpack supports it natively behind `experiments.asyncWebAssembly`
-— which is why `packages/example/webpack.config.js` has exactly one non-default setting. Vite has no native
-equivalent and needs `vite-plugin-wasm`.
+| consumer | before | after |
+|---|---|---|
+| Vite 8, no plugins | silently returned `false` for everything | correct results |
+| webpack 5 | required `experiments.asyncWebAssembly` | works with **no config at all** |
+| Rollup / esbuild / Parcel / Bun | unsupported | standard `new URL` semantics |
 
-**With the plugin installed and loaded, `vite build` silently produces a broken bundle:**
+Costs, for the record: `init()` must be awaited before `search_bytes`, which is a breaking change to
+`@netgrep/search` — absorbed inside `Netgrep`, so `@netgrep/netgrep`'s public API is untouched. The glue grew
+3,136 bytes; the `.wasm` is byte-identical.
 
-- `vite dev` works — 67/67 fixtures match, verified in real Chrome.
-- `vite build` emits `index_bg-<hash>.wasm` as an asset, but **nothing in the JS bundle references it**. The
-  glue survives (`g.search_bytes`, `g.__wbindgen_malloc`, `g.memory`) while `g` is never assigned, so every
-  search returns `false`.
-- **No error is reported anywhere.** `searchBatch` folds per-URL failures into `{result: false, error}` and
-  the demo only renders successes, so a broken build looks exactly like "no matches".
-
-Reproduced on Vite **8.1.5** and **7.3.6**, with and without `optimizeDeps.exclude`. The plugin is loaded and
-well-formed (`enforce`/`resolveId`/`load` hooks present) and declares `vite: ^2 || ... || ^8`, so this is a
-silent incompatibility rather than a declared one. Root cause not established within the timebox.
-
-*Consequence beyond the demo:* this is a **consumer-facing limitation of the published package**. Anyone on
-Vite — most of the current ecosystem — hits it. The real fix is to stop shipping the bundler target: build
-with `--target web`, or ship both behind conditional `exports`. That changes the published artifact, so it
-was ruled out under [`plans/MODERNIZATION.md`](plans/MODERNIZATION.md) decision 1 (no release), and it is the
-strongest argument yet for revisiting that.
-
-Until then the example stays on webpack, which works.
+Dropping the bundler target also removed the need for a separate `--target nodejs` build: the integration
+tests now load the artefact that actually ships.
 
 ### 15. `memmap2` is compiled into a browser binary
 

--- a/docs/plans/MODERNIZATION.md
+++ b/docs/plans/MODERNIZATION.md
@@ -36,16 +36,23 @@ of Rust**. Most of the weight in this plan is configuration, not code.
 
 ## Decisions
 
-### 1. The finish line is green CI, not a release
+### 1. The finish line is green CI, not a release — AMENDED 2026-07-28
 
 Everything builds, lints and tests on a current toolchain. **Nothing is republished** — npm keeps serving
 `@netgrep/netgrep@0.1.5` and `@netgrep/search@0.1.5` throughout.
 
+> **Amended.** PR 4 established that the published package does not work under Vite at all — it fails
+> silently, returning `false` for every search (backlog 16). "Do not release" stopped being the conservative
+> option at that point: it meant knowingly leaving a broken artefact on npm. The scope now ends with a
+> **0.2.0 release of both packages**, prepared by an agent and published by a human. The correctness bugs
+> (3a, 3b, 3c, 3f) remain out of scope and still ship.
+
 *Consequence, stated plainly:* the correctness bugs stay shipped. Users of 0.1.5 keep hitting the
 chunk-boundary false negative. That is an accepted, deliberate outcome of this scope, not an oversight.
 
-*Consequence:* consumer-facing ergonomics (an `exports` map, revisiting the wasm-pack target so consumers
-don't need `experiments.asyncWebAssembly`) are **out of scope**. They only pay off on release.
+*Consequence:* consumer-facing ergonomics were originally **out of scope** on the grounds that they only pay
+off on release. Revisiting the wasm-pack target came back into scope once it turned out not to be an
+ergonomic nicety but a correctness failure for most of the ecosystem.
 
 *This supersedes the "maintenance only, no feature work" stance* in `AGENTS.md` and `docs/BACKLOG.md`, written
 earlier the same day. Those documents are rewritten in PR 5.
@@ -405,7 +412,7 @@ Recorded so a future reader knows these were considered and rejected, not overlo
 
 | | why not |
 |---|---|
-| Publishing 0.2.0 | Decision 1 — the goal is a healthy repo, not a release. **Worth revisiting:** backlog 16 shows the published artifact is unusable under Vite. |
+| ~~Publishing 0.2.0~~ | **Now in scope** — see the amendment to decision 1. |
 | `exports` map; wasm-pack `--target web` | Consumer ergonomics; only pays off on release. |
 | Fixing bugs 3a / 3b / 3c | Decision 6 — would destroy attribution during a large migration. |
 | Node.js / Bun / Deno support | A feature. `fetch` + streams are now universal, so it is newly *possible* — worth its own conversation. |

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:wasm": "pnpm --filter @netgrep/search build",
     "test": "vitest run",
     "test:wasm": "pnpm --filter @netgrep/search test",
+    "verify:pack": "node scripts/verify-pack.mjs",
     "lint": "biome check . && pnpm --filter @netgrep/search lint",
     "format": "biome check --write .",
     "typecheck": "tsc -p packages/netgrep/tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "scripts": {
     "build": "pnpm --filter @netgrep/netgrep build",
     "build:wasm": "pnpm --filter @netgrep/search build",
-    "build:wasm-node": "pnpm --filter @netgrep/search build:node",
     "test": "vitest run",
     "test:wasm": "pnpm --filter @netgrep/search test",
     "lint": "biome check . && pnpm --filter @netgrep/search lint",

--- a/packages/example/webpack.config.js
+++ b/packages/example/webpack.config.js
@@ -8,9 +8,9 @@ module.exports = {
     filename: 'main.js',
     path: path.resolve(__dirname, 'dist'),
   },
-  experiments: {
-    asyncWebAssembly: true,
-  },
+  // No `experiments.asyncWebAssembly` needed any more. @netgrep/search now
+  // ships wasm-pack's `web` target, which loads the binary through a standard
+  // `new URL('index_bg.wasm', import.meta.url)` — plain webpack asset handling.
   devServer: {
     static: ['assets', 'dist'],
     // `http2: true` was removed here, not merely deprecated away: it routes

--- a/packages/netgrep/package.json
+++ b/packages/netgrep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netgrep/netgrep",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "The power of ripgrep over HTTP",
   "license": "MIT",
   "repository": {

--- a/packages/netgrep/src/lib/Netgrep.integration.spec.ts
+++ b/packages/netgrep/src/lib/Netgrep.integration.spec.ts
@@ -24,47 +24,49 @@ import { Netgrep } from './Netgrep.js';
  * always what it should do. The `documented defects` block at the bottom pins
  * known-wrong behaviour on purpose. See the comment there before "fixing" it.
  *
- * WHY pkg-node AND NOT pkg
- * ------------------------
- * The published `pkg/` is built with wasm-pack's *bundler* target, whose
- * `import * as wasm from './index_bg.wasm'` no bundler-less Node can resolve.
- * `pkg-node/` is the same Rust, same release profile, same `.wasm` binary,
- * compiled with `--target nodejs` so the test can load it. The generated
- * marshalling glue is identical; only the module-loading preamble differs.
+ * IT RUNS THE ARTEFACT THAT SHIPS
+ * -------------------------------
+ * `pkg/` is exactly what gets published — wasm-pack's `web` target. The only
+ * accommodation is instantiation: the real `init()` fetches the `.wasm` over
+ * HTTP relative to `import.meta.url`, which has no meaning under Node, so the
+ * bytes are handed to `initSync` from disk instead. Same module, same binary,
+ * same marshalling glue; only the loader differs.
  *
- * Build it with:
- *   cd packages/search && wasm-pack build --target nodejs \
- *     --out-dir pkg-node --out-name index --release
+ * This used to load a separate `--target nodejs` build. That build no longer
+ * exists — the test is now one step closer to what consumers actually get.
+ *
+ * Build it with: pnpm build:wasm
  */
 vi.mock('@netgrep/search', async () => {
-  const { existsSync } = await import('node:fs');
-  const { createRequire } = await import('node:module');
+  const { existsSync, readFileSync } = await import('node:fs');
   const { dirname, resolve } = await import('node:path');
   const { fileURLToPath } = await import('node:url');
 
   const here = dirname(fileURLToPath(import.meta.url));
-  const pkgNode = resolve(here, '../../../search/pkg-node/index.js');
+  const pkg = resolve(here, '../../../search/pkg');
+  const wasmPath = resolve(pkg, 'index_bg.wasm');
 
-  if (!existsSync(pkgNode)) {
+  if (!existsSync(wasmPath)) {
     throw new Error(
       [
         '',
-        'The Node-target WASM build is missing, so the integration tests cannot',
-        'run against the real engine.',
+        'The WASM build is missing, so the integration tests cannot run',
+        'against the real engine.',
         '',
-        'Build it with:',
-        '  cd packages/search && wasm-pack build --target nodejs \\',
-        '    --out-dir pkg-node --out-name index --release',
+        'Build it with:  pnpm build:wasm',
         '',
-        `Expected at: ${pkgNode}`,
+        `Expected at: ${wasmPath}`,
         '',
       ].join('\n'),
     );
   }
 
-  // The nodejs-target build is CommonJS, so it needs `require` rather than a
-  // dynamic import to expose its named exports directly.
-  return createRequire(import.meta.url)(pkgNode);
+  const mod = await import(resolve(pkg, 'index.js'));
+  mod.initSync({ module: readFileSync(wasmPath) });
+
+  // `default` is the real `init()`; it is already instantiated, so awaiting it
+  // must be a no-op rather than a second (fetch-based) instantiation.
+  return { ...mod, default: () => Promise.resolve() };
 });
 
 const encoder = new TextEncoder();

--- a/packages/netgrep/src/lib/Netgrep.spec.ts
+++ b/packages/netgrep/src/lib/Netgrep.spec.ts
@@ -23,9 +23,13 @@ const { mockSearch } = vi.hoisted(() => ({ mockSearch: vi.fn() }));
 
 const mockFetch = vi.fn();
 
-// Mocking the `search_bytes` function.
+// Mocking the `search_bytes` function. `default` stands in for the WASM
+// module's `init()`, which Netgrep awaits before every search.
 vi.mock('@netgrep/search', () => {
-  return { search_bytes: () => mockSearch() };
+  return {
+    default: () => Promise.resolve(),
+    search_bytes: () => mockSearch(),
+  };
 });
 
 // Mocking `fetch` function.

--- a/packages/netgrep/src/lib/Netgrep.ts
+++ b/packages/netgrep/src/lib/Netgrep.ts
@@ -1,4 +1,4 @@
-import { search_bytes } from '@netgrep/search';
+import init, { search_bytes } from '@netgrep/search';
 import type { BatchNetgrepResult } from './data/BatchNetgrepResult.js';
 import type { NetgrepConfig } from './data/NetgrepConfig.js';
 import type { NetgrepInput } from './data/NetgrepInput.js';
@@ -11,6 +11,18 @@ import type { NetgrepSearchConfig } from './data/NetgrepSearchConfig.js';
 const defaultConfig: NetgrepConfig = {
   enableMemoryCache: true,
 };
+
+/**
+ * The WASM module has to be instantiated before `search_bytes` can be called.
+ *
+ * Started once at module load and shared by every `Netgrep` instance: the
+ * download begins as soon as the library is imported rather than on the first
+ * search, and awaiting an already-settled promise costs nothing.
+ *
+ * Kept module-private on purpose — callers should not have to know the engine
+ * needs booting.
+ */
+const wasmReady = init();
 
 /**
  * The `netgrep` library allows to search remote files
@@ -47,12 +59,16 @@ export class Netgrep {
    * A promise resolving to a `NetgrepResult<T>` as soon as a match will
    * be found in the remote file.
    */
-  public search<T extends object>(
+  public async search<T extends object>(
     url: string,
     pattern: string,
     metadata?: T,
     config?: NetgrepSearchConfig,
   ): Promise<NetgrepResult<T>> {
+    // Nothing below can run before the engine exists. Everything after this
+    // line is unchanged from the synchronous-instantiation version.
+    await wasmReady;
+
     return new Promise((resolve, reject) => {
       const handleReader = (
         reader: ReadableStreamDefaultReader<Uint8Array>,

--- a/packages/search/.gitignore
+++ b/packages/search/.gitignore
@@ -1,5 +1,1 @@
 pkg
-
-# Node-target build consumed by the netgrep integration tests.
-# `nx build-node search`
-pkg-node

--- a/packages/search/Cargo.toml
+++ b/packages/search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "search"
-version = "0.1.5"
+version = "0.2.0"
 edition = "2021"
 repository = "https://github.com/dgopsq/netgrep"
 description = "The power of ripgrep over HTTP"

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netgrep/search",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "The power of ripgrep over HTTP",
   "license": "MIT",
   "repository": {
@@ -15,8 +15,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "wasm-pack build --scope netgrep --out-name index --release && node scripts/post_build.js",
-    "build:node": "wasm-pack build --target nodejs --out-dir pkg-node --out-name index --release",
+    "build": "wasm-pack build --scope netgrep --out-name index --target web --release && node scripts/post_build.js",
     "test": "wasm-pack test --chrome --headless",
     "lint": "cargo clippy -p search -- -D warnings --no-deps"
   }

--- a/packages/search/scripts/post_build.js
+++ b/packages/search/scripts/post_build.js
@@ -13,7 +13,7 @@
  *     without this the two drift silently and a release ships the wrong number.
  *     See docs/BACKLOG.md item 9.
  */
-import { readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -29,6 +29,18 @@ const generated = readJson(generatedPath);
 
 generated.type = 'module';
 writeJson(generatedPath, generated);
+
+// 1b. Delete the `.gitignore` wasm-pack drops into pkg/. It contains `*`, and
+// npm honours a package-internal .gitignore when there is no .npmignore — so
+// with `"files": ["pkg"]` in the wrapper manifest it silently excludes the
+// entire directory and publishes a tarball containing no WASM at all.
+//
+// Nothing is lost: packages/search/.gitignore already ignores pkg/.
+const generatedGitignore = join(packageRoot, 'pkg', '.gitignore');
+
+if (existsSync(generatedGitignore)) {
+  rmSync(generatedGitignore);
+}
 
 // 2. Cargo.toml -> package.json version sync.
 const cargoToml = readFileSync(join(packageRoot, 'Cargo.toml'), 'utf8');

--- a/scripts/verify-pack.mjs
+++ b/scripts/verify-pack.mjs
@@ -1,0 +1,116 @@
+/**
+ * Verify the tarballs that would actually be published.
+ *
+ * This exists because nothing else in the pipeline looks at them. Everything
+ * CI runs — lint, typecheck, build, test — operates on the working tree, so a
+ * packaging fault is invisible right up until it reaches npm.
+ *
+ * It was not hypothetical: `@netgrep/search` once packed to a tarball
+ * containing only LICENSE, package.json and README.md. wasm-pack writes a
+ * `.gitignore` holding `*` into pkg/, npm honours a package-internal
+ * .gitignore when there is no .npmignore, and `"files": ["pkg"]` therefore
+ * resolved to nothing. It would have installed cleanly and failed at import.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Files that must be present, or the package is dead on arrival. */
+const EXPECTED = {
+  'packages/search': [
+    'pkg/index.js',
+    'pkg/index.d.ts',
+    'pkg/index_bg.wasm',
+    'package.json',
+  ],
+  'packages/netgrep': ['dist/index.js', 'dist/index.d.ts', 'package.json'],
+};
+
+const out = mkdtempSync(join(tmpdir(), 'netgrep-pack-'));
+const failures = [];
+
+/** Read the version Cargo.toml declares — the source of truth for search. */
+function cargoVersion() {
+  const toml = readFileSync(
+    join(repoRoot, 'packages/search/Cargo.toml'),
+    'utf8',
+  );
+
+  return toml.match(/^version\s*=\s*"([^"]+)"/m)?.[1];
+}
+
+try {
+  for (const [pkgDir, expected] of Object.entries(EXPECTED)) {
+    const cwd = join(repoRoot, pkgDir);
+
+    execFileSync('pnpm', ['pack', '--pack-destination', out], {
+      cwd,
+      stdio: 'pipe',
+    });
+
+    const manifest = JSON.parse(
+      readFileSync(join(cwd, 'package.json'), 'utf8'),
+    );
+    const tarball = join(
+      out,
+      `${manifest.name.replace('@', '').replace('/', '-')}-${manifest.version}.tgz`,
+    );
+
+    const entries = execFileSync('tar', ['-tzf', tarball], { encoding: 'utf8' })
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => line.replace(/^package\//, ''));
+
+    for (const file of expected) {
+      if (!entries.includes(file)) {
+        failures.push(`${manifest.name}: tarball is missing ${file}`);
+      }
+    }
+
+    // A `workspace:` range that survives packing would be unresolvable for
+    // anyone installing from npm.
+    const packed = JSON.parse(
+      execFileSync('tar', ['-xzOf', tarball, 'package/package.json'], {
+        encoding: 'utf8',
+      }),
+    );
+
+    for (const [dep, range] of Object.entries(packed.dependencies ?? {})) {
+      if (String(range).startsWith('workspace:')) {
+        failures.push(
+          `${manifest.name}: dependency ${dep} still says "${range}"`,
+        );
+      }
+    }
+
+    console.log(`${manifest.name}@${packed.version}: ${entries.length} files`);
+  }
+
+  // Cargo.toml is the source of truth; post_build.js copies it across.
+  const cargo = cargoVersion();
+  const npmVersion = JSON.parse(
+    readFileSync(join(repoRoot, 'packages/search/package.json'), 'utf8'),
+  ).version;
+
+  if (cargo !== npmVersion) {
+    failures.push(
+      `@netgrep/search version drift: Cargo.toml ${cargo} vs package.json ${npmVersion}`,
+    );
+  }
+} finally {
+  rmSync(out, { recursive: true, force: true });
+}
+
+if (failures.length > 0) {
+  console.error('\nPackaging verification FAILED:');
+  for (const failure of failures) {
+    console.error(`  - ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('\nPackaging verification passed.');


### PR DESCRIPTION
**Stacked on #7** — base is `chore/example-vite-and-ci`, so review that one first. Merging #7 will retarget this to `main`.

This reverses decision 1 of the plan ("green CI, no release"), with your sign-off. PR #7 established that the *published* package is broken under Vite, and "don't release" stopped being the conservative choice at that point — it meant knowingly leaving a broken artefact on npm.

## The problem

`@netgrep/search` shipped wasm-pack's **bundler** target:

```js
import * as wasm from './index_bg.wasm';   // webpack-specific ESM integration
```

webpack supported it behind `experiments.asyncWebAssembly`. Vite did not — and failed **silently**. The build emitted the `.wasm`, kept the glue, never assigned the exports object, and every search returned `false` with no error. Because `searchBatch` folds per-URL failures into `{result: false}`, a completely broken build looked exactly like "no matches".

Wrong answers, not a crash. That's the worst failure mode for a library whose entire API is a boolean.

## The fix

`--target web` loads the binary via a standard `new URL('index_bg.wasm', import.meta.url)`.

Verified, each in **real headless Chrome**:

| consumer | before | after |
|---|---|---|
| **Vite 8, no plugins** | `false` for everything | `[["/a.txt",true],["/b.txt",false]]` ✅ |
| **webpack 5** | needed `experiments.asyncWebAssembly` | works with **no config at all** — example verified 67/67 with the flag deleted |
| Rollup / esbuild / Parcel / Bun | unsupported | standard `new URL` semantics |

The example's webpack config loses `experiments.asyncWebAssembly`, and the README loses the setup step it required. **Consumers now need no bundler configuration whatsoever.**

## Costs, stated plainly

- **Breaking for `@netgrep/search`**: `init()` must be awaited before `search_bytes`. → 0.2.0.
- **`@netgrep/netgrep`'s public API is unchanged.** `Netgrep` starts `init()` once at module load and awaits it at the top of `search`, so the download begins on import rather than first use. Everything below that line in the streaming loop is untouched — deliberately, so the diff is auditable.
- **Glue grew 3,136 bytes** (2,995 → 6,131). The `.wasm` is byte-identical.
- Upgrading consumers only need to delete their webpack experiment flag.

## Simplification

The separate `--target nodejs` build is **gone**. The integration tests now load the artefact that actually ships, handing the bytes to `initSync` because `import.meta.url` has no meaning under Node. One fewer build, one less thing that can drift from what users receive.

## Verification

| step | result |
|---|---|
| `pnpm lint` / `typecheck` / `build` | pass |
| `pnpm test` | **24 pass, unchanged** — including the four pinning known defects |
| example under webpack, no experiment flag | **67/67** in real Chrome |
| `@netgrep/netgrep` under Vite 8, no plugins | correct results in real Chrome |

## Not published

Versions are bumped to 0.2.0 (`packages/search/Cargo.toml`, synced to its npm manifest by `post_build.js`; `packages/netgrep/package.json`). **Nothing is tagged or published** — that stays human-only per `AGENTS.md` §6. Release commands are in the PR discussion below.

Closes backlog item 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)