### PR TITLE
chore: one-command setup for fresh checkouts and worktrees

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,11 @@
     "allow": [
       "Bash(pnpm install)",
       "Bash(pnpm install --frozen-lockfile)",
+      "Bash(pnpm bootstrap:*)",
+      "Bash(pnpm worktree:*)",
+      "Bash(node scripts/bootstrap.mjs:*)",
+      "Bash(node scripts/worktree.mjs:*)",
+      "Bash(git worktree list:*)",
       "Bash(pnpm build)",
       "Bash(pnpm build:wasm)",
       "Bash(pnpm lint)",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,8 @@ pnpm build:wasm
 `pnpm install` works without it, and so do the unit tests (they mock the engine). Everything else does not.
 This is the first thing to try when something fails inexplicably on a clean checkout.
 
+`pnpm bootstrap` does this step for you, along with the install and the shared Cargo cache — see §4.1.
+
 ---
 
 ## 3. Toolchain
@@ -94,12 +96,17 @@ shipped artefact is a browser-targeted ESM library, so the Node version only eve
 All run from the repository root.
 
 ```bash
+pnpm bootstrap         # fresh clone or fresh worktree: does both of the below
+```
+```bash
 pnpm install           # once
 pnpm build:wasm        # REQUIRED FIRST — see §2.2
 ```
 
 | Task | Command | Notes |
 |---|---|---|
+| Prepare a checkout | `pnpm bootstrap` | Shared Cargo cache + install + WASM. Idempotent — see §4.1 |
+| New worktree | `pnpm worktree <branch>` | `git worktree add` beside this checkout, then bootstrap it |
 | Build WASM | `pnpm build:wasm` | → `packages/search/pkg/`, ~1.15 MB `index_bg.wasm` |
 | Build TS | `pnpm build` | → `packages/netgrep/dist/` |
 | Lint | `pnpm lint` | Biome (JS/TS) **and** clippy (`-D warnings`) |
@@ -107,8 +114,38 @@ pnpm build:wasm        # REQUIRED FIRST — see §2.2
 | Typecheck | `pnpm typecheck` | `tsc --noEmit`, TypeScript 7 |
 | Test TS | `pnpm test` | Vitest — **24 tests** (7 unit, 17 integration) |
 | Test Rust | `pnpm test:wasm` | wasm-bindgen in headless Chrome — **2 tests** |
-| Verify packaging | `pnpm verify:pack` | Packs both packages and inspects the tarballs |
+| Verify packaging | `pnpm verify:pack` | Packs both packages and inspects the tarballs. **Needs `pnpm build` first** |
 | Run the example | `pnpm dev` | Demo, not a test — see §6.3 |
+
+### 4.1 Working in a git worktree
+
+```bash
+pnpm worktree fix/chunk-boundary     # → ../netgrep-fix-chunk-boundary, ready to build
+```
+
+Creates the branch if it does not exist, places the worktree **beside** this checkout (never inside it — a
+nested checkout would be picked up by the workspace glob, Biome and Vitest alike), and bootstraps it.
+
+`pnpm bootstrap` inside an existing worktree does the same preparation. Both accept `--no-install` and
+`--no-build` to skip a step.
+
+**The repository configures no build cache, on purpose.** Cargo keeps `target/` inside each worktree, so each
+one recompiles the ripgrep dependency tree and keeps its own copy (~8s release, ~5s more for clippy, up to
+1.2 GB). Sharing that is a line in the developer's shell profile, not a file in this repo:
+
+```bash
+export CARGO_TARGET_DIR="$HOME/.cache/cargo-shared"
+```
+
+A new worktree then compiles only the `search` crate — under half a second measured, against ~8s cold. Cargo
+**locks** the target directory,
+so simultaneous builds in two worktrees serialize, and the directory grows unbounded. `bootstrap.mjs` reports
+which cache it found and suggests the variable once a second worktree exists.
+
+Do not commit this as `build.target-dir`: it is an absolute path, and CI's caching actions assume the default
+`target/`. [Decision 0012](docs/decisions/0012-worktree-bootstrap.md) records the generated-config approach
+that was built first, measured, and dropped — and what comparable JS+Rust repositories do instead.
+[`CONTRIBUTING.md`](CONTRIBUTING.md) is the human-facing version of this section.
 
 ### `pnpm test:wasm` may fail on your machine
 
@@ -146,11 +183,14 @@ packages/
                      Not published. Runs against local workspace source.
 
 scripts/verify-pack.mjs   Packaging guard, run in CI.
+scripts/bootstrap.mjs     Prepares a checkout: shared Cargo cache, install, WASM (§4.1).
+scripts/worktree.mjs      `git worktree add` + bootstrap, in one command.
 ```
 
 Root config: `pnpm-workspace.yaml`, `Cargo.toml` (Rust workspace **and** the release profile — Cargo ignores
 `[profile.*]` in member packages), `tsconfig.base.json`, `biome.jsonc`, `vitest.config.ts`,
-`rust-toolchain.toml`, `.node-version`, `.github/workflows/`.
+`rust-toolchain.toml`, `.node-version`, `.github/workflows/`. There is deliberately **no `.cargo/config.toml`**
+— see §4.1.
 
 ### Two things about `packages/search` that surprise people
 
@@ -243,3 +283,4 @@ property that is the whole point of the project. See
 | [`docs/decisions/`](docs/decisions/) | Why the system is shaped this way — one record per decision |
 | [`docs/BACKLOG.md`](docs/BACKLOG.md) | Sanctioned maintenance work, prioritised |
 | [`README.md`](README.md) | Public-facing usage docs. Audience is consumers, not contributors. |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Human on-ramp: prerequisites, first run, worktrees, PR checklist. Points here for depth. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,120 @@
+# Contributing
+
+netgrep is an **experiment**, and it is maintained conservatively: fix defects, keep dependencies from
+rotting, keep it working for existing consumers. **New features are out of scope** — the public API is
+deliberately one boolean per URL, and widening it is a design conversation rather than a pull request. See
+[`docs/BACKLOG.md`](docs/BACKLOG.md) for work that is already sanctioned.
+
+[`AGENTS.md`](AGENTS.md) is the authoritative guide to this repository — toolchain pins, the repository map,
+the hard rules, the known correctness caveats. This file is the short human on-ramp; where the two overlap,
+AGENTS.md wins.
+
+## Prerequisites
+
+Everything is pinned in a file, so you should not need to pick versions.
+
+| Tool | Version | Where it comes from |
+|---|---|---|
+| Node | 24.18.0 | `.node-version` — `fnm use`, `nvm use`, or your manager of choice |
+| pnpm | 11.17.0 | `corepack enable`, then it reads `packageManager` in `package.json` |
+| Rust | 1.97.1 | `rust-toolchain.toml` — rustup installs it on first `cargo` call |
+| wasm-pack | 0.13.1 | `cargo install wasm-pack` — the one tool you install by hand |
+
+## First run
+
+```bash
+pnpm bootstrap
+```
+
+That is `pnpm install` followed by `pnpm build:wasm`. **Do not skip the second half.** `@netgrep/netgrep`
+resolves `@netgrep/search` to this workspace, and that package points at `packages/search/pkg/` — a gitignored
+build output that does not exist on a fresh clone. Until you build it, `pnpm typecheck`, `pnpm build` and the
+integration tests all fail in ways that look like anything except a missing WASM build. This is the single
+most common way to lose an hour here.
+
+## Commands
+
+All from the repository root. [AGENTS.md §4](AGENTS.md#4-commands) has the full list and the caveats.
+
+```bash
+pnpm test          # Vitest — 24 tests
+pnpm typecheck     # tsc --noEmit
+pnpm lint          # Biome (JS/TS) and clippy (-D warnings)
+pnpm format        # Biome, writes in place
+pnpm build:wasm    # rebuild after any change to packages/search
+pnpm dev           # the Sherlock Holmes demo — a manual smoke test, not a test
+```
+
+`pnpm test:wasm` runs the Rust tests in headless Chrome and **may fail on your machine** through no fault of
+your change: wasm-pack downloads the newest ChromeDriver, which cannot drive an older installed Chrome. CI is
+unaffected. See [`docs/BACKLOG.md`](docs/BACKLOG.md) item 2.
+
+## Working on several branches at once
+
+```bash
+pnpm worktree fix/chunk-boundary
+```
+
+Creates the branch if it does not exist, adds a git worktree **beside** this checkout (never inside it — a
+nested checkout would be picked up by the pnpm workspace glob, Biome and Vitest alike), and bootstraps it.
+`pnpm bootstrap` inside an existing worktree does the same preparation. Both take `--no-install` and
+`--no-build`.
+
+### Sharing a build cache
+
+Cargo keeps its `target/` **inside each worktree**, so every worktree compiles the ripgrep dependency tree
+again and keeps its own copy — measured here at ~8s for the release profile, ~5s more for clippy's dev
+profile, and a directory that reaches 1.2 GB once the `wasm-pack test` artefacts land in it.
+
+If you keep more than one worktree around, share one cache by exporting a variable from your shell profile:
+
+```bash
+export CARGO_TARGET_DIR="$HOME/.cache/cargo-shared"
+```
+
+A new worktree then compiles only the `search` crate — under half a second measured, against ~8s for a cold
+dependency build. Two things to know: Cargo **locks** the target directory, so two worktrees building at the same instant serialize; and the
+directory grows without bound, so prune it occasionally (`cargo sweep` if you want that automated).
+
+The alternative is [sccache](https://github.com/mozilla/sccache) via `RUSTC_WRAPPER`, which keeps a bounded,
+self-evicting cache and does not serialize parallel builds. It cannot cache the `cdylib` this crate produces,
+but it does cache the dependencies, which is where the cost is; it also requires `CARGO_INCREMENTAL=0`.
+
+**Keep this in your environment, not in the repository.** A committed `build.target-dir` would have to be an
+absolute path, and a committed `rustc-wrapper` would make sccache mandatory for everyone including CI — where
+the caching actions assume the default `target/`. [Decision 0012](docs/decisions/0012-worktree-bootstrap.md)
+records why, and what the comparable JS+Rust projects do.
+
+## Before opening a pull request
+
+```bash
+pnpm lint && pnpm typecheck && pnpm build && pnpm test && pnpm verify:pack
+```
+
+That is the order CI runs them in. `pnpm build` is not optional here even though nothing else needs it:
+`verify:pack` inspects the tarballs that would reach npm, and `packages/netgrep/dist/` has to exist first.
+
+Then, in rough order of how likely each is to bite:
+
+- **Some tests assert behaviour that is deliberately wrong.** `Netgrep.integration.spec.ts` ends with a block
+  titled *documented defects*, pinning known bugs — a match straddling a chunk boundary returning `false`, a
+  NUL byte discarding a chunk. If one fails, something changed the engine; work out what, and if the new
+  behaviour is right, **invert the assertion in the same PR** with a note. Do not quietly "fix" the test.
+  [AGENTS.md §2.1](AGENTS.md#21-some-tests-assert-behaviour-that-is-wrong-on-purpose) has the full story.
+- **Do not bump dependencies as a side effect.** A version change is its own deliberate, tested change. If a
+  tool suggests one while you are doing something else, add it to `docs/BACKLOG.md`.
+- **Do not commit build outputs or lockfile churn.** `packages/netgrep/dist/` and `packages/search/pkg/` are
+  gitignored; if a command rewrites `pnpm-lock.yaml` incidentally, revert it.
+- **ESM only, and relative imports carry a `.js` extension** even though the sources are `.ts`.
+  `moduleResolution` is `nodenext`, which requires it.
+- **Comments explain *why*.** Several places in this repository look wrong and are not; they are commented
+  for a reason. Keep that density.
+
+Releases fire from pushed git tags and publish under the maintainer's npm token. **Version bumps and
+publishing are maintainer-only** — please do not include them in a pull request.
+
+## Where things live
+
+[AGENTS.md §5](AGENTS.md#5-repository-map) maps the three packages and says which file to change for which
+kind of goal. [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) covers the design and the known correctness
+caveats; [`docs/decisions/`](docs/decisions/) explains why the system is shaped the way it is.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ fixes for both are to wait for the full file, which is the thing netgrep is buil
 |---|---|
 | [`docs/ARCHITECTURE.md`](https://github.com/dgopsq/netgrep/blob/main/docs/ARCHITECTURE.md) | How it works, and the limitations in full |
 | [`docs/decisions/`](https://github.com/dgopsq/netgrep/tree/main/docs/decisions) | Why it is shaped this way |
+| [`CONTRIBUTING.md`](https://github.com/dgopsq/netgrep/blob/main/CONTRIBUTING.md) | Building it yourself, and opening a pull request |
 | [`AGENTS.md`](https://github.com/dgopsq/netgrep/blob/main/AGENTS.md) | Working in this repository |
 
 ## License

--- a/docs/decisions/0012-worktree-bootstrap.md
+++ b/docs/decisions/0012-worktree-bootstrap.md
@@ -1,0 +1,88 @@
+# 0012 — A bootstrap script, and no build-cache configuration in the repository
+
+**Status:** Accepted (2026-07-29).
+
+## Context
+
+A `git worktree` of this repository, and a fresh clone, are unusable on arrival. Three things they need are
+untracked build state:
+
+| | Cost in a new checkout |
+|---|---|
+| `node_modules/` | one `pnpm install`; cheap, the pnpm store is global and hardlinked |
+| `packages/search/pkg/` | must be built — see [0009](0009-pnpm-workspaces.md) and `AGENTS.md` §2.2 |
+| `target/` | the whole ripgrep dependency tree, compiled again, kept again |
+
+The second is a trap rather than a cost: forgetting it makes `pnpm typecheck`, `pnpm build` and the
+integration tests fail in ways that point anywhere except at a missing WASM build.
+
+The third is a genuine duplication. Cargo keeps `target/` inside each worktree, so every worktree recompiles
+the same dependencies. Measured here: ~8s for the release profile, ~5s more for clippy's dev profile, and a
+directory that reaches 1.2 GB once `wasm-pack test` artefacts land in it — per worktree.
+
+## Decision
+
+**`pnpm bootstrap`** prepares a checkout: `pnpm install --frozen-lockfile`, then `pnpm build:wasm`. It is
+idempotent. **`pnpm worktree <branch>`** adds a worktree beside the main checkout and bootstraps it.
+
+**The repository configures no build cache.** Sharing Cargo artefacts across worktrees is a one-line
+environment variable in the developer's shell (`CARGO_TARGET_DIR`, or `RUSTC_WRAPPER=sccache`), documented in
+[`CONTRIBUTING.md`](../../CONTRIBUTING.md). `bootstrap.mjs` reports what it finds and suggests the variable
+when more than one worktree exists; it writes nothing.
+
+### What was built first, and why it was dropped
+
+The first version generated a gitignored `.cargo/config.toml` pointing `build.target-dir` at
+`<git-common-dir>/cargo-target`, shared by every worktree. It worked: a new worktree compiled only the
+`search` crate, 0.38s against the warm cache, and a clippy run in one worktree warmed the next run in another
+to 0.02s. One 143 MB directory replaced a 1.2 GB one per worktree.
+
+`CARGO_TARGET_DIR` was then measured to do the same job: a cold dependency build in one worktree (11s, 26
+crates) left the other needing 0.02s.
+
+It was dropped after looking at what comparable JS+Rust projects actually do:
+
+| Project | Rust build cache | JS task cache | `.cargo/config.toml` |
+|---|---|---|---|
+| oxc | `Swatinem/rust-cache` + Namespace remote cache | none | committed — rustflags, linker |
+| biome | `moonrepo/setup-rust`, `cache-base: main` | none | — |
+| swc | none; `CARGO_INCREMENTAL: 0` | none (pnpm store only) | — |
+| rspack | — | none | committed — rustflags, clippy lints |
+| rolldown | — | none | committed — rustflags, target features |
+
+Three things are consistent across all of them. **Nobody unifies the two caches** — Cargo owns Rust, the
+package manager owns JS, and no monorepo tool bridges them, which is the same conclusion
+[0007](0007-nx-cargo-hybrid-monorepo.md) reached from the other direction. **All the investment is in CI**,
+via an off-the-shelf action keyed on the *default* `target/`. And while every one of them commits
+`.cargo/config.toml`, **not one sets `build.target-dir` or `rustc-wrapper`** — what gets committed is
+machine-agnostic (rustflags, linker args, target features), and machine-specific caching lives in the
+developer's environment.
+
+The generated file was the outlier, and it was carrying real weight: a gitignore entry, a proposed
+`postinstall` hook to apply it in worktrees nobody bootstrapped by hand, a `CI` guard on that hook so it could
+not orphan `Swatinem/rust-cache`, and a clobber check so it would not eat a hand-written config. All of it
+existed to distribute one machine-specific path. `export CARGO_TARGET_DIR=…` does the same job, is inherited
+by subprocesses and agent-spawned worktrees for free, and costs the repository nothing.
+
+## Consequences
+
+**Good:**
+- One command from `git worktree add` to a checkout that builds and tests.
+- The repository owns no machine-specific build configuration, and nothing silently redirects a build.
+- CI is unaffected by construction — there is no configuration for it to pick up.
+- The measured saving is still available; it moved to a documented line in a shell profile.
+
+**Costs:**
+- The cache is opt-in and per-machine, so it is invisible to anyone who clones and does not read
+  `CONTRIBUTING.md`. `bootstrap.mjs` mentions it when a second worktree exists, which is when it starts to
+  matter.
+- `CARGO_TARGET_DIR` has the two properties the generated config had: Cargo **locks** the target directory, so
+  simultaneous builds in two worktrees serialize; and the directory grows unbounded, with no eviction.
+  `sccache` avoids both, at the cost of an unpinned binary, `CARGO_INCREMENTAL=0`, and no caching of the
+  `cdylib` this crate produces (the dependencies, which are the expensive part, do cache).
+- `pnpm worktree` can only bootstrap branches that *contain* `scripts/bootstrap.mjs`. For an older branch it
+  creates the worktree, says what it skipped, and stops.
+
+**Deliberately not done:** sharing `node_modules` between worktrees. pnpm's store already makes installs
+hardlink-cheap (1.7s measured), and a shared `node_modules` would break the moment two branches disagreed
+about a dependency.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -24,6 +24,7 @@ reasoning got wrong.
 | [0009](0009-pnpm-workspaces.md) | pnpm workspaces, and a hand-written manifest for the WASM package | Accepted |
 | [0010](0010-vitest-and-biome.md) | Vitest and Biome replace jest, ts-jest, ESLint and Prettier | Accepted |
 | [0011](0011-tests-that-assert-known-bugs.md) | Tests that deliberately assert incorrect behaviour | Accepted |
+| [0012](0012-worktree-bootstrap.md) | A bootstrap script, and no build-cache configuration in the repository | Accepted |
 
 ## Format
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "node": ">=24"
   },
   "scripts": {
+    "bootstrap": "node scripts/bootstrap.mjs",
+    "worktree": "node scripts/worktree.mjs",
     "build": "pnpm --filter @netgrep/netgrep build",
     "build:wasm": "pnpm --filter @netgrep/search build",
     "test": "vitest run",

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -1,0 +1,121 @@
+/**
+ * Prepare a checkout for work: dependencies, then the WASM build.
+ *
+ * This exists because a `git worktree` — or a fresh clone — starts out
+ * unusable. Two of the things it needs are untracked build state:
+ * `node_modules/` and `packages/search/pkg/`. The second one is the trap
+ * documented in AGENTS.md §2.2: `pnpm typecheck`, `pnpm build` and the
+ * integration tests all fail in ways that point anywhere but at a missing WASM
+ * build, and the fix is a command you have to already know about.
+ *
+ * What this script deliberately does NOT do is configure a build cache.
+ *
+ * An earlier version wrote a `.cargo/config.toml` pointing `build.target-dir`
+ * at a directory shared by every worktree, because Cargo otherwise keeps a
+ * private `target/` per worktree and recompiles the whole ripgrep dependency
+ * tree into each one. It worked — measurably — but a survey of comparable
+ * JS+Rust repositories (oxc, rolldown, rspack, biome, swc) found that all of
+ * them commit `.cargo/config.toml` for machine-agnostic settings such as
+ * rustflags, and *none* of them set `build.target-dir` or a `rustc-wrapper`.
+ * Machine-specific caching lives in the developer's environment there, and CI
+ * caching actions assume the default `target/`.
+ *
+ * So the cache is an environment variable you set once, and this script only
+ * reports what it found. See CONTRIBUTING.md.
+ *
+ * Usage:
+ *   node scripts/bootstrap.mjs [--no-install] [--no-build]
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const args = new Set(process.argv.slice(2));
+
+for (const arg of args) {
+  if (arg !== '--no-install' && arg !== '--no-build') {
+    console.error(`bootstrap: unknown option ${arg}`);
+    console.error(
+      'usage: node scripts/bootstrap.mjs [--no-install] [--no-build]',
+    );
+    process.exit(2);
+  }
+}
+
+/** Run a command for its output, trimmed. */
+const capture = (file, argv) =>
+  execFileSync(file, argv, { encoding: 'utf8' }).trim();
+
+/** Run a command for its side effects, streaming its output through. */
+const run = (file, argv, cwd) =>
+  execFileSync(file, argv, { cwd, stdio: 'inherit' });
+
+// Resolved from git rather than from this file's location: the worktree helper
+// runs this script with the new worktree as its working directory.
+const repoRoot = capture('git', ['rev-parse', '--show-toplevel']);
+
+/**
+ * Say what Cargo will do with its build artefacts, and suggest sharing them
+ * when — and only when — more than one worktree exists. A single-checkout
+ * clone has nothing to share with, and nagging it would be noise.
+ */
+function reportBuildCache() {
+  if (process.env.CARGO_TARGET_DIR) {
+    console.log(`cargo target: ${process.env.CARGO_TARGET_DIR}`);
+    return;
+  }
+
+  if (process.env.RUSTC_WRAPPER) {
+    console.log(`compiler cache: ${process.env.RUSTC_WRAPPER}`);
+    return;
+  }
+
+  const worktrees = capture('git', ['worktree', 'list']).split('\n').length;
+
+  if (worktrees > 1) {
+    console.log(
+      `cargo target: ./target (private to this checkout, ${worktrees} exist)`,
+    );
+    console.log('Share one across worktrees with CARGO_TARGET_DIR — see');
+    console.log('CONTRIBUTING.md, "Sharing a build cache".');
+  }
+}
+
+reportBuildCache();
+
+if (args.has('--no-install')) {
+  console.log('skipping pnpm install (--no-install)');
+} else {
+  console.log('\n> pnpm install --frozen-lockfile');
+  run('pnpm', ['install', '--frozen-lockfile'], repoRoot);
+}
+
+if (args.has('--no-build')) {
+  console.log('\nskipping WASM build (--no-build)');
+  console.log('Nothing but `pnpm install` and the unit tests will work until');
+  console.log('you run `pnpm build:wasm` — see AGENTS.md §2.2.');
+  process.exit(0);
+}
+
+// wasm-pack is the one tool not pinned by a file in the repo, so its absence is
+// the likeliest way this step fails, and the error it produces otherwise is a
+// bare ENOENT.
+try {
+  capture('wasm-pack', ['--version']);
+} catch {
+  console.error('\nbootstrap: wasm-pack is not on PATH.');
+  console.error('Install it with `cargo install wasm-pack`, then re-run.');
+  process.exit(1);
+}
+
+console.log('\n> pnpm build:wasm');
+run('pnpm', ['build:wasm'], repoRoot);
+
+// A leftover from the generated-config approach described above. Harmless, but
+// it silently redirects every build, which is exactly the confusion that
+// approach was dropped for.
+if (existsSync(join(repoRoot, '.cargo', 'config.toml'))) {
+  console.log('\nNote: .cargo/config.toml exists and may redirect builds.');
+}
+
+console.log('\nReady. Try `pnpm test` or `pnpm dev`.');

--- a/scripts/worktree.mjs
+++ b/scripts/worktree.mjs
@@ -1,0 +1,81 @@
+/**
+ * Create a git worktree and make it usable in one command.
+ *
+ * `git worktree add` on its own leaves a checkout that cannot build: no
+ * `node_modules/`, no `packages/search/pkg/`, and a cold Cargo target. This
+ * wraps it and runs `scripts/bootstrap.mjs` in the new checkout, which is where
+ * the interesting part lives — read the comment at the top of that file.
+ *
+ * Worktrees are placed beside the main checkout rather than inside it. A nested
+ * checkout would sit under the workspace glob, the Biome `**` include and the
+ * Vitest include, and every one of them would pick up a second copy of the
+ * sources.
+ *
+ * Usage:
+ *   node scripts/worktree.mjs <branch> [path] [--no-install] [--no-build]
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
+
+const argv = process.argv.slice(2);
+const flags = argv.filter((arg) => arg.startsWith('-'));
+const positional = argv.filter((arg) => !arg.startsWith('-'));
+const [branch, requestedPath] = positional;
+
+if (!branch) {
+  console.error(
+    'usage: pnpm worktree <branch> [path] [--no-install] [--no-build]',
+  );
+  process.exit(2);
+}
+
+/** Run a command for its output, trimmed. */
+const capture = (file, args) =>
+  execFileSync(file, args, { encoding: 'utf8' }).trim();
+
+// The first entry `git worktree list` reports is always the main checkout.
+const mainWorktree = capture('git', ['worktree', 'list', '--porcelain'])
+  .split('\n')[0]
+  .replace(/^worktree /, '');
+
+// Branch names may contain `/`, which would otherwise create a nested path.
+const directoryName = `${basename(mainWorktree)}-${branch.replaceAll('/', '-')}`;
+const worktreePath = resolve(
+  requestedPath ?? join(dirname(mainWorktree), directoryName),
+);
+
+let branchExists = true;
+
+try {
+  capture('git', ['rev-parse', '--verify', '--quiet', `refs/heads/${branch}`]);
+} catch {
+  branchExists = false;
+}
+
+// Without an existing branch, `-b` creates one from the current HEAD, which is
+// the behaviour you want when starting a piece of work.
+const addArgs = branchExists
+  ? ['worktree', 'add', worktreePath, branch]
+  : ['worktree', 'add', '-b', branch, worktreePath];
+
+console.log(`> git ${addArgs.join(' ')}`);
+execFileSync('git', addArgs, { stdio: 'inherit' });
+
+const bootstrap = join(worktreePath, 'scripts', 'bootstrap.mjs');
+
+if (!existsSync(bootstrap)) {
+  console.warn(
+    `\nworktree: ${branch} has no scripts/bootstrap.mjs — skipping.`,
+  );
+  console.warn(`Set it up by hand in ${worktreePath}.`);
+  process.exit(0);
+}
+
+console.log('');
+execFileSync(process.execPath, [bootstrap, ...flags], {
+  cwd: worktreePath,
+  stdio: 'inherit',
+});
+
+console.log(`\nWorktree ready at ${worktreePath}`);


### PR DESCRIPTION
A fresh clone — and every `git worktree` — starts out unusable. `node_modules/` and `packages/search/pkg/` are both untracked build state, and forgetting the second makes `pnpm typecheck`, `pnpm build` and the integration tests fail in ways that point anywhere except at a missing WASM build (AGENTS.md §2.2).

## What this adds

- **`pnpm bootstrap`** — `pnpm install --frozen-lockfile` then `pnpm build:wasm`, idempotent. Fresh clone to working checkout: **17s** measured.
- **`pnpm worktree <branch>`** — creates the branch if needed, adds the worktree *beside* the main checkout, and bootstraps it. Never inside: a nested checkout falls under the pnpm workspace glob, Biome's `**` include and Vitest's `include`, and each would see a second copy of every source file.
- **`CONTRIBUTING.md`** — the repository had no human on-ramp. README targets consumers, AGENTS.md targets agents. It defers to AGENTS.md rather than forking it.
- **Decision 0012**, plus AGENTS.md §4.1.

## No build cache is configured in the repository

Cargo keeps `target/` inside each worktree, so each one recompiles the ripgrep dependency tree and keeps its own copy (~8s release, ~5s more for clippy, up to 1.2 GB). Sharing that is one line in a shell profile — `CARGO_TARGET_DIR` takes a new worktree's build from **10.17s to 0.37s** — and it is documented in CONTRIBUTING.md rather than configured here.

An earlier version of this change generated a gitignored `.cargo/config.toml` pointing `build.target-dir` at a directory shared by every worktree. It worked and was measured, and it was dropped after checking what comparable JS+Rust projects do:

| Project | Rust build cache | JS task cache | `.cargo/config.toml` |
|---|---|---|---|
| oxc | `Swatinem/rust-cache` + Namespace remote cache | none | committed — rustflags, linker |
| biome | `moonrepo/setup-rust` | none | — |
| swc | none; `CARGO_INCREMENTAL: 0` | none | — |
| rspack | — | none | committed — rustflags, clippy lints |
| rolldown | — | none | committed — rustflags, target features |

All of them commit `.cargo/config.toml` for machine-agnostic settings; **none** set `build.target-dir` or `rustc-wrapper`. Nobody unifies the JS and Rust caches, and all the investment goes into CI actions keyed on the *default* `target/`. The generated file was also carrying a gitignore entry, a proposed `postinstall` hook, a `CI` guard on that hook so it could not orphan `Swatinem/rust-cache`, and a clobber check — all to distribute one machine-specific path.

## A fix that came out of testing

`pnpm verify:pack` needs `pnpm build` first — it inspects the tarballs, and `packages/netgrep/dist/` has to exist. It passed locally only because `dist/` was already there; on a fresh clone it failed with `tarball is missing dist/index.d.ts`. The documented sequence now matches CI's order, and AGENTS.md §4 marks the prerequisite.

## Testing

Verified in a disposable clone with these changes committed, so the full `pnpm worktree` chain could actually run:

- fresh clone → `pnpm bootstrap` → **17s** to a working checkout
- `lint`, `typecheck`, `build`, `test` (24/24), `verify:pack` — all pass
- `pnpm worktree fix/chunk-boundary` → branch created, `/`→`-` in the directory name, placed beside the clone, bootstrapped; 24/24 tests and a clean typecheck inside it
- `CARGO_TARGET_DIR` sharing reproduced: 0.37s vs 10.17s
- example bundle builds against the local workspace WASM

`pnpm test:wasm` fails locally with `driver status: signal: 9 (SIGKILL)` — the known ChromeDriver-versus-Chrome mismatch in AGENTS.md §4 and BACKLOG item 2. Pre-existing and environmental; nothing here touches the Rust test path. CI is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)