### PR TITLE
docs: lead with what netgrep actually is, everywhere someone lands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,14 @@ files **over HTTP while they are still downloading**. It answers exactly one que
 occur in the file at this URL?* — a boolean, nothing more.
 
 The intended use case is a client-side search over a small, static, file-based corpus (e.g. Markdown posts
-emitted by a static site generator), as an alternative to standing up an index-based search backend.
+emitted by a static site generator), instead of standing up an index-based search backend.
+
+**It is an experiment, and the README says so first.** netgrep is not claimed to be a good way to build
+search — a prebuilt index (Pagefind, Lunr, FlexSearch, a hosted service) is usually smaller, faster and more
+capable, and can rank, snippet and locate matches, none of which netgrep does. What the project explores is
+the narrower question of whether ripgrep's real engine can usefully run over HTTP against files as they
+download. Keep that framing when you touch user-facing text: describe what it does and what it costs, and do
+not sell it.
 
 **Project status: maintained, conservative.** The toolchain is current and CI is green. Keep it that way:
 fix defects, keep dependencies from rotting, keep it working for existing consumers. **Do not add features.**

--- a/README.md
+++ b/README.md
@@ -4,7 +4,19 @@
 
 # netgrep
 
-Netgrep is an **experimental** porting of [ripgrep](https://github.com/BurntSushi/ripgrep) on WASM using the HTTP protocol. The scope of this project is to provide a viable alternative to index-based search engines for applications with a small files-based database. It is built on the `grep-matcher`, `grep-regex` and `grep-searcher` crates published from the `ripgrep` repository, used unmodified from crates.io. 
+> **Note**
+> **This is an experiment, not a recommendation.** Netgrep is almost certainly not the best way to add search
+> to your site. A prebuilt index — [Pagefind](https://pagefind.app/), [Lunr](https://lunrjs.com/),
+> [FlexSearch](https://github.com/nextapps-de/flexsearch), or a hosted service — will usually be smaller,
+> faster and far more capable: it can rank results, show snippets and tell you *where* a term appears, none
+> of which netgrep does.
+>
+> What this project explores is a narrower question: what happens if you take ripgrep's actual search engine,
+> compile it to WebAssembly, and run it over HTTP against files *while they are still downloading*? The
+> answer turns out to be "it works, and it is genuinely fast on a small corpus" — but it is a demonstration
+> of that idea, not infrastructure. Read the [known limitations](#known-limitations) before building on it.
+
+Netgrep is an **experimental** porting of [ripgrep](https://github.com/BurntSushi/ripgrep) on WASM using the HTTP protocol. The scope of this project is to explore an alternative to index-based search engines for applications with a small files-based database. It is built on the `grep-matcher`, `grep-regex` and `grep-searcher` crates published from the `ripgrep` repository, used unmodified from crates.io. 
 
 At the moment Netgrep is just going to tell whether a pattern is present on a remote file leveraging the `ripgrep` core search engine. This happens **while the file is being downloaded** in order to maximize the performance. 
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,6 +20,11 @@ understand out of the box.
 
 **Non-goals:** indexing, ranking, snippets, highlighting, Node.js support, filesystem search, a CLI.
 
+**It is an experiment rather than a recommended way to build search**, and the public README leads with that.
+A prebuilt index will usually beat it on size, speed and capability; what netgrep tests is whether ripgrep's
+real engine is usable over HTTP against files as they download. That framing is why the correctness caveats
+below are documented rather than hidden, and why the API has stayed a boolean.
+
 ---
 
 ## The three packages

--- a/docs/plans/MODERNIZATION.md
+++ b/docs/plans/MODERNIZATION.md
@@ -3,7 +3,9 @@
 **Status:** Complete as of 2026-07-28, with two amendments recorded below (decision 1 and the PR
 sequence). Kept as the record of why the repository changed shape.
 **Goal:** a repository that builds, lints and tests green on a current toolchain.
-**Explicit non-goal:** shipping anything to npm. See [Decision 1](#1-the-finish-line-is-green-ci-not-a-release).
+**Originally an explicit non-goal:** shipping anything to npm — later amended to include a 0.2.0 release of
+both packages, once PR 4 established that what was already on npm did not work under Vite. See
+[Decision 1](#1-the-finish-line-is-green-ci-not-a-release--amended-2026-07-28).
 
 This document is the durable record of a design conversation. It exists so that the *reasoning* behind the
 fourteen decisions below survives — an agent resuming at PR 3 should not have to re-derive why pnpm, why the
@@ -11,7 +13,7 @@ grep sub-crates, why no dependency bot.
 
 Every version number here was verified against the live registries on **2026-07-28**. Every claim about the
 repository was verified by reading it. The one non-obvious technical claim — that the ripgrep fork is
-droppable — was verified by building it; see [Appendix A](#appendix-a-the-fork-removal-probe).
+droppable — was verified by building it; see [Appendix A](#appendix-a--the-fork-removal-probe).
 
 ---
 
@@ -150,7 +152,7 @@ keeps dragging in exactly the wasm-hostile crates the fork had to patch.
 atomic change, not three — 0.2.82 requires Rust ≤ 1.81 (Rust 1.82 changed the wasm C ABI), and current
 `grep-matcher` requires edition 2024, i.e. Rust ≥ 1.85. Backlog item 4 called these mutually exclusive. They
 are not; that deadlock was an artifact of the old pins, and both sides clear together. Verified — see
-[Appendix A](#appendix-a-the-fork-removal-probe).
+[Appendix A](#appendix-a--the-fork-removal-probe).
 
 *Also:* remove `wee_alloc` (dead since 2019, known unfixed leak) and **report the `.wasm` size delta**.
 Current binary is ~1.0 MB. Modern `rustc` may have closed the gap that justified it in 2022. Measure; do not

--- a/packages/netgrep/README.md
+++ b/packages/netgrep/README.md
@@ -1,3 +1,15 @@
 # @netgrep/netgrep
 
 The main `netgrep` package. See the [main README](https://github.com/dgopsq/netgrep) for more information.
+
+> **Note**
+> **This is an experiment, not a recommendation.** netgrep is almost certainly not the best way to add
+> search to your site — a prebuilt index ([Pagefind](https://pagefind.app/), [Lunr](https://lunrjs.com/),
+> [FlexSearch](https://github.com/nextapps-de/flexsearch), or a hosted service) will usually be smaller,
+> faster and far more capable. What this explores is a narrower question: what happens if you compile
+> ripgrep's actual search engine to WebAssembly and run it over HTTP against files *while they are still
+> downloading*.
+>
+> It answers one question per URL — *does this pattern occur?* — as a boolean. No ranking, no snippets, no
+> match positions. It has [known limitations](https://github.com/dgopsq/netgrep#known-limitations),
+> including silent false negatives, that are worth reading before you build on it.

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -1,3 +1,21 @@
 # @netgrep/search
 
 The WASM porting of [ripgrep](https://github.com/BurntSushi/ripgrep). See the [main README](https://github.com/dgopsq/netgrep) for more information.
+
+This is the low-level core of [`@netgrep/netgrep`](https://www.npmjs.com/package/@netgrep/netgrep), which is
+probably the package you want — it adds the streaming, batching and caching that make the engine useful over
+HTTP. Used directly, this one exposes a single function —
+`search_bytes(chunk: Uint8Array, pattern: string): boolean` — and its default export is an `init` you must
+await before calling it.
+
+> **Note**
+> **This is an experiment, not a recommendation.** netgrep is almost certainly not the best way to add
+> search to your site — a prebuilt index ([Pagefind](https://pagefind.app/), [Lunr](https://lunrjs.com/),
+> [FlexSearch](https://github.com/nextapps-de/flexsearch), or a hosted service) will usually be smaller,
+> faster and far more capable. What this explores is a narrower question: what happens if you compile
+> ripgrep's actual search engine to WebAssembly and run it over HTTP against files *while they are still
+> downloading*.
+>
+> Note also that this package is a **~1.15 MB WebAssembly binary** (~480 KB gzipped) and has
+> [known limitations](https://github.com/dgopsq/netgrep#known-limitations) — an invalid pattern traps the
+> instance, and a single NUL byte discards the chunk being searched.


### PR DESCRIPTION
Two commits. The first puts an honest framing at the top of the main README; the second carries it to the other places a reader actually arrives.

## The callout

It sits directly under the `# netgrep` title, before the first paragraph, so it is the first prose anyone reads. (Above the banner image would have been literally first, but a callout stacked over the header would look broken.)

- **A prebuilt index will usually beat this** — Pagefind, Lunr, FlexSearch, or a hosted service — named so the claim is concrete rather than false modesty.
- **What netgrep gives up**: no ranking, no snippets, no match positions. A boolean per URL.
- **The question it actually explores**: what happens if you compile ripgrep's real engine to WebAssembly and run it over HTTP against files *while they are still downloading*. It works and it is fast on a small corpus — but it is a demonstration, not infrastructure.

## Everywhere else it belongs

**The npm pages matter more than this repo.** `packages/netgrep/README.md` and `packages/search/README.md` are what npm renders, and both were one-line pointers here — so anyone evaluating the library from a package page got the pitch and none of the caveats. Each now carries a condensed callout.

The `@netgrep/search` one also answers what a reader landing there most needs: it is the low-level core, `@netgrep/netgrep` is probably the package they want, and using it directly means awaiting `init()` and shipping ~1.15 MB of WebAssembly. (Signature verified against the generated `index.d.ts`.)

**`AGENTS.md` §1** described the use case as *"an alternative to standing up an index-based search backend"* — the same overclaim the callout walks back. Reworded, plus an instruction aimed at agents: keep this framing in user-facing text, state cost alongside capability, don't sell it.

**`docs/ARCHITECTURE.md`** Scope now says the same, and ties it to why the correctness caveats below are documented rather than hidden.

Skipped deliberately: the example README (already framed as a demo) and the npm `description` fields (accurate, and 80 characters is the wrong place for this).

## One sentence softened

The paragraph below the callout described the project's scope as **"a viable alternative to index-based search engines"** — precisely the claim being walked back one line above. Now *"explore an alternative"*. This is the only pre-existing prose rewritten; flagging it because it is your own long-standing description, so say the word if you'd rather it stayed.

## Two broken anchors fixed on the way

Both pre-existing in `MODERNIZATION.md`, and both invisible to the link checker used in #10 — that one validated file paths but not anchors:

- `#1-the-finish-line-is-green-ci-not-a-release` broke when its heading gained `— AMENDED 2026-07-28`. The line carrying it *also* still called shipping to npm an explicit non-goal, which is exactly what that amendment reversed. Now states the original goal and the change.
- `#appendix-a-the-fork-removal-probe`, twice, needed a double hyphen.

Same trap both times: GitHub strips an em dash but keeps the spaces around it, yielding two hyphens. My first checker collapsed whitespace and so reported a *correct* anchor as broken — the known-good `#known-limitations--correctness-caveats` link is what showed the checker was wrong, not the doc.

## Verification

The corrected checker validates local, cross-file and repo-URL anchors: **100 links across every tracked markdown file resolve.** Lint clean, typecheck clean, 24 tests passing, `verify:pack` passing. No source changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)