### PR TITLE
docs: fix inconsistencies left behind by the modernization, and document the README's sharp edges

### DIFF
--- a/.claude/skills/wasm-release/SKILL.md
+++ b/.claude/skills/wasm-release/SKILL.md
@@ -51,23 +51,31 @@ pnpm typecheck
 pnpm build
 pnpm test              # 24 tests
 pnpm test:wasm         # 2 tests
+pnpm verify:pack       # the tarballs that would actually reach npm
 ```
+
+`pnpm verify:pack` matters most of all here, and it is the only check that looks at a release artefact.
+Everything above it inspects the working tree, which is how `@netgrep/search` once published a tarball
+containing no WASM at all. Never hand over a release without it passing.
 
 `pnpm test:wasm` fails on a fresh machine — `wasm-pack` fetches the latest ChromeDriver, which cannot drive
 an older installed Chrome (`invalid session id`, driver killed with signal 9). It also **overrides**
 `CHROMEDRIVER`, so exporting it and re-running `wasm-pack` changes nothing; invoke the harness directly. See
 [`docs/BACKLOG.md`](../../../docs/BACKLOG.md) item 2 for the exact commands.
 
-Do **not** try to verify via the example app — it runs against published npm packages, not local source.
+The example app now runs against **local workspace source**, so `pnpm dev` is a legitimate manual smoke
+test. It is still not automated and does not run in CI, so it never substitutes for the targets above.
 
 ---
 
 ## 3. Build outputs
 
 **`@netgrep/search`** — `pnpm build:wasm` runs `wasm-pack` then `scripts/post_build.js`, which marks `pkg/`
-as ESM and copies the version out of `Cargo.toml`. Do not skip the second step.
+as ESM, copies the version out of `Cargo.toml`, **and deletes the `.gitignore` wasm-pack writes into
+`pkg/`** — that file contains `*`, npm honours it, and it is what emptied the tarball. Do not skip the
+second step.
 
-→ `packages/search/pkg/`: `index.js`, `index_bg.js`, `index_bg.wasm` (~1.12 MB), `index.d.ts`,
+→ `packages/search/pkg/`: `index.js`, `index_bg.js`, `index_bg.wasm` (~1.15 MB), `index.d.ts`,
 `package.json`. Gitignored.
 
 **What gets published is `packages/search/package.json`**, a hand-written wrapper with `"files": ["pkg"]` —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ pnpm build:wasm        # REQUIRED FIRST — see §2.2
 
 | Task | Command | Notes |
 |---|---|---|
-| Build WASM | `pnpm build:wasm` | → `packages/search/pkg/`, ~1.12 MB `index_bg.wasm` |
+| Build WASM | `pnpm build:wasm` | → `packages/search/pkg/`, ~1.15 MB `index_bg.wasm` |
 | Build TS | `pnpm build` | → `packages/netgrep/dist/` |
 | Lint | `pnpm lint` | Biome (JS/TS) **and** clippy (`-D warnings`) |
 | Format | `pnpm format` | Biome, writes in place |
@@ -125,7 +125,7 @@ packages/
     → published as @netgrep/search
 
   netgrep/           TypeScript wrapper. Streaming + batching + caching.
-    src/lib/Netgrep.ts               the whole public API (~215 lines)
+    src/lib/Netgrep.ts               the whole public API (~225 lines)
     src/lib/data/*.ts                5 type definitions, one per file
     src/lib/Netgrep.spec.ts          unit suite; mocks fetch and the engine
     src/lib/Netgrep.integration.spec.ts   real WASM through the real streaming loop

--- a/README.md
+++ b/README.md
@@ -11,10 +11,15 @@ At the moment Netgrep is just going to tell whether a pattern is present on a re
 > **Note**
 > Searching for posts on a blog created through a Static Site Generator is an interesting use-case for this experiment. Netgrep could easily be used to create a real-time search engine from the raw post files. A live example for this behavior can be found on [my blog](https://diegopasquali.com/search) (you can take a look at the [source code](https://github.com/dgopsq/writings)).
 
-> **Warning**
-> This library is distributed as **ESM only** and targets the browser. There is no CommonJS `require` entry
-> point and no Node.js support — it needs `fetch` with a readable response body stream. Since `0.2.0` no
-> bundler *configuration* is required; see below.
+## Requirements
+
+- **A browser.** Netgrep needs `fetch` with a readable response body stream. There is no Node.js support.
+- **ESM.** The package is distributed as ESM only — there is no CommonJS `require` entry point.
+- **A ~1.15 MB WebAssembly download** (~480 KB gzipped), fetched once per page load. Most of it is the regex
+  engine's Unicode tables. This is the main cost of the approach, and it is worth weighing against your
+  corpus size before adopting it.
+
+Since `0.2.0` no bundler *configuration* is required.
 
 ## Usage
 
@@ -58,7 +63,7 @@ NG.search("url", "pattern")
 // It's possible to pass custom metadata during
 // the search. These will be returned back in the result
 // for convenience.
-NG.search("url", "pattern", { post })
+NG.search("url", "pattern", { title: 'A blog post' })
   .then((output) => {
     console.log('The pattern has matched', output.result)
     console.log('Metadata', output.metadata)
@@ -89,6 +94,117 @@ NG.searchBatchWithCallback([
   console.log(`The pattern has matched for ${output.url}`, output.result)
 });
 ```
+
+## What you get back
+
+A single search resolves to a result carrying the answer and whatever metadata you passed in:
+
+```ts
+{
+  url: string;
+  pattern: string;
+  result: boolean;      // the whole answer: did the pattern occur?
+  metadata?: T;         // returned untouched, for correlating results back to your own objects
+}
+```
+
+The batch methods add an `error` field, and this is the part worth reading twice:
+
+```ts
+{ /* …as above… */ error: string | null }
+```
+
+> **Warning**
+> **`searchBatch` and `searchBatchWithCallback` never reject.** A failed request — network error, 404, CORS —
+> is captured as `{ result: false, error: "…" }`, which is indistinguishable from a genuine "no match" unless
+> you check `error`. Single `search` calls behave the opposite way: they *reject*, and have no `error` field.
+
+```ts
+const outputs = await NG.searchBatch(inputs, pattern);
+
+const matched = outputs.filter((o) => o.error === null && o.result);
+const failed = outputs.filter((o) => o.error !== null);
+```
+
+## Patterns
+
+A pattern is anything the Rust [`regex`](https://docs.rs/regex/) crate understands, which is what ripgrep
+itself uses. Note that **smart case is hardcoded on**:
+
+| Pattern | Behaviour |
+|---|---|
+| `sherlock` — all lowercase | case-**in**sensitive, matches `Sherlock` |
+| `Sherlock` — contains an uppercase character | case-**sensitive**, does not match `sherlock` |
+
+This is not configurable. Lowercase your pattern to search case-insensitively.
+
+> **Warning**
+> **An invalid pattern crashes the search engine.** A stray `(` or `[` surfaces as a
+> `RuntimeError: unreachable` from WebAssembly rather than a catchable error. If patterns come straight from
+> a user-facing search box — the use case this library was built for — validate or escape them before
+> passing them in.
+
+## Cancelling a search
+
+Every search method takes an optional config with an `AbortSignal`, which is threaded into the underlying
+`fetch`. This is the natural fit for a search-as-you-type box:
+
+```ts
+let controller: AbortController | undefined;
+
+function onInput(pattern: string) {
+  controller?.abort();           // cancel the previous keystroke's searches
+  controller = new AbortController();
+
+  NG.searchBatch(inputs, pattern, { signal: controller.signal })
+    .then(render);
+}
+```
+
+Aborted searches surface as an `error` on batch results, so filter them out as shown above.
+
+## Caching
+
+Netgrep keeps downloaded bytes in memory, keyed by URL, so repeat searches over the same corpus cost no
+network at all. **It is enabled by default**, and it has no eviction, size cap or TTL — bytes are retained
+for the lifetime of the `Netgrep` instance.
+
+```ts
+const NG = new Netgrep({ enableMemoryCache: false });
+```
+
+Disable it if you are searching a large or unbounded set of URLs, or scope the growth by discarding the
+instance. See the limitation below before relying on it.
+
+## Known limitations
+
+Netgrep is experimental, and the following are real, present in the published package, and **documented
+rather than fixed**. They are pinned by tests so they cannot change unnoticed; the full analysis is in
+[`docs/ARCHITECTURE.md`](https://github.com/dgopsq/netgrep/blob/main/docs/ARCHITECTURE.md#known-limitations--correctness-caveats).
+
+- **A match spanning two network chunks is missed.** Chunks are searched as they arrive and are never
+  overlapped, so a pattern straddling the boundary is invisible. This is a silent `false`, and because it
+  depends on how the network happens to chunk the response it is not reproducible on demand. Short patterns
+  in reasonably sized files are unlikely to hit it; it is not impossible.
+- **The cache can answer a later search wrongly.** A search resolves the moment a chunk matches and stops
+  downloading, so the cache is left holding only the beginning of the file, with nothing marking it
+  incomplete. A later search on the same URL for a *different* pattern reads that partial copy and can
+  return `false` for text further down the file. Set `enableMemoryCache: false` if this matters more than
+  the network savings.
+- **An invalid regex traps the WASM instance**, as described above.
+- **A file containing a NUL byte reports no match** for the chunk containing it, even when the match came
+  earlier. Binary detection abandons the whole chunk rather than stopping at the NUL.
+
+The first two exist because searching *while downloading* is the entire point of the project — the naive
+fixes for both are to wait for the full file, which is the thing netgrep is built not to do.
+
+## Documentation
+
+| | |
+|---|---|
+| [`docs/ARCHITECTURE.md`](https://github.com/dgopsq/netgrep/blob/main/docs/ARCHITECTURE.md) | How it works, and the limitations in full |
+| [`docs/decisions/`](https://github.com/dgopsq/netgrep/tree/main/docs/decisions) | Why it is shaped this way |
+| [`AGENTS.md`](https://github.com/dgopsq/netgrep/blob/main/AGENTS.md) | Working in this repository |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # netgrep
 
-Netgrep is an **experimental** porting of [ripgrep](https://github.com/BurntSushi/ripgrep) on WASM using the HTTP protocol. The scope of this project is to provide a viable alternative to index-based search engines for applications with a small files-based database. It uses [a fork of the original `ripgrep` repository](https://github.com/dgopsq/ripgrep) with just enough changes to make it runnable on WASM. 
+Netgrep is an **experimental** porting of [ripgrep](https://github.com/BurntSushi/ripgrep) on WASM using the HTTP protocol. The scope of this project is to provide a viable alternative to index-based search engines for applications with a small files-based database. It is built on the `grep-matcher`, `grep-regex` and `grep-searcher` crates published from the `ripgrep` repository, used unmodified from crates.io. 
 
 At the moment Netgrep is just going to tell whether a pattern is present on a remote file leveraging the `ripgrep` core search engine. This happens **while the file is being downloaded** in order to maximize the performance. 
 
@@ -12,7 +12,9 @@ At the moment Netgrep is just going to tell whether a pattern is present on a re
 > Searching for posts on a blog created through a Static Site Generator is an interesting use-case for this experiment. Netgrep could easily be used to create a real-time search engine from the raw post files. A live example for this behavior can be found on [my blog](https://diegopasquali.com/search) (you can take a look at the [source code](https://github.com/dgopsq/writings)).
 
 > **Warning**
-> At the moment this library is exported only as an ESM, thus a bundler like [Webpack](https://webpack.js.org/) is required to use it. 
+> This library is distributed as **ESM only** and targets the browser. There is no CommonJS `require` entry
+> point and no Node.js support — it needs `fetch` with a readable response body stream. Since `0.2.0` no
+> bundler *configuration* is required; see below.
 
 ## Usage
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,8 +84,8 @@ The release profile (`lto`, `opt-level = 's'`, `codegen-units = 1`, `panic = 'ab
 **workspace root** `Cargo.toml`. It has to: Cargo silently ignores `[profile.*]` in a member package, and for
 most of this project's life the size-tuned profile sat in `packages/search/Cargo.toml` doing nothing at all.
 
-`index_bg.wasm` is **~1.12 MB** (~500 KB gzipped) — every consumer downloads it. Roughly a third is
-`regex-automata`'s DFA and Unicode tables.
+`index_bg.wasm` is **~1.15 MB** (1,148,922 bytes; ~480 KB gzipped) — every consumer downloads it. Roughly a
+third is `regex-automata`'s DFA and Unicode tables.
 
 ---
 
@@ -143,7 +143,7 @@ any of them.
 **Documented, not fixed.** Caveats 1 and 2 interact: fixing either one naively reintroduces or worsens the
 other.
 
-### 1. Chunk-boundary false negatives — `Netgrep.ts:71`
+### 1. Chunk-boundary false negatives — `Netgrep.ts`, the `search_bytes` call in `handleReader`
 
 `search_bytes(u8Array, pattern)` is called with **one chunk at a time**, and chunks are never overlapped or
 joined before searching. A pattern that straddles the boundary between two `fetch` chunks is never seen by the
@@ -155,14 +155,14 @@ network chunking, so it is non-deterministic across runs and effectively untesta
 *Any fix requires retaining a tail buffer of at least `pattern.length - 1` bytes (more for regex patterns,
 where the maximum match length is not knowable from the pattern alone) and prepending it to the next chunk.*
 
-### 2. Poisoned partial cache — `Netgrep.ts:76`, `:80`, `:89-91`
+### 2. Poisoned partial cache — `Netgrep.ts`, `handleReader` and the cache-hit branch of `search`
 
-`upsertMemoryCache` appends each chunk as it arrives (`:76`), but the loop **resolves and stops reading the
-moment a chunk matches** (`:80`). The cache is then left holding only the *prefix* of the file downloaded so
-far, with no marker that it is incomplete.
+`upsertMemoryCache` appends each chunk as it arrives, but the loop **resolves and stops reading the moment a
+chunk matches**. The cache is then left holding only the *prefix* of the file downloaded so far, with no
+marker that it is incomplete.
 
-A later search on the same URL for a different pattern takes the cache-hit path (`:89-91`) and searches that
-truncated prefix — returning `false` for text that was never downloaded.
+A later search on the same URL for a different pattern takes the cache-hit branch at the top of `search` and
+searches that truncated prefix — returning `false` for text that was never downloaded.
 
 Reproduction: search a large file for a term near the top (populates a short prefix), then search the same URL
 for a term near the bottom → `false`.
@@ -170,13 +170,13 @@ for a term near the bottom → `false`.
 *Any fix needs a completeness flag per cache entry, so partial entries are only ever used to resume, never to
 answer.*
 
-### 3. Unbounded cache growth — `Netgrep.ts:198`
+### 3. Unbounded cache growth — `Netgrep.ts`, `upsertMemoryCache`
 
 The cache is a plain `Record<string, Uint8Array>` with no eviction, no size cap and no TTL. It retains the
 full bytes of every file searched for the lifetime of the `Netgrep` instance. `upsertMemoryCache` also
 reallocates and copies the whole accumulated buffer **per chunk**, making cache population O(n²) in bytes.
 
-### 4. Regex recompiled per chunk — `lib.rs:13-17`
+### 4. Regex recompiled per chunk — `lib.rs`, the `RegexMatcherBuilder` in `search_bytes`
 
 `search_bytes` builds a fresh `RegexMatcher` on **every call**, i.e. once per network chunk per file. Regex
 compilation is the expensive part of a small search; this discards it every time.
@@ -188,7 +188,12 @@ straight from a user-facing search box, a stray `(` or `[` surfaces as a wasm tr
 (`RuntimeError: unreachable`) rather than a catchable domain error. The instance does remain usable
 afterwards.
 
-### 7. One NUL byte discards the whole chunk
+### 6. No completion signal from `searchBatchWithCallback`
+
+It returns `void` and starts every search eagerly with no concurrency limit. Callers cannot await it, cannot
+detect completion, and a batch of N URLs opens N simultaneous connections.
+
+### 7. One NUL byte discards the whole chunk — `lib.rs`, `BinaryDetection::quit`
 
 `BinaryDetection::quit(b'\x00')` does not stop *at* the NUL — it abandons the entire chunk. A match is
 dropped even when it occurs before the NUL, and even on an earlier line. Any remote file containing a stray
@@ -196,11 +201,6 @@ NUL therefore reports "no match" for content that is demonstrably present.
 
 Quitting on binary input is a reasonable ripgrep default; the surprise is that the API cannot distinguish
 "binary, not searched" from "no match", because the API is a boolean.
-
-### 6. No completion signal from `searchBatchWithCallback`
-
-It returns `void` and starts every search eagerly with no concurrency limit. Callers cannot await it, cannot
-detect completion, and a batch of N URLs opens N simultaneous connections.
 
 ---
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -98,7 +98,7 @@ The runner must match the `wasm-bindgen` version in `Cargo.toml`; a stale cached
 `panicked at 'remaining data [...]', crates/cli-support/src/descriptor.rs`. Running `wasm-pack test` once
 downloads the right one into the cache.
 
-### 14. The `.wasm` is ~1.12 MB, up 10.6% from the 2022 build
+### 14. The `.wasm` is ~1.15 MB, up 10.6% from the 2022 build
 
 1,038,608 → 1,148,922 bytes. Accounted for (all measured 2026-07-28, release builds through `wasm-pack`):
 
@@ -112,7 +112,7 @@ downloads the right one into the cache.
 | **net** | **+110,314** |
 
 The bulk is upstream — newer `regex-automata` carries larger DFA and Unicode tables — and is not really
-reducible without giving up the modern crates. Roughly 500 KB gzipped over the wire.
+reducible without giving up the modern crates. Roughly 480 KB gzipped over the wire.
 
 Remaining levers, none taken: `opt-level = 'z'` (a further ~27 KB, at some throughput cost in a
 regex-scanning hot path); `wasm-opt -Oz`; disabling `grep-regex`'s Unicode support, which would change

--- a/docs/decisions/0002-search-while-downloading.md
+++ b/docs/decisions/0002-search-while-downloading.md
@@ -11,7 +11,7 @@ files, that is the difference between feeling instant and feeling broken.
 ## Decision
 
 Consume the response as a stream (`res.body.getReader()`) and call the WASM matcher on **each chunk as it
-arrives**, resolving the promise the moment a chunk matches. See `Netgrep.ts:50-104`.
+arrives**, resolving the promise the moment a chunk matches. See `handleReader` inside `Netgrep.search`.
 
 This is why the matching engine has to be ripgrep rather than a JavaScript regex over the assembled string:
 the whole point is to never assemble the string.
@@ -27,8 +27,8 @@ the whole point is to never assemble the string.
 - **Correctness: patterns straddling a chunk boundary are missed.** Chunks are searched in isolation with no
   overlap retained, so a match spanning the boundary is invisible. Silent false negative, dependent on
   non-deterministic network chunking. See `ARCHITECTURE.md` caveat 1.
-- The regex is recompiled per chunk (`lib.rs:13-17`), discarding the most expensive part of the work on every
-  iteration.
+- The regex is recompiled per chunk (the `RegexMatcherBuilder` in `lib.rs`'s `search_bytes`), discarding the
+  most expensive part of the work on every iteration.
 - Resolving early stops *reading* but does not cancel the underlying request, so bytes may keep arriving.
 - Interacts badly with the memory cache — the cache is left holding a partial file. See
   [0006](0006-in-memory-cache.md) and `ARCHITECTURE.md` caveat 2.

--- a/docs/decisions/0004-two-package-split.md
+++ b/docs/decisions/0004-two-package-split.md
@@ -1,6 +1,7 @@
 # 0004 — Ship two npm packages, not one
 
-**Status:** Accepted.
+**Status:** Accepted, **amended (2026-07-28)** — see *Amendment* at the end. Two of the costs recorded below
+no longer apply, and the description of what gets published is out of date.
 
 ## Context
 

--- a/docs/decisions/0005-esm-only-distribution.md
+++ b/docs/decisions/0005-esm-only-distribution.md
@@ -1,6 +1,7 @@
 # 0005 — ESM only; a bundler is required
 
-**Status:** Accepted. Acknowledged in the README as a limitation.
+**Status:** Accepted, **amended (2026-07-28)** — see *Amendment* at the end. ESM-only still holds, but the
+bundler requirement recorded below is gone; consumers now need no bundler configuration at all.
 
 ## Context
 
@@ -16,8 +17,8 @@ Ship ESM only.
   `wasm-pack` does not emit it and without it Node and some bundlers misread the generated ESM.
 - Consumers must enable `experiments.asyncWebAssembly` in their webpack config.
 
-The README carries this as an explicit warning: *"At the moment this library is exported only as an ESM, thus
-a bundler like Webpack is required to use it."*
+The README carried this as an explicit warning: *"At the moment this library is exported only as an ESM, thus
+a bundler like Webpack is required to use it."* (Removed in 2026 — see the amendment.)
 
 ## Consequences
 

--- a/docs/decisions/0006-in-memory-cache.md
+++ b/docs/decisions/0006-in-memory-cache.md
@@ -18,8 +18,8 @@ const defaultConfig: NetgrepConfig = { enableMemoryCache: true };
 ```
 
 On a cache hit, `search_bytes` runs once over the stored bytes and resolves immediately, skipping `fetch`
-entirely (`Netgrep.ts:89-91`). While streaming, each chunk is appended via `upsertMemoryCache`
-(`Netgrep.ts:76`).
+entirely (the cache-hit branch at the top of `Netgrep.search`). While streaming, each chunk is appended via
+`upsertMemoryCache`.
 
 The cache is per-instance, so a consumer can scope or discard it by managing the `Netgrep` object's lifetime.
 

--- a/docs/decisions/0008-wee-alloc.md
+++ b/docs/decisions/0008-wee-alloc.md
@@ -52,7 +52,7 @@ all. Measure before and after rather than assuming either way. Tracked in [`../B
 
 **Removed. The measurement this record asked for was taken, and the assumption behind it no longer held.**
 
-Against the modernized dependencies, `wee_alloc` was worth **6,839 bytes — 0.6%** of a ~1.12 MB binary.
+Against the modernized dependencies, `wee_alloc` was worth **6,839 bytes — 0.6%** of a ~1.15 MB binary.
 Modern `rustc` has closed the gap that justified it in 2022, so the project was carrying an unmaintained
 crate with a known unfixed leak, in a published package's hot path, for a rounding error.
 

--- a/packages/example/README.md
+++ b/packages/example/README.md
@@ -1,25 +1,22 @@
 # Netgrep example
 
-This is an example for a basic usage of the `@netgrep/netgrep` package using [Webpack](https://webpack.js.org/). See the [main README](https://github.com/dgopsq/netgrep) for more informations.
+This is an example for a basic usage of the `@netgrep/netgrep` package using [Webpack](https://webpack.js.org/). See the [main README](https://github.com/dgopsq/netgrep) for more information.
+
+It runs against the **local workspace source**, not a published release, so changes to `packages/netgrep` or `packages/search` show up here after a rebuild.
 
 ## Usage
 
-From the root of this repository install all the dependencies:
+From the root of this repository install the dependencies and build the WASM core — the example cannot resolve `@netgrep/search` until `packages/search/pkg/` exists:
 
 ```bash
-# Using yarn
-yarn add @netgrep/netgrep
-
-# Using npm
-npm install @netgrep/netgrep
+pnpm install
+pnpm build:wasm
 ```
 
-and then run:
+and then start the dev server:
 
 ```bash
-# Using yarn
-yarn nx serve example
-
-# Using npm
-npx nx serve example
+pnpm dev
 ```
+
+This is a manual smoke test, not part of the automated suite.

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -10,7 +10,7 @@
     "@netgrep/netgrep": "workspace:*",
     "lodash": "^4.17.21"
   },
-  "//": "Unchanged from the pre-pnpm root manifest on purpose. The example moves to Vite in its own PR; bumping webpack here would drag in the dev-server 5 config break (`http2` removed) for no benefit.",
+  "//": "Deliberately left on these versions. The example is an unpublished manual smoke test, so its dependencies are not on the maintenance path; bumping them buys nothing and risks another dev-server config break. That the published package works under other bundlers is established by docs/decisions/0005-esm-only-distribution.md, not by this app.",
   "devDependencies": {
     "html-webpack-plugin": "^5.5.0",
     "webpack": "^5.74.0",

--- a/packages/netgrep/README.md
+++ b/packages/netgrep/README.md
@@ -1,3 +1,3 @@
 # @netgrep/netgrep
 
-The main `netgrep` package. See the [main README](https://github.com/dgopsq/netgrep) for more informations.
+The main `netgrep` package. See the [main README](https://github.com/dgopsq/netgrep) for more information.

--- a/packages/netgrep/src/lib/Netgrep.integration.spec.ts
+++ b/packages/netgrep/src/lib/Netgrep.integration.spec.ts
@@ -14,11 +14,12 @@ import { Netgrep } from './Netgrep.js';
  *
  * WHY THIS EXISTS
  * ---------------
- * It is the behavioural baseline for the modernization sequence described in
- * `docs/plans/MODERNIZATION.md`. The next two PRs replace the entire JS
- * toolchain and then jump `wasm-bindgen` 44 minor versions while removing the
- * ripgrep fork. The claim those PRs need to support is "behaviour is
+ * It was written as the behavioural baseline for the modernization sequence in
+ * `docs/plans/MODERNIZATION.md`, ahead of the PRs that replaced the entire JS
+ * toolchain and then jumped `wasm-bindgen` 44 minor versions while removing the
+ * ripgrep fork. The claim those PRs had to support was "behaviour is
  * identical", and nothing in this repository could previously substantiate it.
+ * It keeps that job for every future dependency change.
  *
  * So: these assertions describe what netgrep ACTUALLY DOES TODAY, which is not
  * always what it should do. The `documented defects` block at the bottom pins
@@ -435,7 +436,7 @@ describe('Netgrep integration (real WASM)', () => {
       });
     });
 
-    it('UNDOCUMENTED: one NUL byte discards the entire chunk, match included', async () => {
+    it('BACKLOG 3f: one NUL byte discards the entire chunk, match included', async () => {
       // `BinaryDetection::quit(b'\x00')` abandons the chunk on the first NUL.
       // Not "stops at the NUL" — the match is dropped even when it occurs
       // BEFORE the NUL, and even on an earlier line.

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -1,3 +1,3 @@
 # @netgrep/search
 
-The WASM porting of [ripgrep](https://github.com/BurntSushi/ripgrep). See the [main README](https://github.com/dgopsq/netgrep) for more informations.
+The WASM porting of [ripgrep](https://github.com/BurntSushi/ripgrep). See the [main README](https://github.com/dgopsq/netgrep) for more information.

--- a/packages/search/scripts/post_build.js
+++ b/packages/search/scripts/post_build.js
@@ -1,13 +1,17 @@
 /**
  * Post-processing for `wasm-pack build`.
  *
- * Two jobs:
+ * Three jobs, all of them load-bearing:
  *
  *  1. Mark the generated `pkg/` as ESM. wasm-pack does not emit
  *     `"type": "module"`, and without it Node treats `pkg/index.js` as
  *     CommonJS and the import fails.
  *
- *  2. Copy the version out of `Cargo.toml` into `packages/search/package.json`.
+ *  2. Delete the `.gitignore` wasm-pack drops into `pkg/`. It contains `*`,
+ *     and npm honours a package-internal .gitignore, which silently empties
+ *     the published tarball. See the comment at the step itself.
+ *
+ *  3. Copy the version out of `Cargo.toml` into `packages/search/package.json`.
  *     Cargo.toml is the single source of truth for this package's version — the
  *     npm manifest is a hand-written wrapper around the wasm-pack output, so
  *     without this the two drift silently and a release ships the wrong number.
@@ -30,7 +34,7 @@ const generated = readJson(generatedPath);
 generated.type = 'module';
 writeJson(generatedPath, generated);
 
-// 1b. Delete the `.gitignore` wasm-pack drops into pkg/. It contains `*`, and
+// 2. Delete the `.gitignore` wasm-pack drops into pkg/. It contains `*`, and
 // npm honours a package-internal .gitignore when there is no .npmignore — so
 // with `"files": ["pkg"]` in the wrapper manifest it silently excludes the
 // entire directory and publishes a tarball containing no WASM at all.
@@ -42,7 +46,7 @@ if (existsSync(generatedGitignore)) {
   rmSync(generatedGitignore);
 }
 
-// 2. Cargo.toml -> package.json version sync.
+// 3. Cargo.toml -> package.json version sync.
 const cargoToml = readFileSync(join(packageRoot, 'Cargo.toml'), 'utf8');
 const cargoVersion = cargoToml.match(/^version\s*=\s*"([^"]+)"/m)?.[1];
 


### PR DESCRIPTION
Two commits. The first is a consistency sweep of every README, guide, decision record, skill and load-bearing code comment against the code as it actually is. The second fills in what the public README never told consumers.

Documentation only. The non-doc edits are a test *name* and comment prose — no assertion, no logic, no dependency touched.

---

# 1. Fixing what was wrong

## Wrong, and user-facing

| | |
|---|---|
| `README.md` | Still advertised **the ripgrep fork** as the engine, linking to `dgopsq/ripgrep`. The fork was dropped in 0.2.0 — the three `grep-*` crates now come unmodified from crates.io. |
| `README.md` | Warned that *"a bundler like Webpack is required"*, contradicted **fifteen lines later** by *"No bundler configuration is required"* and a list of six bundlers. |
| `packages/example/README.md` | Told you to run `yarn nx serve example`. **Nx was removed** — that command cannot work. Replaced with the pnpm flow, including the `build:wasm` step it never mentioned. |

## Two documents disagreeing

The release skill (`.claude/skills/wasm-release/`) said:

> Do **not** try to verify via the example app — it runs against published npm packages, not local source.

`AGENTS.md` §6.3 and `ARCHITECTURE.md` both say the opposite, and have since PR 2.

Worse, its verification list **omitted `pnpm verify:pack`** — the only check that inspects a release artefact rather than the working tree, missing from the document whose entire job is releases. It also described `post_build.js` as doing two things, leaving out the `.gitignore` deletion, which is precisely the step that stops the tarball shipping empty.

## Comments contradicting their own code

- `post_build.js` announced **"Two jobs"** and then did three, numbered `1`, `1b`, `2`.
- `packages/example/package.json` promised a Vite migration that was attempted, reverted, and is tracked nowhere.
- The integration suite's last defect test was still labelled `UNDOCUMENTED:` — it is **BACKLOG 3f**, and every sibling uses the `BACKLOG 3x:` prefix. Its header also described completed PRs in the future tense.

## Stale references

- Every `Netgrep.ts:71`-style citation in `ARCHITECTURE.md` and decisions 0002/0006 pointed at **the wrong lines**, having drifted when `await wasmReady` was added. Replaced with **symbol references**, which cannot rot the same way.
- `ARCHITECTURE.md` listed correctness caveats in the order `1,2,3,4,5,7,6`.
- The binary was quoted as `~1.12 MB` in five places. A fresh build measures **1,148,922 bytes** — `~1.15 MB` — and **481,102** gzipped rather than `~500 KB`.
- Decisions 0004 and 0005 carried a bare `Accepted` status while the index listed them as amended, so a reader could stop before reaching the correction.

---

# 2. Documenting the sharp edges

The README explained the happy path and nothing else. Everything below is behaviour a consumer hits without warning today.

**The batch methods never reject.** A 404, a CORS failure or an abort is folded into `{ result: false, error: "…" }` — indistinguishable from a genuine "no match" unless you check `error`. Single `search` calls do the exact opposite and reject. This asymmetry was documented nowhere and is silent-wrong-answer territory.

**Smart case is hardcoded on.** `sherlock` matches `Sherlock`; `Sherlock` does not match `sherlock`. Not configurable, not previously written down.

**An invalid pattern traps the WASM instance** with `RuntimeError: unreachable`. This matters precisely because the motivating use case is a user-facing search box, and users type `(`.

**`AbortSignal` existed and was documented nowhere**, despite being the natural fit for search-as-you-type.

**The cache is on by default** with no eviction, cap or TTL.

Plus a **Known limitations** section linking to `ARCHITECTURE.md` — the chunk-boundary miss, the partial-cache false negative, the invalid-pattern trap and the NUL byte. These were public knowledge in the repo docs; someone reading only the npm page had no way to learn them. Also stated the ~1.15 MB WASM download up front, and replaced a snippet that referenced an undefined `post` variable.

---

## Verification

Because the second commit makes assertions about *behaviour*, I verified them with a temporary spec against real WASM rather than reasoning about the source: batch folds both a failed request and an abort into `error`; single `search` rejects; smart case behaves as the table claims; `enableMemoryCache: false` re-fetches instead of answering from a partial cache. All five passed, the probe was removed, suite back to **24 tests**.

`build:wasm` reproduces **1,148,922 bytes exactly**, confirming the corrected size. `lint`, `typecheck`, `build` and `verify:pack` all pass. Every relative link across every tracked `.md`, and every repo link in the README, resolves.

`pnpm test:wasm` fails locally with ChromeDriver 151 against Chrome 150 (SIGKILL) — `BACKLOG.md` item 2 verbatim, pre-existing and local-only. No Rust was touched.

## One thing found but deliberately not fixed

`packages/netgrep/src/index.ts` re-exports only the `Netgrep` class, so **`NetgrepResult`, `NetgrepConfig`, `NetgrepInput`, `NetgrepSearchConfig` and `BatchNetgrepResult` are not importable** — a TypeScript consumer cannot name the types appearing in the library's own public signatures. Confirmed against the built package:

```
error TS2305: Module '"@netgrep/netgrep"' has no exported member 'NetgrepResult'.
```

The README therefore documents result *shapes* rather than showing an import that would not compile. The fix is one line, but it changes the published API surface, which under this repo's rules is its own deliberate task rather than a side effect of a docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)