### PR TITLE
test: run the browser suite under Playwright, delete the ChromeDriver harness

### DIFF
--- a/.claude/skills/wasm-release/SKILL.md
+++ b/.claude/skills/wasm-release/SKILL.md
@@ -50,8 +50,8 @@ pnpm build:wasm        # must run first: the TS package compiles against pkg/ind
 pnpm lint              # Biome + clippy
 pnpm typecheck
 pnpm build
-pnpm test              # 24 tests
-pnpm test:wasm         # 2 tests
+pnpm test              # 24 tests: 7 in Node, 17 in headless Chromium
+pnpm test:rust         # 2 tests, native cargo test
 pnpm verify:pack       # the tarballs that would actually reach npm
 ```
 
@@ -59,10 +59,11 @@ pnpm verify:pack       # the tarballs that would actually reach npm
 Everything above it inspects the working tree, which is how `@netgrep/search` once published a tarball
 containing no WASM at all. Never hand over a release without it passing.
 
-`pnpm test:wasm` fails on a fresh machine — `wasm-pack` fetches the latest ChromeDriver, which cannot drive
-an older installed Chrome (`invalid session id`, driver killed with signal 9). It also **overrides**
-`CHROMEDRIVER`, so exporting it and re-running `wasm-pack` changes nothing; invoke the harness directly. See
-[`docs/BACKLOG.md`](../../../docs/BACKLOG.md) item 2 for the exact commands.
+`pnpm test` needs Playwright's Chromium (`pnpm exec playwright install chromium`, ~180 MB, once per machine).
+It is pinned to the `playwright` version in the lockfile, so it cannot drift from its driver the way the old
+ChromeDriver setup did. That half of the suite is the one that loads `pkg/` through the real fetch-based
+`init()`, so it is also the closest thing to a release rehearsal short of `verify:pack`. See
+[decision 0013](../../../docs/decisions/0013-playwright-for-browser-tests.md).
 
 The example app now runs against **local workspace source**, so `pnpm dev` is a legitimate manual smoke
 test. It is still not automated and does not run in CI, so it never substitutes for the targets above.

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -37,18 +37,12 @@ jobs:
         with:
           version: 'v0.13.1'
 
-      # NOTE: ChromeDriver is deliberately NOT pinned here.
-      #
-      # Pinning it via browser-actions/setup-chrome was tried and reverted: it
-      # installs a driver into the tool cache, but the browser ChromeDriver
-      # actually launches is the runner's system Chrome, so pinning one half of
-      # the pair CREATES the version mismatch it was meant to prevent
-      # (ChromeDriver 151 vs the system browser -> SIGKILL).
-      #
-      # Letting `wasm-pack` manage the driver keeps both halves current
-      # together. docs/BACKLOG.md item 2 is a local-machine problem, where the
-      # installed Chrome is older than the driver wasm-pack fetches; CI does
-      # not have that problem.
+      # The browser `pnpm test` runs in is Playwright's own Chromium, pinned to
+      # the `playwright` version in the lockfile. Nothing here depends on the
+      # runner's system Chrome, so the browser and the thing driving it cannot
+      # drift apart — which is exactly what ChromeDriver used to do. Only
+      # chromium is downloaded; firefox and webkit are not used.
+      - run: pnpm exec playwright install --with-deps chromium
 
       # The WASM build comes first: `@netgrep/netgrep` resolves
       # `@netgrep/search` to this workspace, so typecheck, build and the
@@ -59,7 +53,7 @@ jobs:
       - run: pnpm typecheck
       - run: pnpm build
       - run: pnpm test
-      - run: pnpm test:wasm
+      - run: pnpm test:rust
 
       # Everything above inspects the working tree. This inspects the tarballs
       # that would actually reach npm — the only artefact users ever see, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ place only.
 | pnpm | **11.17.0** | `packageManager` in root `package.json` (via corepack) |
 | Rust | **1.97.1** | `rust-toolchain.toml`, with `wasm32-unknown-unknown` + clippy |
 | wasm-pack | 0.13.1 | CI action; install locally with `cargo install wasm-pack` |
+| Playwright | 1.62.0 | root `package.json` + lockfile; the browser it downloads is pinned to it — see §4.2 |
 
 The Rust pin is deliberate, not incidental. `rust-toolchain.toml` used to say `channel = "stable"`, which
 meant an unrelated Rust release broke the build with no commit to point at (1.82 changed the wasm C ABI).
@@ -112,8 +113,8 @@ pnpm build:wasm        # REQUIRED FIRST — see §2.2
 | Lint | `pnpm lint` | Biome (JS/TS) **and** clippy (`-D warnings`) |
 | Format | `pnpm format` | Biome, writes in place |
 | Typecheck | `pnpm typecheck` | `tsc --noEmit`, TypeScript 7 |
-| Test TS | `pnpm test` | Vitest — **24 tests** (7 unit, 17 integration) |
-| Test Rust | `pnpm test:wasm` | wasm-bindgen in headless Chrome — **2 tests** |
+| Test TS | `pnpm test` | Vitest — **24 tests**: 7 unit in Node, 17 integration in headless Chromium |
+| Test Rust | `pnpm test:rust` | `cargo test`, native, no browser — **2 tests** |
 | Verify packaging | `pnpm verify:pack` | Packs both packages and inspects the tarballs. **Needs `pnpm build` first** |
 | Run the example | `pnpm dev` | Demo, not a test — see §6.3 |
 
@@ -126,12 +127,12 @@ pnpm worktree fix/chunk-boundary     # → ../netgrep-fix-chunk-boundary, ready 
 Creates the branch if it does not exist, places the worktree **beside** this checkout (never inside it — a
 nested checkout would be picked up by the workspace glob, Biome and Vitest alike), and bootstraps it.
 
-`pnpm bootstrap` inside an existing worktree does the same preparation. Both accept `--no-install` and
-`--no-build` to skip a step.
+`pnpm bootstrap` inside an existing worktree does the same preparation. Both accept `--no-install`,
+`--no-build` and `--no-browser` to skip a step.
 
 **The repository configures no build cache, on purpose.** Cargo keeps `target/` inside each worktree, so each
-one recompiles the ripgrep dependency tree and keeps its own copy (~8s release, ~5s more for clippy, up to
-1.2 GB). Sharing that is a line in the developer's shell profile, not a file in this repo:
+one recompiles the ripgrep dependency tree and keeps its own copy (~8s release, ~5s more for clippy, hundreds
+of MB). Sharing that is a line in the developer's shell profile, not a file in this repo:
 
 ```bash
 export CARGO_TARGET_DIR="$HOME/.cache/cargo-shared"
@@ -147,13 +148,21 @@ Do not commit this as `build.target-dir`: it is an absolute path, and CI's cachi
 that was built first, measured, and dropped — and what comparable JS+Rust repositories do instead.
 [`CONTRIBUTING.md`](CONTRIBUTING.md) is the human-facing version of this section.
 
-### `pnpm test:wasm` may fail on your machine
+### 4.2 The browser the tests run in
 
-`wasm-pack` downloads the *latest* ChromeDriver, which cannot drive an older installed Chrome
-(`invalid session id`, driver killed with signal 9). CI is unaffected — its Chrome and driver move together.
+`pnpm test` runs the integration suite in **Playwright's own Chromium**, pinned to the `playwright` version in
+the lockfile. `pnpm bootstrap` installs it; on its own that is:
 
-It also **overrides** `CHROMEDRIVER`, so exporting it and re-running `wasm-pack` changes nothing. Invoke the
-harness directly; see [`docs/BACKLOG.md`](docs/BACKLOG.md) item 2 for the exact commands.
+```bash
+pnpm exec playwright install chromium     # ~180 MB, once per machine
+```
+
+It lands in a shared per-user cache, not in the checkout, so worktrees share one copy.
+
+Nothing depends on the Chrome installed on your machine. This replaced `wasm-pack test --chrome --headless`,
+which downloaded the newest ChromeDriver, could not drive an older local Chrome, and **overrode**
+`CHROMEDRIVER` so the mismatch was not fixable by hand. That whole failure mode is gone — browser and driver
+now ship as one pinned unit. See [decision 0013](docs/decisions/0013-playwright-for-browser-tests.md).
 
 ---
 
@@ -165,7 +174,7 @@ Three packages, ~450 lines of first-party source. pnpm workspaces link them; the
 packages/
   search/            Rust → WASM core. The actual search engine.
     src/lib.rs         ~45 lines. Exports one function: search_bytes(&[u8], &str) -> bool
-    tests/search.rs    wasm-bindgen tests, run in headless Chrome
+    tests/search.rs    plain native `cargo test` — no browser, no WebDriver
     scripts/post_build.js   fixes up the generated pkg/ (see below)
     package.json       hand-written wrapper; THIS is what gets published
     pkg/               BUILD OUTPUT, gitignored
@@ -175,7 +184,8 @@ packages/
     src/lib/Netgrep.ts               the whole public API (~225 lines)
     src/lib/data/*.ts                5 type definitions, one per file
     src/lib/Netgrep.spec.ts          unit suite; mocks fetch and the engine
-    src/lib/Netgrep.integration.spec.ts   real WASM through the real streaming loop
+    src/lib/Netgrep.integration.spec.ts   real WASM through the real streaming loop,
+                                          in headless Chromium (§4.2)
     dist/              BUILD OUTPUT, gitignored
     → published as @netgrep/netgrep
 
@@ -189,8 +199,8 @@ scripts/worktree.mjs      `git worktree add` + bootstrap, in one command.
 
 Root config: `pnpm-workspace.yaml`, `Cargo.toml` (Rust workspace **and** the release profile — Cargo ignores
 `[profile.*]` in member packages), `tsconfig.base.json`, `biome.jsonc`, `vitest.config.ts`,
-`rust-toolchain.toml`, `.node-version`, `.github/workflows/`. There is deliberately **no `.cargo/config.toml`**
-— see §4.1.
+`vitest.global-setup.ts` (the "run `pnpm build:wasm`" guard for the browser project), `rust-toolchain.toml`,
+`.node-version`, `.github/workflows/`. There is deliberately **no `.cargo/config.toml`** — see §4.1.
 
 ### Two things about `packages/search` that surprise people
 
@@ -232,7 +242,7 @@ manifests cannot drift, and **deletes the `.gitignore` wasm-pack writes into `pk
 
 3. **The example is a demo.** It now runs against local workspace source, so it is a legitimate manual smoke
    test — but it is not automated and does not run in CI. Correctness is established by `pnpm test`,
-   `pnpm test:wasm` and `pnpm verify:pack`.
+   `pnpm test:rust` and `pnpm verify:pack`.
 
 4. **Do not commit build outputs or lockfile churn.** `packages/netgrep/dist/` and `packages/search/pkg/` are
    gitignored. If a command rewrites a lockfile as a side effect of something unrelated, revert it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,8 @@ most common way to lose an hour here.
 All from the repository root. [AGENTS.md §4](AGENTS.md#4-commands) has the full list and the caveats.
 
 ```bash
-pnpm test          # Vitest — 24 tests
+pnpm test          # Vitest — 24 tests (7 in Node, 17 in headless Chromium)
+pnpm test:rust     # cargo test — 2 tests, native, no browser
 pnpm typecheck     # tsc --noEmit
 pnpm lint          # Biome (JS/TS) and clippy (-D warnings)
 pnpm format        # Biome, writes in place
@@ -45,9 +46,16 @@ pnpm build:wasm    # rebuild after any change to packages/search
 pnpm dev           # the Sherlock Holmes demo — a manual smoke test, not a test
 ```
 
-`pnpm test:wasm` runs the Rust tests in headless Chrome and **may fail on your machine** through no fault of
-your change: wasm-pack downloads the newest ChromeDriver, which cannot drive an older installed Chrome. CI is
-unaffected. See [`docs/BACKLOG.md`](docs/BACKLOG.md) item 2.
+The integration half of `pnpm test` drives the real WASM engine in a real browser, so it needs Playwright's
+Chromium. `pnpm bootstrap` installs it; on its own it is:
+
+```bash
+pnpm exec playwright install chromium     # ~180 MB, once per machine
+```
+
+It is pinned to the `playwright` version in the lockfile and is unrelated to the Chrome you have installed,
+so it cannot fall out of step with its driver. That used to be this repository's most annoying local failure
+— see [decision 0013](docs/decisions/0013-playwright-for-browser-tests.md).
 
 ## Working on several branches at once
 
@@ -57,14 +65,16 @@ pnpm worktree fix/chunk-boundary
 
 Creates the branch if it does not exist, adds a git worktree **beside** this checkout (never inside it — a
 nested checkout would be picked up by the pnpm workspace glob, Biome and Vitest alike), and bootstraps it.
-`pnpm bootstrap` inside an existing worktree does the same preparation. Both take `--no-install` and
-`--no-build`.
+`pnpm bootstrap` inside an existing worktree does the same preparation. Both take `--no-install`,
+`--no-build` and `--no-browser`.
 
 ### Sharing a build cache
 
 Cargo keeps its `target/` **inside each worktree**, so every worktree compiles the ripgrep dependency tree
 again and keeps its own copy — measured here at ~8s for the release profile, ~5s more for clippy's dev
-profile, and a directory that reaches 1.2 GB once the `wasm-pack test` artefacts land in it.
+profile, and a directory that runs to hundreds of megabytes per worktree. (It used to reach 1.2 GB, when
+`wasm-pack test` dropped a browser-test toolchain in there too; see
+[decision 0013](docs/decisions/0013-playwright-for-browser-tests.md).)
 
 If you keep more than one worktree around, share one cache by exporting a variable from your shell profile:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,23 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.3",
-]
-
-[[package]]
-name = "autocfg"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
 name = "bstr"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,22 +27,6 @@ name = "bumpalo"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
-
-[[package]]
-name = "cast"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
-name = "cc"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
-dependencies = [
- "find-msvc-tools",
- "shlex",
-]
 
 [[package]]
 name = "cfg-if"
@@ -83,36 +50,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
 dependencies = [
  "encoding_rs",
-]
-
-[[package]]
-name = "find-msvc-tools"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "futures-core"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
-
-[[package]]
-name = "futures-task"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
-
-[[package]]
-name = "futures-util"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
-dependencies = [
- "futures-core",
- "futures-task",
- "pin-project-lite",
- "slab",
 ]
 
 [[package]]
@@ -153,33 +90,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
-
-[[package]]
-name = "js-sys"
-version = "0.3.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
-dependencies = [
- "cfg-if",
- "futures-util",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "log"
@@ -203,51 +117,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "minicov"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
-dependencies = [
- "cc",
- "walkdir",
-]
-
-[[package]]
-name = "nu-ansi-term"
-version = "0.50.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
- "libm",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
-
-[[package]]
-name = "oorandom"
-version = "11.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "proc-macro2"
@@ -291,21 +164,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
-name = "ryu"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "search"
 version = "0.2.0"
 dependencies = [
@@ -313,17 +171,6 @@ dependencies = [
  "grep-regex",
  "grep-searcher",
  "wasm-bindgen",
- "wasm-bindgen-test",
-]
-
-[[package]]
-name = "serde"
-version = "1.0.229"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
-dependencies = [
- "serde_core",
- "serde_derive",
 ]
 
 [[package]]
@@ -345,29 +192,6 @@ dependencies = [
  "quote",
  "syn 3.0.3",
 ]
-
-[[package]]
-name = "serde_json"
-version = "1.0.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "shlex"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
-
-[[package]]
-name = "slab"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "syn"
@@ -398,16 +222,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,16 +232,6 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -460,89 +264,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-bindgen-test"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0d555ca874445df8d314f94f5c948a4e74e5418f332c89f660a3d8310a96f4"
-dependencies = [
- "async-trait",
- "cast",
- "js-sys",
- "libm",
- "minicov",
- "nu-ansi-term",
- "num-traits",
- "oorandom",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-bindgen-test-macro",
- "wasm-bindgen-test-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-test-macro"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94eb68555b95bcea5e8cf4abe280b529049479fa995bfc23734af96a6aedc120"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "wasm-bindgen-test-shared"
-version = "0.2.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31d56021e873866c968588ed85ccdf56db5c426e44afdb4618c39895104b920"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
 ]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -242,7 +242,7 @@ that only webpack supported, and that failed *silently* under Vite — see
 
 | Workflow | Trigger | Action |
 |---|---|---|
-| `test-and-lint.yml` | push/PR to `main`, or called | `build:wasm` → `lint` → `typecheck` → `build` → `test` → `test:wasm` → `verify:pack` |
+| `test-and-lint.yml` | push/PR to `main`, or called | `playwright install chromium` → `build:wasm` → `lint` → `typecheck` → `build` → `test` → `test:rust` → `verify:pack` |
 | `publish-search.yml` | tag `search-**` | test-and-lint → `build:wasm` → npm publish `packages/search/package.json` |
 | `publish-netgrep.yml` | tag `netgrep-**` | test-and-lint → `build:wasm` → `build` → npm publish `packages/netgrep/package.json` |
 
@@ -261,14 +261,19 @@ so local and CI cannot drift the way they once did.
 
 | Suite | Runner | What it covers |
 |---|---|---|
-| `Netgrep.spec.ts` | Vitest, 7 tests | Orchestration only — `fetch` **and** `@netgrep/search` are mocked. Result shape, error capture, and that a cache hit avoids a second `fetch`. |
-| `Netgrep.integration.spec.ts` | Vitest, 17 tests | **The real engine through the real streaming loop.** Only `fetch` is faked, and only to remove the network: bytes still travel through a real `ReadableStream`, still arrive chunked, still get matched by the compiled `search_bytes`. |
-| `packages/search/tests/search.rs` | `wasm-bindgen-test` in headless Chrome, 2 tests | The engine in a real browser. |
+| `Netgrep.spec.ts` | Vitest in **Node**, 7 tests | Orchestration only — `fetch` **and** `@netgrep/search` are mocked. Result shape, error capture, and that a cache hit avoids a second `fetch`. |
+| `Netgrep.integration.spec.ts` | Vitest in **headless Chromium** (Playwright), 17 tests | **The real engine through the real streaming loop, in a real browser.** Only `fetch` is faked, and only to remove the network: bytes still travel through a real `ReadableStream`, still arrive chunked, still get matched by the compiled `search_bytes`. |
+| `packages/search/tests/search.rs` | `cargo test`, native, 2 tests | `search_bytes` as pure Rust — bytes in, bool out. No browser involved. |
 | `scripts/verify-pack.mjs` | Node, in CI | The published tarballs: required files present, no `workspace:` range survived packing, no version drift. |
 
-The integration suite loads **the artefact that actually ships** (`packages/search/pkg`), handing the bytes to
-`initSync` because `import.meta.url` has no meaning under Node. There is no separate Node-target build to
-drift from what consumers receive.
+The integration suite loads **the artefact that actually ships** (`packages/search/pkg`) and instantiates it
+through its own real, fetch-based `init()` — the same loader a consumer gets, resolving `index_bg.wasm`
+relative to `import.meta.url` over HTTP. There is no separate Node-target build to drift from what consumers
+receive, and no `initSync`-from-disk accommodation either: that was a Node limitation, and the loader it hid
+is precisely the part that failed silently under Vite in [decision 0005](decisions/0005-esm-only-distribution.md).
+
+Why a browser at all, and why Playwright rather than ChromeDriver:
+[decision 0013](decisions/0013-playwright-for-browser-tests.md).
 
 Its last block deliberately asserts **incorrect** behaviour, pinning the caveats above so that an unintended
 change is caught. Read

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -72,32 +72,6 @@ distinction — which is an API change and therefore out of scope today.
 
 ## P2 — Health
 
-### 2. `pnpm test:wasm` fails on a fresh machine
-
-`wasm-pack test --chrome --headless` downloads the *latest* ChromeDriver, which cannot drive an older
-installed Chrome. Observed: ChromeDriver 151 vs Chrome 150 → `invalid session id`, driver killed (signal 9).
-
-**This is a local-machine problem only.** CI's Chrome and driver move together.
-
-*Do not try to pin it in CI.* That was attempted with `browser-actions/setup-chrome` and reverted: the action
-installs a driver into the tool cache, but the browser ChromeDriver actually launches is the runner's
-*system* Chrome, so pinning one half of the pair creates the very mismatch it was meant to prevent.
-
-Locally, note that `wasm-pack` **overrides** `CHROMEDRIVER` with its own cached copy, so exporting it and
-running `wasm-pack test` does nothing. Invoke the harness directly:
-
-```bash
-cd packages/search
-export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=~/Library/Caches/.wasm-pack/wasm-bindgen-<hash>/wasm-bindgen-test-runner
-export CHROMEDRIVER=/path/to/matching/chromedriver   # from Chrome for Testing
-export WASM_BINDGEN_TEST_ONLY_WEB=1
-cargo test --target wasm32-unknown-unknown
-```
-
-The runner must match the `wasm-bindgen` version in `Cargo.toml`; a stale cached one fails with
-`panicked at 'remaining data [...]', crates/cli-support/src/descriptor.rs`. Running `wasm-pack test` once
-downloads the right one into the cache.
-
 ### 14. The `.wasm` is ~1.15 MB, up 10.6% from the 2022 build
 
 1,038,608 → 1,148,922 bytes. Accounted for (all measured 2026-07-28, release builds through `wasm-pack`):
@@ -156,6 +130,7 @@ analysis was wrong.
 
 | # | Item | Outcome |
 |---|---|---|
+| 2 | `pnpm test:wasm` fails on a fresh machine | **Fixed by removing the harness.** ChromeDriver was versioned independently of the browser it drove, by a mechanism this repo did not control, so the mismatch was structural. Playwright now runs the browser tests with a Chromium pinned to its own package version, the Rust tests became a native `cargo test` (`pnpm test:rust`), and browser coverage went *up* — 2 assertions about pure byte logic replaced by the 17-test integration suite, which now also exercises the fetch-based loader. See [0013](decisions/0013-playwright-for-browser-tests.md). |
 | 16 | Published package did not work under Vite | **Fixed.** Shipped wasm-pack's `web` target; the `bundler` target failed *silently* under Vite, returning `false` for every search. Verified in real Chrome against Vite (no plugins), webpack (no config), and a fresh app installed from the actual tarballs. See [0005](decisions/0005-esm-only-distribution.md). |
 | 10 | Root depended on its own published packages | **Fixed** by pnpm workspaces. The example now bundles local source. This was the repository's headline gotcha. See [0009](decisions/0009-pnpm-workspaces.md). |
 | 9 | `@netgrep/search` version drift unenforced | **Fixed.** `workspace:*` plus `post_build.js` copying the version from `Cargo.toml`; `verify:pack` asserts it. |

--- a/docs/decisions/0012-worktree-bootstrap.md
+++ b/docs/decisions/0012-worktree-bootstrap.md
@@ -25,6 +25,11 @@ directory that reaches 1.2 GB once `wasm-pack test` artefacts land in it — per
 **`pnpm bootstrap`** prepares a checkout: `pnpm install --frozen-lockfile`, then `pnpm build:wasm`. It is
 idempotent. **`pnpm worktree <branch>`** adds a worktree beside the main checkout and bootstraps it.
 
+> **Amended (2026-07-29):** bootstrap also runs `pnpm exec playwright install chromium`, since the
+> integration suite moved into a real browser — see [0013](0013-playwright-for-browser-tests.md). The browser
+> lives in a shared per-user cache, so unlike `target/` it is not duplicated per worktree, and the third
+> skip flag `--no-browser` was added alongside `--no-install` and `--no-build`.
+
 **The repository configures no build cache.** Sharing Cargo artefacts across worktrees is a one-line
 environment variable in the developer's shell (`CARGO_TARGET_DIR`, or `RUSTC_WRAPPER=sccache`), documented in
 [`CONTRIBUTING.md`](../../CONTRIBUTING.md). `bootstrap.mjs` reports what it finds and suggests the variable

--- a/docs/decisions/0013-playwright-for-browser-tests.md
+++ b/docs/decisions/0013-playwright-for-browser-tests.md
@@ -1,0 +1,82 @@
+# 0013 — Playwright runs the browser tests; ChromeDriver is gone
+
+**Status:** Accepted (2026-07-29).
+
+## Context
+
+netgrep shipped two kinds of test, and the split between them was upside down.
+
+| | Ran in | Covered |
+|---|---|---|
+| `packages/search/tests/search.rs` (2 tests) | headless Chrome, via `wasm-pack test` → ChromeDriver | `search_bytes` — pure bytes in, bool out |
+| `packages/netgrep/src/**/*.spec.ts` (24 tests) | Node | the streaming loop, batching, caching, and the real engine |
+
+So the only thing that reached a real browser was the part with nothing browser-specific about it, while the
+part that is *only* ever used in a browser was tested where browsers do not exist.
+
+**The browser harness was also broken on contributors' machines.** `wasm-pack test --chrome --headless`
+downloads the *latest* ChromeDriver, which cannot drive an older installed Chrome — observed here as
+ChromeDriver 151 against Chrome 150, `invalid session id`, driver killed with signal 9. It further
+**overrides** `CHROMEDRIVER`, so exporting a matching driver and re-running changed nothing; the documented
+workaround was to bypass `wasm-pack` and invoke the test runner by hand with three environment variables
+(former `docs/BACKLOG.md` item 2).
+
+Pinning the pair in CI was tried and reverted. `browser-actions/setup-chrome` installs a driver into the tool
+cache, but the browser ChromeDriver actually launches is the runner's *system* Chrome — pinning one half
+creates the very mismatch it was meant to prevent.
+
+The failure is structural: **the browser and the thing driving it were versioned independently**, by two
+different mechanisms, neither pinned by this repository.
+
+Meanwhile the integration suite could not test the loader at all. `pkg/`'s real `init()` fetches
+`index_bg.wasm` over HTTP relative to `import.meta.url`, which has no meaning under Node, so the suite read
+the bytes off disk and called `initSync`. The loader is not a hypothetical risk: under
+[0005](0005-esm-only-distribution.md) the `bundler` target failed *silently* under Vite and every search
+returned `false`.
+
+## Decision
+
+**Playwright drives a real browser; ChromeDriver and `wasm-pack test` are removed.**
+
+`vitest.config.ts` declares two projects:
+
+| Project | Environment | Suite |
+|---|---|---|
+| `unit` | Node | `Netgrep.spec.ts` — mocks `fetch` *and* the engine, so a browser would add nothing |
+| `browser` | Playwright Chromium, headless | `Netgrep.integration.spec.ts` — the real WASM, the real streaming loop |
+
+Playwright downloads a Chromium pinned to its own package version, which is pinned in the lockfile. Browser
+and driver ship as one unit and cannot drift — locally or in CI. CI gains one step,
+`pnpm exec playwright install --with-deps chromium`, and loses the ChromeDriver caveat entirely.
+
+**The Rust tests became native.** `tests/search.rs` dropped `run_in_browser` and `wasm-bindgen-test` and is
+now a plain `cargo test` (`pnpm test:rust`, formerly `pnpm test:wasm`). It needs no browser, and runs in
+milliseconds.
+
+**The integration suite now instantiates through the real, fetch-based `init()`.** The `initSync`-from-disk
+accommodation is gone — the suite loads the published artefact the way a consumer does.
+
+## Consequences
+
+**Good:**
+- `pnpm test` works on a fresh machine. The version mismatch it used to hit is now unrepresentable.
+- Browser coverage went up, not down: 2 assertions about pure byte logic were replaced by 17 tests driving
+  the real engine through the real streaming loop — including the loader, which nothing previously exercised.
+- One fewer toolchain in the test path. No ChromeDriver, no `wasm-bindgen-test`, no `WASM_BINDGEN_TEST_ONLY_WEB`.
+- The Rust tests got faster and can run with no network and no browser at all.
+
+**Costs:**
+- A ~180 MB Chromium download on first run, and two new devDependencies (`@vitest/browser-playwright`,
+  `playwright`). CI pays the download on every run; it is not cached.
+- `pnpm test` now boots a browser, so it is slower than an all-Node run — a few seconds.
+- Nothing runs `wasm-bindgen`-generated glue under a *non*-Chromium engine. That was already true; ChromeDriver
+  was Chrome-only too. Playwright makes firefox and webkit a config line if that ever matters.
+- `optimizeDeps.exclude: ['@netgrep/search']` is load-bearing in the browser project. Vite's pre-bundling
+  would rewrite the module into `.vite/deps/`, and the loader resolves the binary relative to its own module
+  URL — a moved module fetches the `.wasm` from a directory that has none.
+- A missing `pkg/` fails during Vite's transform, before any test module or `vi.mock` factory is evaluated, so
+  the actionable "run `pnpm build:wasm`" message lives in `vitest.global-setup.ts` rather than in the test.
+
+**Deliberately not done:** moving the unit suite into the browser. It mocks the engine and `fetch`, so a
+browser buys it nothing but startup time. Keeping it in Node also preserves the documented property that unit
+tests pass on a checkout that has never run `pnpm build:wasm` (`AGENTS.md` §2.2).

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -25,6 +25,7 @@ reasoning got wrong.
 | [0010](0010-vitest-and-biome.md) | Vitest and Biome replace jest, ts-jest, ESLint and Prettier | Accepted |
 | [0011](0011-tests-that-assert-known-bugs.md) | Tests that deliberately assert incorrect behaviour | Accepted |
 | [0012](0012-worktree-bootstrap.md) | A bootstrap script, and no build-cache configuration in the repository | Accepted |
+| [0013](0013-playwright-for-browser-tests.md) | Playwright runs the browser tests; ChromeDriver is gone | Accepted |
 
 ## Format
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "pnpm --filter @netgrep/netgrep build",
     "build:wasm": "pnpm --filter @netgrep/search build",
     "test": "vitest run",
-    "test:wasm": "pnpm --filter @netgrep/search test",
+    "test:rust": "pnpm --filter @netgrep/search test",
     "verify:pack": "node scripts/verify-pack.mjs",
     "lint": "biome check . && pnpm --filter @netgrep/search lint",
     "format": "biome check --write .",
@@ -24,6 +24,8 @@
   "devDependencies": {
     "@biomejs/biome": "2.5.6",
     "@types/node": "^26.1.2",
+    "@vitest/browser-playwright": "4.1.10",
+    "playwright": "1.62.0",
     "typescript": "7.0.2",
     "vitest": "4.1.10"
   }

--- a/packages/netgrep/src/lib/Netgrep.integration.spec.ts
+++ b/packages/netgrep/src/lib/Netgrep.integration.spec.ts
@@ -1,4 +1,3 @@
-import { ReadableStream } from 'node:stream/web';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Netgrep } from './Netgrep.js';
 
@@ -25,48 +24,34 @@ import { Netgrep } from './Netgrep.js';
  * always what it should do. The `documented defects` block at the bottom pins
  * known-wrong behaviour on purpose. See the comment there before "fixing" it.
  *
- * IT RUNS THE ARTEFACT THAT SHIPS
- * -------------------------------
- * `pkg/` is exactly what gets published — wasm-pack's `web` target. The only
- * accommodation is instantiation: the real `init()` fetches the `.wasm` over
- * HTTP relative to `import.meta.url`, which has no meaning under Node, so the
- * bytes are handed to `initSync` from disk instead. Same module, same binary,
- * same marshalling glue; only the loader differs.
+ * IT RUNS THE ARTEFACT THAT SHIPS, THE WAY IT SHIPS
+ * -------------------------------------------------
+ * This suite runs in a real headless Chromium (see `vitest.config.ts`), so
+ * there is no longer any accommodation at all: `pkg/` is exactly what gets
+ * published — wasm-pack's `web` target — and it is instantiated by its own
+ * real `init()`, which fetches `index_bg.wasm` over HTTP relative to
+ * `import.meta.url`. Same module, same binary, same marshalling glue, same
+ * loader a consumer gets.
  *
- * This used to load a separate `--target nodejs` build. That build no longer
- * exists — the test is now one step closer to what consumers actually get.
+ * Under Node this was impossible: `import.meta.url` has no HTTP meaning there,
+ * so the bytes had to be read off disk and handed to `initSync`, leaving the
+ * loader — the part that has actually broken before, see decision 0005 — the
+ * one thing nothing exercised.
  *
  * Build it with: pnpm build:wasm
  */
-vi.mock('@netgrep/search', async () => {
-  const { existsSync, readFileSync } = await import('node:fs');
-  const { dirname, resolve } = await import('node:path');
-  const { fileURLToPath } = await import('node:url');
+vi.mock('@netgrep/search', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@netgrep/search')>();
 
-  const here = dirname(fileURLToPath(import.meta.url));
-  const pkg = resolve(here, '../../../search/pkg');
-  const wasmPath = resolve(pkg, 'index_bg.wasm');
+  // Instantiate through the REAL, fetch-based `init()` — the point of running
+  // in a browser. It happens here, at mock-factory time, because the factory
+  // runs while `Netgrep.ts` is being imported, which is before this file's
+  // body replaces `globalThis.fetch` with a spy. Doing it any later would send
+  // the engine's own `.wasm` request into the spy.
+  await mod.default();
 
-  if (!existsSync(wasmPath)) {
-    throw new Error(
-      [
-        '',
-        'The WASM build is missing, so the integration tests cannot run',
-        'against the real engine.',
-        '',
-        'Build it with:  pnpm build:wasm',
-        '',
-        `Expected at: ${wasmPath}`,
-        '',
-      ].join('\n'),
-    );
-  }
-
-  const mod = await import(resolve(pkg, 'index.js'));
-  mod.initSync({ module: readFileSync(wasmPath) });
-
-  // `default` is the real `init()`; it is already instantiated, so awaiting it
-  // must be a no-op rather than a second (fetch-based) instantiation.
+  // Already instantiated, so `Netgrep.ts`'s module-level `init()` must be a
+  // no-op rather than a second instantiation.
   return { ...mod, default: () => Promise.resolve() };
 });
 
@@ -141,7 +126,7 @@ function bytes(...parts: Array<string | number>): Uint8Array {
 }
 
 const mockFetch = vi.fn();
-global.fetch = mockFetch;
+globalThis.fetch = mockFetch;
 
 /**
  * Serve the given chunks for any URL, and expose the read counter.

--- a/packages/search/Cargo.toml
+++ b/packages/search/Cargo.toml
@@ -36,8 +36,10 @@ grep-regex = "0.1.14"
 # exactly the fork this PR is deleting. Left alone on purpose.
 grep-searcher = "0.1.17"
 
-[dev-dependencies]
-wasm-bindgen-test = "0.3.76"
+# NOTE: there are deliberately no [dev-dependencies]. `tests/search.rs` used to
+# need `wasm-bindgen-test` to run in a browser through wasm-pack/ChromeDriver;
+# it is now a plain native `cargo test`, and the browser is covered by the
+# TypeScript integration suite under Playwright. See docs/decisions/0013.
 
 # NOTE: profile settings live in the WORKSPACE ROOT Cargo.toml. Cargo ignores
 # `[profile.*]` in a member package, so the `lto`/`opt-level` that used to sit

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -16,7 +16,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "wasm-pack build --scope netgrep --out-name index --target web --release && node scripts/post_build.js",
-    "test": "wasm-pack test --chrome --headless",
+    "test": "cargo test -p search",
     "lint": "cargo clippy -p search -- -D warnings --no-deps"
   }
 }

--- a/packages/search/tests/search.rs
+++ b/packages/search/tests/search.rs
@@ -1,34 +1,36 @@
+//! Rust-level tests for the search engine.
+//!
+//! These run NATIVELY, under a plain `cargo test` — no browser, no WebDriver.
+//!
+//! They used to be `wasm-bindgen-test`s with `run_in_browser`, driven by
+//! `wasm-pack test --chrome --headless`. That harness downloaded the newest
+//! ChromeDriver on every run, which could not drive an older locally installed
+//! Chrome, and it overrode `CHROMEDRIVER`, so the mismatch was not fixable by
+//! hand. It cost every contributor a broken command to guard two assertions
+//! about pure byte-in/bool-out logic that has nothing browser-specific in it.
+//!
+//! The browser is still covered, and covered better: the TypeScript
+//! integration suite drives this same compiled engine through the real
+//! streaming loop in a real headless Chromium. See decision 0013.
+
 #[cfg(test)]
 mod search {
-    use wasm_bindgen_test::*;
+    const POEM: &str = "One Wiseman came to Jhaampe-town. \
+                        He set aside both Queen and Crown \
+                        Did his task and fell asleep \
+                        Gave his bones to the stones to keep.";
 
-    wasm_bindgen_test_configure!(run_in_browser);
+    #[test]
+    fn test_search_bytes() {
+        let result = search::search_bytes(POEM.as_bytes(), "set aside");
 
-    #[wasm_bindgen_test]
-    pub fn test_search_bytes() {
-        let text = "One Wiseman came to Jhaampe-town. \
-                    He set aside both Queen and Crown \
-                    Did his task and fell asleep \
-                    Gave his bones to the stones to keep.";
-
-        let bytes = text.as_bytes();
-
-        let result = search::search_bytes(bytes, "set aside");
-
-        assert_eq!(result, true);
+        assert!(result);
     }
 
-    #[wasm_bindgen_test]
-    pub fn test_search_bytes_smart_case() {
-        let text = "One Wiseman came to Jhaampe-town. \
-                    He set aside both Queen and Crown \
-                    Did his task and fell asleep \
-                    Gave his bones to the stones to keep.";
+    #[test]
+    fn test_search_bytes_smart_case() {
+        let result = search::search_bytes(POEM.as_bytes(), "both queen and crown");
 
-        let bytes = text.as_bytes();
-
-        let result = search::search_bytes(bytes, "both queen and crown");
-
-        assert_eq!(result, true);
+        assert!(result);
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,18 @@ importers:
       '@types/node':
         specifier: ^26.1.2
         version: 26.1.2
+      '@vitest/browser-playwright':
+        specifier: 4.1.10
+        version: 4.1.10(playwright@1.62.0)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.0))(vitest@4.1.10)
+      playwright:
+        specifier: 1.62.0
+        version: 1.62.0
       typescript:
         specifier: 7.0.2
         version: 7.0.2
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@types/node@26.1.2)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.0))
+        version: 4.1.10(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.0))
 
   packages/example:
     dependencies:
@@ -109,6 +115,9 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@blazediff/core@1.9.1':
+    resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
   '@discoveryjs/json-ext@0.5.7':
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
@@ -306,6 +315,9 @@ packages:
 
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
   '@rolldown/binding-android-arm64@1.1.5':
     resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
@@ -608,6 +620,17 @@ packages:
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
+
+  '@vitest/browser-playwright@4.1.10':
+    resolution: {integrity: sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==}
+    peerDependencies:
+      playwright: '*'
+      vitest: 4.1.10
+
+  '@vitest/browser@4.1.10':
+    resolution: {integrity: sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==}
+    peerDependencies:
+      vitest: 4.1.10
 
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
@@ -1117,6 +1140,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1504,6 +1532,10 @@ packages:
       uglify-js:
         optional: true
 
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
@@ -1643,6 +1675,20 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  playwright-core@1.62.0:
+    resolution: {integrity: sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.0:
+    resolution: {integrity: sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   postcss@8.5.23:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
@@ -1803,6 +1849,10 @@ packages:
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
+
   sockjs@0.3.24:
     resolution: {integrity: sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==}
 
@@ -1894,6 +1944,10 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -2160,6 +2214,8 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.6':
     optional: true
 
+  '@blazediff/core@1.9.1': {}
+
   '@discoveryjs/json-ext@0.5.7': {}
 
   '@emnapi/core@1.11.1':
@@ -2285,6 +2341,8 @@ snapshots:
     optional: true
 
   '@oxc-project/types@0.139.0': {}
+
+  '@polka/url@1.0.0-next.29': {}
 
   '@rolldown/binding-android-arm64@1.1.5':
     optional: true
@@ -2504,6 +2562,36 @@ snapshots:
 
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
+
+  '@vitest/browser-playwright@4.1.10(playwright@1.62.0)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.0))(vitest@4.1.10)':
+    dependencies:
+      '@vitest/browser': 4.1.10(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.0))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.0))
+      playwright: 1.62.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@4.1.10(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.0))(vitest@4.1.10)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.0))
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.0))
+      ws: 8.21.1
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -3078,6 +3166,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -3397,6 +3488,8 @@ snapshots:
       lightningcss: 1.33.0
       postcss: 8.5.23
 
+  mrmime@2.0.1: {}
+
   ms@2.0.0: {}
 
   ms@2.1.3: {}
@@ -3507,6 +3600,16 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  playwright-core@1.62.0: {}
+
+  playwright@1.62.0:
+    dependencies:
+      playwright-core: 1.62.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  pngjs@7.0.0: {}
 
   postcss@8.5.23:
     dependencies:
@@ -3725,6 +3828,12 @@ snapshots:
 
   signal-exit@3.0.7: {}
 
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   sockjs@0.3.24:
     dependencies:
       faye-websocket: 0.11.4
@@ -3817,6 +3926,8 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  totalist@3.0.1: {}
+
   tslib@2.8.1: {}
 
   type-is@1.6.18:
@@ -3880,7 +3991,7 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.49.0
 
-  vitest@4.1.10(@types/node@26.1.2)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.0)):
+  vitest@4.1.10(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.0))
@@ -3904,6 +4015,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.1.2
+      '@vitest/browser-playwright': 4.1.10(playwright@1.62.0)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.0))(vitest@4.1.10)
     transitivePeerDependencies:
       - msw
 

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -8,6 +8,11 @@
  * integration tests all fail in ways that point anywhere but at a missing WASM
  * build, and the fix is a command you have to already know about.
  *
+ * The third is Playwright's Chromium, which the integration suite runs in.
+ * It lives in a shared per-user cache rather than in the checkout, so it is
+ * usually already there and this step costs nothing; on a new machine it is a
+ * ~180 MB download. It is here so that the closing "try `pnpm test`" is true.
+ *
  * What this script deliberately does NOT do is configure a build cache.
  *
  * An earlier version wrote a `.cargo/config.toml` pointing `build.target-dir`
@@ -24,7 +29,7 @@
  * reports what it found. See CONTRIBUTING.md.
  *
  * Usage:
- *   node scripts/bootstrap.mjs [--no-install] [--no-build]
+ *   node scripts/bootstrap.mjs [--no-install] [--no-build] [--no-browser]
  */
 import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
@@ -32,11 +37,13 @@ import { join } from 'node:path';
 
 const args = new Set(process.argv.slice(2));
 
+const known = new Set(['--no-install', '--no-build', '--no-browser']);
+
 for (const arg of args) {
-  if (arg !== '--no-install' && arg !== '--no-build') {
+  if (!known.has(arg)) {
     console.error(`bootstrap: unknown option ${arg}`);
     console.error(
-      'usage: node scripts/bootstrap.mjs [--no-install] [--no-build]',
+      'usage: node scripts/bootstrap.mjs [--no-install] [--no-build] [--no-browser]',
     );
     process.exit(2);
   }
@@ -88,6 +95,17 @@ if (args.has('--no-install')) {
 } else {
   console.log('\n> pnpm install --frozen-lockfile');
   run('pnpm', ['install', '--frozen-lockfile'], repoRoot);
+}
+
+// Before the --no-build exit: skipping the WASM build is not a reason to skip
+// the browser, and the download is the slow part to get out of the way.
+if (args.has('--no-browser')) {
+  console.log('\nskipping browser download (--no-browser)');
+  console.log('`pnpm test` will fail until you run');
+  console.log('`pnpm exec playwright install chromium` — see AGENTS.md §4.2.');
+} else {
+  console.log('\n> pnpm exec playwright install chromium');
+  run('pnpm', ['exec', 'playwright', 'install', 'chromium'], repoRoot);
 }
 
 if (args.has('--no-build')) {

--- a/scripts/worktree.mjs
+++ b/scripts/worktree.mjs
@@ -12,7 +12,7 @@
  * sources.
  *
  * Usage:
- *   node scripts/worktree.mjs <branch> [path] [--no-install] [--no-build]
+ *   node scripts/worktree.mjs <branch> [path] [--no-install] [--no-build] [--no-browser]
  */
 import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
@@ -25,7 +25,7 @@ const [branch, requestedPath] = positional;
 
 if (!branch) {
   console.error(
-    'usage: pnpm worktree <branch> [path] [--no-install] [--no-build]',
+    'usage: pnpm worktree <branch> [path] [--no-install] [--no-build] [--no-browser]',
   );
   process.exit(2);
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,57 @@
+import { playwright } from '@vitest/browser-playwright';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    // The library targets browsers, but nothing under test needs a DOM: the
-    // suites reach for `fetch` (replaced by a spy) and web streams, both of
-    // which Node provides natively. Dropping jsdom drops a dependency.
-    environment: 'node',
-    include: ['packages/netgrep/src/**/*.spec.ts'],
+    projects: [
+      {
+        // The unit suite mocks `fetch` AND the engine, so it never executes a
+        // line of Rust and never touches a DOM. Node is the right environment
+        // for it: no browser to boot, and everything it reaches for (web
+        // streams, `fetch`) Node provides natively.
+        test: {
+          name: 'unit',
+          environment: 'node',
+          include: ['packages/netgrep/src/**/*.spec.ts'],
+          exclude: ['**/*.integration.spec.ts'],
+        },
+      },
+      {
+        // The integration suite drives the real WASM engine, so it runs in a
+        // real browser — the environment the library actually ships to.
+        //
+        // Playwright downloads a Chromium pinned to its own package version,
+        // so the browser and the thing driving it can never drift apart. That
+        // is why this replaced `wasm-pack test --chrome --headless`, which
+        // fetched the newest ChromeDriver and then could not drive an older
+        // locally installed Chrome. See decision 0013.
+        test: {
+          name: 'browser',
+          include: ['packages/netgrep/src/**/*.integration.spec.ts'],
+          // Turns a missing `pkg/` into "run pnpm build:wasm" rather than an
+          // unresolved-import stack trace. See the file for why it cannot be
+          // a check inside the test itself.
+          globalSetup: ['./vitest.global-setup.ts'],
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: playwright(),
+            instances: [{ browser: 'chromium' }],
+          },
+        },
+        // `@netgrep/search` must reach the browser as the file wasm-pack
+        // emitted it. Vite's dependency pre-bundling would rewrite it into
+        // `.vite/deps/`, and the loader resolves the binary RELATIVE to its
+        // own module URL (`new URL('index_bg.wasm', import.meta.url)`), so a
+        // moved module would fetch the `.wasm` from a directory that has none.
+        //
+        // This is the same class of failure as decision 0005, where the
+        // `bundler` target broke silently under Vite and every search returned
+        // `false`.
+        optimizeDeps: {
+          exclude: ['@netgrep/search'],
+        },
+      },
+    ],
   },
 });

--- a/vitest.global-setup.ts
+++ b/vitest.global-setup.ts
@@ -1,0 +1,41 @@
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Fail the browser project with an actionable message when the WASM has not
+ * been built.
+ *
+ * This check cannot live inside the test file. `packages/search/pkg/` is a
+ * gitignored build output, so on a fresh clone Vite cannot even *resolve*
+ * `@netgrep/search` while transforming `Netgrep.ts` — the run dies before any
+ * test module, and therefore any `vi.mock` factory, is ever evaluated. What a
+ * contributor sees is `Failed to resolve import "@netgrep/search"`, which does
+ * not mention the one command that fixes it.
+ *
+ * `globalSetup` runs in Node, ahead of the browser and ahead of Vite's
+ * transform, which is early enough to say something useful.
+ *
+ * It is deliberately NOT applied to the unit project: that suite mocks the
+ * engine outright and is documented as working on a checkout that has never
+ * run `pnpm build:wasm`. See AGENTS.md §2.2.
+ */
+export function setup() {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const wasmPath = resolve(here, 'packages/search/pkg/index_bg.wasm');
+
+  if (!existsSync(wasmPath)) {
+    throw new Error(
+      [
+        '',
+        'The WASM build is missing, so the integration tests cannot run',
+        'against the real engine.',
+        '',
+        'Build it with:  pnpm build:wasm',
+        '',
+        `Expected at: ${wasmPath}`,
+        '',
+      ].join('\n'),
+    );
+  }
+}


### PR DESCRIPTION
The browser/Node split was upside down.

| | Ran in | Covered |
|---|---|---|
| `packages/search/tests/search.rs` (2 tests) | headless Chrome, via `wasm-pack test` → ChromeDriver | `search_bytes` — pure bytes in, bool out |
| `packages/netgrep/src/**/*.spec.ts` (24 tests) | Node | the streaming loop, batching, caching, the real engine |

The only thing reaching a real browser was the part with nothing browser-specific about it. The part that is *only* ever used in a browser was tested where browsers do not exist — and so could not instantiate `pkg/` the way a consumer does. `init()` resolves `index_bg.wasm` relative to `import.meta.url` over HTTP, which has no meaning under Node, so the suite read the bytes off disk and called `initSync`. **The loader went untested, and the loader is what failed silently under Vite in [decision 0005](docs/decisions/0005-esm-only-distribution.md)** — every search returned `false`.

## The harness was also broken on contributors' machines

PR #14's own testing notes recorded it: `pnpm test:wasm` failing with `driver status: signal: 9 (SIGKILL)`.

`wasm-pack test --chrome --headless` downloads the *latest* ChromeDriver, which cannot drive an older installed Chrome — 151 against 150 here, `invalid session id`. It further **overrides** `CHROMEDRIVER`, so exporting a matching driver and re-running changed nothing; the documented workaround (former BACKLOG item 2) was to bypass `wasm-pack` and invoke the test runner by hand with three environment variables.

Pinning in CI was tried and reverted: `browser-actions/setup-chrome` installs a driver into the tool cache, but the browser ChromeDriver actually launches is the runner's *system* Chrome, so pinning one half creates the very mismatch it was meant to prevent.

The failure is structural. **The browser and the thing driving it were versioned independently, by two mechanisms this repository did not control.**

## What this does

Vitest declares two projects:

| Project | Environment | Suite |
|---|---|---|
| `unit` | Node | `Netgrep.spec.ts` — mocks `fetch` *and* the engine, so a browser buys it nothing but startup time |
| `browser` | Playwright Chromium, headless | `Netgrep.integration.spec.ts` — the real engine, the real streaming loop, the **real fetch-based `init()`** |

Playwright's browser is pinned to its own package version, which is pinned in the lockfile. Browser and driver ship as one unit and cannot drift — locally or in CI.

`tests/search.rs` drops `run_in_browser` and `wasm-bindgen-test` and becomes a plain native `cargo test` — `pnpm test:rust`, formerly `pnpm test:wasm`. No browser, no WebDriver, runs in milliseconds; `Cargo.lock` loses 281 lines.

`pnpm bootstrap` gains the browser download (`--no-browser` to skip), so its closing "try `pnpm test`" stays true on a fresh machine. The browser lives in a shared per-user cache, so unlike `target/` it is not duplicated per worktree.

## Net coverage goes up, not down

Two assertions about pure byte logic were replaced by 17 tests driving the real engine through the real streaming loop — including the loader, which nothing previously exercised.

**All five defect-pinning tests (AGENTS.md §2.1) pass unchanged in Chromium.** The chunk-boundary false negative, the poisoned partial cache, the invalid-pattern trap and the NUL-byte discard all behave in a real browser exactly as they did under Node, so nothing needed inverting. That block did its job here: it is the evidence that moving execution environments changed no engine behaviour.

## Two sharp edges, both commented in place

- **`optimizeDeps.exclude: ['@netgrep/search']`** is load-bearing. Vite's dependency pre-bundling would rewrite the module into `.vite/deps/`, and the loader resolves the binary relative to its own module URL — a moved module fetches the `.wasm` from a directory that has none. Same class of failure as 0005.
- **The "run `pnpm build:wasm`" hint moved to `vitest.global-setup.ts`.** A missing `pkg/` fails during Vite's *transform*, before any test module — and therefore any `vi.mock` factory — is evaluated, so a check inside the test can never fire. What you would otherwise see is `Failed to resolve import "@netgrep/search"`, which does not mention the one command that fixes it.

## Testing

Full CI chain locally, in order: `lint` (Biome + clippy), `typecheck`, `build`, `test` **24/24** (7 Node, 17 Chromium — verified as `|browser (chromium)|` in verbose output, not a silent Node fallback), `test:rust` **2/2**, `verify:pack`. Plus `pnpm bootstrap` end to end and `pnpm install --frozen-lockfile`.

Negative controls, since 0005 is a precedent for this suite passing while broken:

- `pkg/` removed → browser project fails with the actionable "Build it with: `pnpm build:wasm`" message.
- `pkg/` removed → **unit** project still passes 7/7, preserving the documented property (AGENTS.md §2.2) that unit tests work on a checkout that has never built the WASM.

## Docs

Decision **0013**; BACKLOG item 2 moved to Done; AGENTS.md §4.2 (new) and §3/§4/§5/§6; CONTRIBUTING, ARCHITECTURE, the `wasm-release` skill, and an amendment on 0012 for the bootstrap change.

## Note for the reviewer

The `gh` OAuth token lacks the `workflow` scope, so this branch was pushed over SSH. Your remote is still HTTPS and unchanged; `gh auth refresh -s workflow` would fix it for next time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
