### PR TITLE
perf(search): compile each pattern once, and make an invalid one catchable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,9 +115,9 @@ pnpm build:wasm        # REQUIRED FIRST — see §2.2
 | Lint | `pnpm lint` | Biome (JS/TS) **and** clippy (`-D warnings`); `lint:js` / `lint:rust` run one each |
 | Format | `pnpm format` | Biome, writes in place |
 | Typecheck | `pnpm typecheck` | `tsc --noEmit`, TypeScript 7 |
-| Test TS | `pnpm test` | Vitest — **58 tests**: 30 unit in Node, 28 integration in headless Chromium |
+| Test TS | `pnpm test` | Vitest — **59 tests**: 30 unit in Node, 29 integration in headless Chromium |
 | — one suite | `pnpm test:unit` / `pnpm test:browser` | The two Vitest projects separately. `test:unit` needs no WASM and no browser |
-| Test Rust | `pnpm test:rust` | `cargo test`, native, no browser — **25 tests** |
+| Test Rust | `pnpm test:rust` | `cargo test`, native, no browser — **28 tests** |
 | Verify packaging | `pnpm verify:pack` | Packs both packages and inspects the tarballs. **Needs `pnpm build` first** |
 | Run the example | `pnpm dev` | Demo, not a test — see §6.3 |
 
@@ -214,12 +214,14 @@ again.
 
 ## 5. Repository map
 
-Three packages, ~450 lines of first-party source. pnpm workspaces link them; there is no task runner.
+Three packages, ~530 lines of first-party source. pnpm workspaces link them; there is no task runner.
 
 ```
 packages/
   search/            Rust → WASM core. The actual search engine.
-    src/lib.rs         ~45 lines. Exports one function: search_bytes(&[u8], &str) -> bool
+    src/lib.rs         ~125 lines, mostly comment. Exports one function:
+                       search_bytes(&[u8], &str) -> Result<bool, JsError>, which caches
+                       the last compiled matcher. See decision 0016
     tests/search.rs    plain native `cargo test` — no browser, no WebDriver.
                        Ends with a `documented_defects` module; read §2.1 first
     scripts/post_build.js   fixes up the generated pkg/ (see below)
@@ -317,7 +319,6 @@ in `packages/search/tests/search.rs`. Read §2.1 before touching any of them.
 |---|---|---|
 | Chunk-boundary false negatives | `Netgrep.ts` search loop | A match spanning two `fetch` chunks is never found. Silent, non-deterministic. |
 | Poisoned partial cache | `Netgrep.ts` cache paths | Early resolution caches a prefix; later searches answer `false` for text never downloaded. |
-| Panic on invalid pattern | `lib.rs`, `.build(pattern).unwrap()` | A stray `(` traps the WASM instance instead of surfacing a catchable error. A literal newline in the pattern does the same. |
 | One NUL discards the chunk | `lib.rs`, `BinaryDetection::quit` | A match is dropped even when it precedes the NUL. |
 | `$` misses on CRLF input | `lib.rs`, no `.crlf(true)` | The line terminator is `\n`, so `\r` sits between the text and `$`. A `$`-anchored pattern silently misses on Windows-authored files. |
 | Concurrent searches double a cache entry | `Netgrep.ts`, no in-flight tracking | Two searches of one url started together both fetch and both append, so the entry holds the file twice — joined with no separator, forming a line the file never had. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,7 +219,7 @@ Three packages, ~530 lines of first-party source. pnpm workspaces link them; the
 ```
 packages/
   search/            Rust → WASM core. The actual search engine.
-    src/lib.rs         ~125 lines, mostly comment. Exports one function:
+    src/lib.rs         ~135 lines, mostly comment. Exports one function:
                        search_bytes(&[u8], &str) -> Result<bool, JsError>, which caches
                        the last compiled matcher. See decision 0016
     tests/search.rs    plain native `cargo test` — no browser, no WebDriver.

--- a/README.md
+++ b/README.md
@@ -151,11 +151,10 @@ itself uses. Note that **smart case is hardcoded on**:
 
 This is not configurable. Lowercase your pattern to search case-insensitively.
 
-> [!CAUTION]
-> **An invalid pattern crashes the search engine.** A stray `(` or `[` surfaces as a
-> `RuntimeError: unreachable` from WebAssembly rather than a catchable error. If patterns come straight from
-> a user-facing search box — the use case this library was built for — validate or escape them before
-> passing them in.
+An invalid pattern — a stray `(`, or a literal newline from a pasted two-line string — is an ordinary
+failure: `search` rejects, and the batch methods report it as `{ result: false, error: "…" }` like any other
+error, carrying the regex crate's own diagnostic. Nothing needs escaping in advance, and one bad keystroke in
+a search box does not affect the searches after it.
 
 ## Cancelling a search
 
@@ -204,8 +203,6 @@ rather than fixed**. They are pinned by tests so they cannot change unnoticed; t
   incomplete. A later search on the same URL for a *different* pattern reads that partial copy and can
   return `false` for text further down the file. Set `enableMemoryCache: false` if this matters more than
   the network savings.
-- **An invalid regex traps the WASM instance**, as described above. A pattern containing a literal newline
-  does the same, so guard against pasted multi-line input.
 - **A file containing a NUL byte reports no match** for the chunk containing it, even when the match came
   earlier. Binary detection abandons the whole chunk rather than stopping at the NUL.
 - **`$` does not match on CRLF files.** The line terminator is `\n`, so on Windows-authored text the `\r`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,7 +43,7 @@ below are documented rather than hidden, and why the API has stayed a boolean.
                             │ workspace:*
 ┌───────────────────────────▼─────────────────────────────────────┐
 │ packages/search   — @netgrep/search (Rust → WASM)                │
-│   search_bytes(&[u8], &str) -> bool                              │
+│   search_bytes(&[u8], &str) -> Result<bool, JsError>             │
 │   wasm-pack `web` target: new URL(…, import.meta.url)            │
 └───────────────────────────┬─────────────────────────────────────┘
                             │ crates.io
@@ -65,21 +65,34 @@ never compiled. See [decision 0001](decisions/0001-fork-ripgrep-for-wasm.md).
 
 ## The Rust core — `packages/search`
 
-`src/lib.rs` is ~45 lines and exposes exactly one `#[wasm_bindgen]` function:
+`src/lib.rs` is ~125 lines, most of them comment, and exposes exactly one `#[wasm_bindgen]` function:
 
 ```rust
-pub fn search_bytes(chunk: &[u8], pattern: &str) -> bool
+pub fn search_bytes(chunk: &[u8], pattern: &str) -> Result<bool, JsError>
 ```
+
+wasm-bindgen unwraps that `Result`, so the TypeScript a consumer sees is
+`search_bytes(chunk: Uint8Array, pattern: string): boolean` — it simply **throws** on a pattern the regex
+engine will not accept, rather than trapping the instance as it did until 2026.
 
 Per call it:
 
-1. Builds a `RegexMatcherBuilder` with `line_terminator(b'\n')` and **`case_smart(true)`**
-   — smart case is hardcoded on and not configurable. A lowercase pattern matches case-insensitively;
-   a pattern containing an uppercase character matches case-sensitively.
+1. Reuses the **last compiled matcher** if the pattern is unchanged, and otherwise compiles a new one with
+   `line_terminator(b'\n')` and **`case_smart(true)`** — smart case is hardcoded on and not configurable. A
+   lowercase pattern matches case-insensitively; a pattern containing an uppercase character matches
+   case-sensitively. netgrep calls this once per network chunk with the same pattern every time, so the cache
+   hits on every chunk after the first; compilation was 97–99% of the cost before it existed. Failed compiles
+   are cached alongside successful ones. See [decision 0016](decisions/0016-compiled-matcher-memo.md).
 2. Builds a `Searcher` with `BinaryDetection::quit(b'\x00')` and `line_number(false)`.
-3. Runs `search_slice` into `MemSink`, a minimal `Sink` implementation that does nothing but increment a
-   counter — chosen because ripgrep's real sinks write to stdout, which does not exist in WASM.
-4. Returns `match_count > 0`.
+3. Runs `search_slice` into `MemSink`, a minimal `Sink` implementation that does nothing but record that a
+   match happened and stop — chosen because ripgrep's real sinks write to stdout, which does not exist in
+   WASM.
+4. Returns whether it matched.
+
+The engine is split in two: `try_search_bytes` is plain Rust returning `Result<bool, String>`, and
+`search_bytes` is a two-line `#[wasm_bindgen]` wrapper mapping that to a `JsError`. The split is not
+tidiness — `JsError` is a wasm-bindgen import that panics if constructed on a native target, and the Rust
+tests run natively.
 
 The default Rust allocator is used. `wee_alloc` was the global allocator until 2026; it was removed once
 measurement showed it saved 6,839 bytes — 0.6% — which no longer justified an unmaintained dependency with a
@@ -182,24 +195,12 @@ The cache is a plain `Record<string, Uint8Array>` with no eviction, no size cap 
 full bytes of every file searched for the lifetime of the `Netgrep` instance. `upsertMemoryCache` also
 reallocates and copies the whole accumulated buffer **per chunk**, making cache population O(n²) in bytes.
 
-### 4. Regex recompiled per chunk — `lib.rs`, the `RegexMatcherBuilder` in `search_bytes`
-
-`search_bytes` builds a fresh `RegexMatcher` on **every call**, i.e. once per network chunk per file. Regex
-compilation is the expensive part of a small search; this discards it every time.
-
-### 5. Panic on invalid pattern
-
-`.build(pattern).unwrap()` panics inside WASM if the pattern is not valid regex. Since patterns typically come
-straight from a user-facing search box, a stray `(` or `[` surfaces as a wasm trap
-(`RuntimeError: unreachable`) rather than a catchable domain error. The instance does remain usable
-afterwards.
-
-### 6. No completion signal from `searchBatchWithCallback`
+### 4. No completion signal from `searchBatchWithCallback`
 
 It returns `void` and starts every search eagerly with no concurrency limit. Callers cannot await it, cannot
 detect completion, and a batch of N URLs opens N simultaneous connections.
 
-### 7. One NUL byte discards the whole chunk — `lib.rs`, `BinaryDetection::quit`
+### 5. One NUL byte discards the whole chunk — `lib.rs`, `BinaryDetection::quit`
 
 `BinaryDetection::quit(b'\x00')` does not stop *at* the NUL — it abandons the entire chunk. A match is
 dropped even when it occurs before the NUL, and even on an earlier line. Any remote file containing a stray
@@ -208,7 +209,7 @@ NUL therefore reports "no match" for content that is demonstrably present.
 Quitting on binary input is a reasonable ripgrep default; the surprise is that the API cannot distinguish
 "binary, not searched" from "no match", because the API is a boolean.
 
-### 8. `$` does not match on CRLF input — `lib.rs`, no `.crlf(true)` on the matcher
+### 6. `$` does not match on CRLF input — `lib.rs`, no `.crlf(true)` on the matcher
 
 The searcher is given `line_terminator(Some(b'\n'))`, so on a Windows-authored file the `\r` is the last
 character of the line and `$` sits behind it. `needle$` matches `"needle\n"` and does **not** match
@@ -218,7 +219,7 @@ Silent, and it depends on who wrote the file rather than on anything the caller 
 `RegexMatcherBuilder::crlf(true)` is the one-line fix; it is a matching-semantics change, so it is a
 deliberate task rather than a drive-by.
 
-### 9. Concurrent searches of one url double its cache entry — `Netgrep.ts`, `search`
+### 7. Concurrent searches of one url double its cache entry — `Netgrep.ts`, `search`
 
 Nothing tracks a download already in flight. Two searches of the same url started before either resolves both
 `fetch`, and both append what they read to the same cache entry.
@@ -307,8 +308,8 @@ components straight out of `rust-toolchain.toml`.
 | Suite | Runner | What it covers |
 |---|---|---|
 | `Netgrep.spec.ts` | Vitest in **Node**, 30 tests | Orchestration only — `fetch` **and** `@netgrep/search` are mocked. Result shape, metadata, abort plumbing, error capture and serialisation, config defaults, cache scope and accumulation, and all three public methods including `searchBatchWithCallback`. |
-| `Netgrep.integration.spec.ts` | Vitest in **headless Chromium** (Playwright), 28 tests | **The real engine through the real streaming loop, in a real browser.** Only `fetch` is faked, and only to remove the network: bytes still travel through a real `ReadableStream`, still arrive chunked, still get matched by the compiled `search_bytes`. |
-| `packages/search/tests/search.rs` | `cargo test`, native, 25 tests | `search_bytes` as pure Rust — bytes in, bool out. Regex features, smart case, line semantics, encoding and BOM handling, binary detection. No browser involved. |
+| `Netgrep.integration.spec.ts` | Vitest in **headless Chromium** (Playwright), 29 tests | **The real engine through the real streaming loop, in a real browser.** Only `fetch` is faked, and only to remove the network: bytes still travel through a real `ReadableStream`, still arrive chunked, still get matched by the compiled `search_bytes`. |
+| `packages/search/tests/search.rs` | `cargo test`, native, 28 tests | `try_search_bytes` as pure Rust — bytes in, bool out. Regex features, smart case, line semantics, encoding and BOM handling, binary detection, and the compiled-matcher cache. No browser involved. |
 | `scripts/verify-pack.mjs` | Node, in CI | The published tarballs: required files present, no `workspace:` range survived packing, no version drift. |
 
 The split between the first three is deliberate: anything that depends only on the bytes is cheapest to pin

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,7 +65,7 @@ never compiled. See [decision 0001](decisions/0001-fork-ripgrep-for-wasm.md).
 
 ## The Rust core — `packages/search`
 
-`src/lib.rs` is ~125 lines, most of them comment, and exposes exactly one `#[wasm_bindgen]` function:
+`src/lib.rs` is ~135 lines, most of them comment, and exposes exactly one `#[wasm_bindgen]` function:
 
 ```rust
 pub fn search_bytes(chunk: &[u8], pattern: &str) -> Result<bool, JsError>

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -48,14 +48,6 @@ Needs a completeness flag per entry: partial entries may resume a download, neve
 A naive fix for either 3a or 3b — always draining the stream — destroys the early-resolution property that is
 the entire point of the project. See [decision 0002](decisions/0002-search-while-downloading.md).
 
-### 3c. Panic on invalid pattern — `packages/search/src/lib.rs`
-
-`.build(pattern).unwrap()` traps the WASM instance when the pattern is not valid regex. Patterns normally
-come straight from a user's search box, so a stray `(` surfaces as `RuntimeError: unreachable` instead of a
-catchable domain error. The instance does remain usable afterwards.
-
-Return a `Result`/`Option` across the boundary, or validate before calling.
-
 ### 3f. A single NUL byte discards the whole chunk — `packages/search/src/lib.rs`
 
 `BinaryDetection::quit(b'\x00')` does not merely stop at the NUL; it abandons the entire chunk. A match is
@@ -154,17 +146,6 @@ Removing it means patching `grep-searcher`, i.e. reintroducing the fork that was
 Reallocates and copies the whole accumulated buffer per chunk. Collect chunks in an array and join once. The
 cache also has no eviction, size cap or TTL — it retains every file searched for the lifetime of the instance.
 
-### 12. Regex recompiled per chunk — `packages/search/src/lib.rs`
-
-`search_bytes` builds a fresh `RegexMatcher` on every call, i.e. once per chunk per file, discarding the most
-expensive part of the work each time. Fixing it needs a compiled-matcher handle across the WASM boundary — a
-real interface change, so weigh it against the conservative scope.
-
-### 13. `MemSink` does not short-circuit
-
-`Sink::matched` returns `Ok(true)` (keep searching) when the result is only ever `count > 0`. Returning
-`Ok(false)` stops at the first match within a chunk. One line, small win.
-
 ---
 
 # Done
@@ -174,6 +155,9 @@ analysis was wrong.
 
 | # | Item | Outcome |
 |---|---|---|
+| 3c | Panic on invalid pattern | **Fixed.** `search_bytes` returns `Result<bool, JsError>`, so a stray `(` — or a literal newline, which the `\n` line terminator forbids — is a rejected promise carrying the regex crate's own diagnostic instead of `RuntimeError: unreachable`. The generated TypeScript signature did not change, so `Netgrep.ts` needed no edit. The engine is now split into a plain-Rust `try_search_bytes` and a two-line wasm wrapper, because `JsError` cannot be constructed on a native target and the Rust suite runs natively. Three assertions inverted. See [0016](decisions/0016-compiled-matcher-memo.md). |
+| 12 | Regex recompiled per chunk | **Fixed, and it was not a papercut.** A one-entry `thread_local` cache of the last compiled pattern; compile failures cached alongside successes. Over 800 16 KB chunks: a literal 91.2ms → 2.2ms, a Unicode class 2.9s → 20.6ms. Compilation was **97–99% of the total cost**, not the P3 nuisance this entry called it. The compiled-matcher *handle* this entry recommended was considered and rejected — it puts `.free()` on four exit paths of a promise executor and breaks a package whose whole surface is one function. See [0016](decisions/0016-compiled-matcher-memo.md). |
+| 13 | `MemSink` does not short-circuit | **Fixed.** `Ok(false)` stops at the first match; `match_count: u64` became `found: bool`. On chunks where every line matches, 16.4ms → 1.3ms at 16 KB and 61.9ms → 1.8ms at 64 KB; neutral on a single late match. Behaviourally unobservable — all 59 tests pass either way — so measurement is the only evidence it does anything. |
 | 2 | `pnpm test:wasm` fails on a fresh machine | **Fixed by removing the harness.** ChromeDriver was versioned independently of the browser it drove, by a mechanism this repo did not control, so the mismatch was structural. Playwright now runs the browser tests with a Chromium pinned to its own package version, the Rust tests became a native `cargo test` (`pnpm test:rust`), and browser coverage went *up* — 2 assertions about pure byte logic replaced by the 17-test integration suite, which now also exercises the fetch-based loader. See [0013](decisions/0013-playwright-for-browser-tests.md). |
 | 16 | Published package did not work under Vite | **Fixed.** Shipped wasm-pack's `web` target; the `bundler` target failed *silently* under Vite, returning `false` for every search. Verified in real Chrome against Vite (no plugins), webpack (no config), and a fresh app installed from the actual tarballs. See [0005](decisions/0005-esm-only-distribution.md). |
 | 10 | Root depended on its own published packages | **Fixed** by pnpm workspaces. The example now bundles local source. This was the repository's headline gotcha. See [0009](decisions/0009-pnpm-workspaces.md). |

--- a/docs/decisions/0002-search-while-downloading.md
+++ b/docs/decisions/0002-search-while-downloading.md
@@ -27,8 +27,10 @@ the whole point is to never assemble the string.
 - **Correctness: patterns straddling a chunk boundary are missed.** Chunks are searched in isolation with no
   overlap retained, so a match spanning the boundary is invisible. Silent false negative, dependent on
   non-deterministic network chunking. See `ARCHITECTURE.md` caveat 1.
-- The regex is recompiled per chunk (the `RegexMatcherBuilder` in `lib.rs`'s `search_bytes`), discarding the
-  most expensive part of the work on every iteration.
+- ~~The regex is recompiled per chunk (the `RegexMatcherBuilder` in `lib.rs`'s `search_bytes`), discarding the
+  most expensive part of the work on every iteration.~~ **Fixed 2026-07-29**: the engine caches the last
+  compiled pattern, so chunking no longer multiplies compilation. It was the largest cost this decision
+  carried — 97–99% of per-chunk time. See [0016](0016-compiled-matcher-memo.md).
 - Resolving early stops *reading* but does not cancel the underlying request, so bytes may keep arriving.
 - Interacts badly with the memory cache — the cache is left holding a partial file. See
   [0006](0006-in-memory-cache.md) and `ARCHITECTURE.md` caveat 2.

--- a/docs/decisions/0003-boolean-only-results.md
+++ b/docs/decisions/0003-boolean-only-results.md
@@ -14,7 +14,13 @@ matching posts; it does not render snippets.
 ## Decision
 
 `search_bytes(chunk, pattern) -> bool`. Internally `MemSink` implements `grep::searcher::Sink` and does
-nothing but increment a counter; the function returns `match_count > 0`.
+nothing but record that a match happened; the function returns that flag.
+
+> **Amended (2026-07-29).** `MemSink` counted matches until [0016](0016-compiled-matcher-memo.md); it now
+> records a `bool` and stops at the first hit, which is what the *Consequences* below always said it could
+> do. The signature also gained a fallible path — `Result<bool, JsError>` in Rust, still
+> `(chunk, pattern): boolean` in the generated TypeScript, throwing rather than trapping on an invalid
+> pattern. **The answer is still a boolean**, so this record's decision stands unchanged.
 
 The README states this plainly: *"At the moment Netgrep is just going to tell whether a pattern is present on
 a remote file."*
@@ -26,7 +32,9 @@ a remote file."*
   *where* or *how often* a term appears without a second pass in JavaScript.
 - Because only membership is needed, the searcher can stop at the first match. Combined with
   [0002](0002-search-while-downloading.md), that is what makes early resolution possible at all.
-- `MemSink` counting rather than short-circuiting is slightly wasteful — `Sink::matched` returns `Ok(true)`
-  ("keep searching") when it could return `Ok(false)` to stop at the first hit within a chunk.
+- ~~`MemSink` counting rather than short-circuiting is slightly wasteful — `Sink::matched` returns `Ok(true)`
+  ("keep searching") when it could return `Ok(false)` to stop at the first hit within a chunk.~~ **Done
+  2026-07-29** (BACKLOG 13); it returns `Ok(false)`. Worth 16.4ms → 1.3ms over 800 16 KB chunks in which
+  every line matches, and nothing at all where matches are rare.
 - The richer output would require designing a serialisation format across the boundary. Out of scope while the
   project is in maintenance mode.

--- a/docs/decisions/0011-tests-that-assert-known-bugs.md
+++ b/docs/decisions/0011-tests-that-assert-known-bugs.md
@@ -5,8 +5,8 @@
 ## Context
 
 netgrep has known, unfixed correctness bugs: a pattern straddling a `fetch` chunk boundary is missed, a
-partial cache answers later queries, an invalid pattern traps the WASM instance, a single NUL byte discards a
-chunk. They are documented in [`../ARCHITECTURE.md`](../ARCHITECTURE.md#known-limitations--correctness-caveats)
+partial cache answers later queries, a single NUL byte discards a chunk, `$` misses on CRLF input. (The
+invalid-pattern trap was on this list until 2026-07-29; see the second amendment below.) They are documented in [`../ARCHITECTURE.md`](../ARCHITECTURE.md#known-limitations--correctness-caveats)
 and tracked in [`../BACKLOG.md`](../BACKLOG.md).
 
 Fixing them is out of scope for dependency work: the first two interact, and a naive fix to either destroys
@@ -53,3 +53,11 @@ case-sensitive. No source change, no release note, nothing else in the repositor
 
 The defect test failed, the change was investigated, the new behaviour was confirmed correct, and the
 assertion was inverted in the same PR. That is the mechanism working exactly as intended.
+
+> **Amended again (2026-07-29).** The first of these tests was retired the way this record prescribes, which
+> is the point of writing it down. BACKLOG 3c — the trap on an invalid pattern — was fixed in
+> [0016](0016-compiled-matcher-memo.md), and its three assertions were inverted **in the same PR**: two
+> `#[should_panic]` tests in `search.rs` became assertions on the error message, and the integration test
+> asserting `rejects.toThrow('unreachable')` became one asserting a real diagnostic plus the thing the trap
+> had made impossible to assert — that the same instance still answers correctly afterwards. Both keep their
+> `BACKLOG 3c` label with a `(FIXED)` marker and a note saying what they used to claim, following 3e.

--- a/docs/decisions/0016-compiled-matcher-memo.md
+++ b/docs/decisions/0016-compiled-matcher-memo.md
@@ -1,0 +1,132 @@
+# 0016 — Cache the compiled matcher inside Rust, rather than hand a handle to JavaScript
+
+**Status: ACCEPTED (2026-07-29).** Closes [`BACKLOG`](../BACKLOG.md) items **3c**, **12** and **13**, and
+records why the design proposed in [issue #17](https://github.com/dgopsq/netgrep/issues/17) was not the one
+taken.
+
+## Context
+
+Two problems in `packages/search/src/lib.rs` were the same problem.
+
+`search_bytes` compiled the pattern on **every call**, and `Netgrep.ts` calls it once per `fetch` chunk per
+url. A batch over 200 files averaging four chunks each compiled one pattern 800 times and discarded the
+result each time — item **12**.
+
+`.build(pattern).unwrap()` **trapped the WASM instance** when the pattern was not valid, surfacing as
+`RuntimeError: unreachable`. Patterns come straight from a user's search box, so a stray `(` was routine
+input, not a hypothetical — item **3c**, a P1 correctness defect.
+
+Both are fixed by making compilation happen once, somewhere a `Result` can be returned.
+
+## Considered: a compiled matcher handle
+
+Issue #17 proposed exposing the compiled matcher to JavaScript as a `#[wasm_bindgen]` struct:
+
+```ts
+const matcher = new Matcher(pattern);   // fallible: compiles once
+matcher.search(chunk);                  // reused per chunk
+matcher.free();                         // wasm-bindgen owned handle
+```
+
+It is the more explicit design — construction-is-fallible becomes visible in the type — and `BACKLOG` item 12
+recommended it in as many words. **It was rejected**, for three reasons:
+
+1. **`.free()` becomes `Netgrep.ts`'s problem.** wasm-bindgen handles are not garbage collected. Every exit
+   from the streaming loop — resolve-on-match, stream done, fetch rejection, abort — would have to free, in a
+   promise-executor-based function with no cleanup discipline today. An abort mid-batch is the easy one to
+   miss, and the cost of missing it is a leaked DFA.
+2. **It is a breaking change to a package whose entire public surface is one function**, requiring a major
+   bump and coordination with the publish-order rule in [`AGENTS.md` §6.5](../../AGENTS.md#6-hard-rules) — to
+   buy something a caller never asked for. netgrep's promise is a boolean per url; a lifetime is not part of
+   that.
+3. **The cache-hit path gets *slower*.** `Netgrep.search` answers from `memoryCache[url]` without fetching.
+   There the compile is amortized over exactly one search, so a handle adds construction and teardown to a
+   path that previously had neither.
+
+## Decision
+
+Keep the exported surface exactly as it is, and cache inside Rust.
+
+```rust
+static LAST_COMPILED: RefCell<Option<(String, Result<RegexMatcher, String>)>>
+```
+
+- **One entry.** Every url in a single `searchBatch` shares one pattern, so a single slot hits on every chunk
+  after the first. Two patterns interleaving — a search-as-you-type box whose previous keystroke has not
+  finished — thrashes the slot back to the old behaviour plus one string comparison, which is why an LRU
+  would be machinery defending a case whose fallback is *no worse than today*.
+- **Failures are cached too.** An invalid pattern is what a search box emits on the way to a valid one;
+  without this a stray `(` re-fails once per chunk per url.
+- **`thread_local!`, not a `static`.** wasm32 is single-threaded, so this is simply the safe way to spell
+  "global" there. Under `cargo test`, which runs a thread per test, it also keeps the tests independent.
+
+`search_bytes` now returns `Result<bool, JsError>`. **The generated TypeScript signature does not change** —
+still `(chunk: Uint8Array, pattern: string): boolean`, throwing rather than trapping — so `Netgrep.ts` needed
+no edit at all: a throw inside the promise executor rejects the promise, and one inside `handleReader` reaches
+the existing `.catch(reject)`.
+
+### The engine is split in two, and the split is load-bearing
+
+```rust
+pub fn try_search_bytes(chunk: &[u8], pattern: &str) -> Result<bool, String>   // plain Rust
+#[wasm_bindgen] pub fn search_bytes(..) -> Result<bool, JsError>               // two-line wrapper
+```
+
+`JsError` is a wasm-bindgen *import*. It compiles on a native target and then panics at runtime with
+*"cannot call wasm-bindgen imported functions on non-wasm targets"*. `packages/search/tests/search.rs` runs
+natively. Without the split, its two error-path tests would still have passed — by panicking for a reason that
+has nothing to do with the pattern being invalid. This is worth knowing before touching the error path again.
+
+The cached error is a `String` rather than `grep_regex::Error` for a duller reason: it is handed out
+repeatedly and that type is not `Clone`.
+
+## Measurements
+
+Native, release profile, 800 chunks of prose — the shape of the worked example above. Native rather than
+wasm32 because the ratio between compiling and scanning is what matters, and no dependency was added to
+measure it (see [`AGENTS.md` §6.2](../../AGENTS.md#6-hard-rules)); the harness was thrown away.
+
+| pattern | 16 KB chunk | 64 KB chunk |
+|---|---|---|
+| `needle` | 91.2ms → **2.2ms** | 79.4ms → **9.1ms** |
+| `(needle\|thimble\|thread)` | 199.9ms → **2.4ms** | 216.4ms → **7.8ms** |
+| `\w+dle\b` | 699.8ms → **2.9ms** | 710.6ms → **6.8ms** |
+| `n\p{L}+dle` | 2.9s → **20.6ms** | 3.2s → **49.1ms** |
+
+Compilation was not merely significant; on these workloads it was **97–99% of the total cost**. Item 12 was
+filed as a P3 papercut and was closer to the dominant term.
+
+Item **13** was taken in the same pass: `Sink::matched` returned `Ok(true)` — keep searching — and counted
+every match, when the only question asked of the count is `> 0`. On chunks where every line matches,
+16.4ms → **1.3ms** at 16 KB and 61.9ms → **1.8ms** at 64 KB; on a chunk with one match near the end it is
+neutral, as expected. The answer is identical either way, so no test can pin it and measurement is the only
+evidence it does anything.
+
+## Considered and not taken: reusing the `Searcher` too
+
+`SearcherBuilder::new()…build()` also runs per chunk. Measured after the two changes above, reusing it is
+worth a further **14–22%** on sparse chunks — but of a per-chunk cost that is now ~2µs, against a chunk that
+took milliseconds to arrive over the network.
+
+It was left alone because the risk is not symmetric with the matcher's. A `RegexMatcher` is used through
+`&self`; a `Searcher` needs `&mut`, so reusing one means carrying **mutable state across calls** in the one
+place where stale state would produce a silently wrong boolean rather than a crash — the failure mode this
+library can least afford. Not worth 0.5µs. Recorded here so it is not rediscovered and re-measured.
+
+## Consequences
+
+- `lib.rs` grows from ~45 to ~120 lines, most of it comment. The exported surface is unchanged: still one
+  function, still a boolean.
+- **There is now state in the engine.** Its failure mode — answering with the previous pattern's matcher — is
+  a wrong answer, not a crash. Three tests in `search.rs` pin it: a changed pattern is not answered by the old
+  matcher; two patterns differing only in case are not confused (smart case is decided at *compile* time, so
+  they genuinely need different matchers); and a cached failure does not wedge the valid pattern after it.
+- The `CAUTION` block about invalid patterns is **gone from the README** rather than reworded, and
+  `AGENTS.md` §7 loses a row.
+- Per [0011](0011-tests-that-assert-known-bugs.md) and
+  [`AGENTS.md` §2.1](../../AGENTS.md#21-some-tests-assert-behaviour-that-is-wrong-on-purpose),
+  the three assertions that pinned 3c were inverted in the same change. The integration test now asserts the
+  thing that could only ever be asserted in a browser: after an invalid pattern, **the same instance still
+  answers correctly**.
+- Not fixed, and unaffected: 3a (chunk-boundary false negatives), 3b (poisoned partial cache), 3f (one NUL
+  discards the chunk), 17 (`$` on CRLF), 18 (concurrent searches double a cache entry).

--- a/docs/decisions/0016-compiled-matcher-memo.md
+++ b/docs/decisions/0016-compiled-matcher-memo.md
@@ -48,7 +48,9 @@ recommended it in as many words. **It was rejected**, for three reasons:
 Keep the exported surface exactly as it is, and cache inside Rust.
 
 ```rust
-static LAST_COMPILED: RefCell<Option<(String, Result<RegexMatcher, String>)>>
+struct Compiled { pattern: String, matcher: Result<RegexMatcher, String> }
+
+static LAST_COMPILED: RefCell<Option<Compiled>>
 ```
 
 - **One entry.** Every url in a single `searchBatch` shares one pattern, so a single slot hits on every chunk
@@ -86,6 +88,13 @@ Native, release profile, 800 chunks of prose — the shape of the worked example
 wasm32 because the ratio between compiling and scanning is what matters, and no dependency was added to
 measure it (see [`AGENTS.md` §6.2](../../AGENTS.md#6-hard-rules)); the harness was thrown away.
 
+Issue #17 suggested benchmarking against the 67-file Sherlock corpus in `packages/example` instead. That was
+**not** what was done, deliberately: the example is a manual demo with a browser and a network in the way, so
+it measures the whole pipeline rather than the thing being changed, and it cannot separate a 40× win on
+compilation from the milliseconds a chunk spends arriving. The synthetic chunks below isolate the ratio. The
+trade is that these numbers say nothing about end-to-end wall-clock, which is dominated by the network and
+barely moves.
+
 | pattern | 16 KB chunk | 64 KB chunk |
 |---|---|---|
 | `needle` | 91.2ms → **2.2ms** | 79.4ms → **9.1ms** |
@@ -115,7 +124,7 @@ library can least afford. Not worth 0.5µs. Recorded here so it is not rediscove
 
 ## Consequences
 
-- `lib.rs` grows from ~45 to ~120 lines, most of it comment. The exported surface is unchanged: still one
+- `lib.rs` grows from ~45 to ~135 lines, most of it comment. The exported surface is unchanged: still one
   function, still a boolean.
 - **There is now state in the engine.** Its failure mode — answering with the previous pattern's matcher — is
   a wrong answer, not a crash. Three tests in `search.rs` pin it: a changed pattern is not answered by the old

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -28,6 +28,7 @@ reasoning got wrong.
 | [0013](0013-playwright-for-browser-tests.md) | Playwright runs the browser tests; ChromeDriver is gone | Accepted |
 | [0014](0014-sccache-not-a-shared-target-dir.md) | Cache Rust builds with sccache, and never with a shared target directory | Accepted |
 | [0015](0015-ci-jobs-grouped-by-toolchain.md) | Five CI jobs, grouped by toolchain, with the WASM built once | Accepted |
+| [0016](0016-compiled-matcher-memo.md) | Cache the compiled matcher inside Rust, rather than hand a handle to JavaScript | Accepted |
 
 ## Format
 

--- a/packages/netgrep/src/lib/Netgrep.integration.spec.ts
+++ b/packages/netgrep/src/lib/Netgrep.integration.spec.ts
@@ -589,14 +589,48 @@ describe('Netgrep integration (real WASM)', () => {
       });
     });
 
-    it('BACKLOG 3c: an invalid pattern traps the WASM instance', async () => {
+    it('BACKLOG 3c (FIXED): an invalid pattern rejects, and the engine survives it', async () => {
+      // This assertion used to sit here inverted, pinning a real bug:
+      // `.build(pattern).unwrap()` in lib.rs panicked on a malformed regex,
+      // which surfaced as `RuntimeError: unreachable` — a wasm trap rather
+      // than a catchable domain error.
+      //
+      // `search_bytes` now returns a `Result<bool, JsError>`, so the rejection
+      // carries the regex crate's own diagnostic. Per the block comment above,
+      // the assertion is inverted in the same PR that changed it.
       serve([encoder.encode(POEM)]);
 
-      // `.build(pattern).unwrap()` in lib.rs panics on a malformed regex,
-      // which surfaces as a wasm trap rather than a catchable domain error.
-      await expect(
-        new Netgrep({ enableMemoryCache: false }).search('url', '('),
-      ).rejects.toThrow('unreachable');
+      const NG = new Netgrep({ enableMemoryCache: false });
+
+      await expect(NG.search('url', '(')).rejects.toThrow('unclosed group');
+
+      // The point of the whole change: a trap would have poisoned the module
+      // for every later call, so this could only be asserted in a browser.
+      // The same instance still answers correctly afterwards.
+      serve([encoder.encode(POEM)]);
+
+      await expect(NG.search('url', 'set aside')).resolves.toMatchObject({
+        result: true,
+      });
+    });
+
+    it('BACKLOG 3c (FIXED): a bad pattern is a per-url error in a batch, not a crash', async () => {
+      // `searchBatch` already documents that a failed url comes back as
+      // `{ result: false, error }`. Before the fix an invalid pattern took a
+      // different path out — a trap — so this is the assertion that the
+      // README's deleted CAUTION block was standing in for.
+      serve([encoder.encode(POEM)]);
+
+      const results = await new Netgrep({
+        enableMemoryCache: false,
+      }).searchBatch([{ url: 'a' }, { url: 'b' }], '(');
+
+      expect(results).toHaveLength(2);
+
+      for (const result of results) {
+        expect(result.result).toBe(false);
+        expect(result.error).toContain('unclosed group');
+      }
     });
 
     it('BACKLOG 3e (FIXED upstream): `^` anchors to the line, on any line', async () => {

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -6,7 +6,8 @@ This is the low-level core of [`@netgrep/netgrep`](https://www.npmjs.com/package
 probably the package you want — it adds the streaming, batching and caching that make the engine useful over
 HTTP. Used directly, this one exposes a single function —
 `search_bytes(chunk: Uint8Array, pattern: string): boolean` — and its default export is an `init` you must
-await before calling it.
+await before calling it. It **throws** if the pattern is not valid regex, so a stray `(` from a search box is
+an ordinary catchable error.
 
 > [!IMPORTANT]
 > **This is an experiment, not a recommendation.** netgrep is almost certainly not the best way to add
@@ -17,5 +18,5 @@ await before calling it.
 > downloading*.
 >
 > Note also that this package is a **~1.15 MB WebAssembly binary** (~480 KB gzipped) and has
-> [known limitations](https://github.com/dgopsq/netgrep#known-limitations) — an invalid pattern traps the
-> instance, and a single NUL byte discards the chunk being searched.
+> [known limitations](https://github.com/dgopsq/netgrep#known-limitations) — a single NUL byte discards the
+> chunk being searched, and `$` does not match on CRLF input.

--- a/packages/search/src/lib.rs
+++ b/packages/search/src/lib.rs
@@ -91,18 +91,18 @@ fn search_with(matcher: &RegexMatcher, chunk: &[u8]) -> bool {
         .line_number(false)
         .build();
 
-    let mut sink = MemSink { match_count: 0 };
+    let mut sink = MemSink { found: false };
 
     let _ = searcher.search_slice(matcher, chunk, &mut sink);
 
-    sink.match_count > 0
+    sink.found
 }
 
 /// An in-memory `Sink` implementation in order
 /// to store the matches in a structured way instead
 /// of just writing on a stdout.
 struct MemSink {
-    match_count: u64,
+    found: bool,
 }
 
 impl Sink for MemSink {
@@ -113,7 +113,13 @@ impl Sink for MemSink {
         _searcher: &Searcher,
         _mat: &SinkMatch<'_>,
     ) -> Result<bool, std::io::Error> {
-        self.match_count += 1;
-        Ok(true)
+        self.found = true;
+
+        // `false` means "stop". netgrep answers a boolean, so every match
+        // after the first is scanned for nothing: this used to count them all,
+        // to the end of the chunk. Measured over 800 16 KB chunks in which
+        // every line matches, 16.4ms → 1.3ms. The answer is identical either
+        // way, which is also why no test can pin this.
+        Ok(false)
     }
 }

--- a/packages/search/src/lib.rs
+++ b/packages/search/src/lib.rs
@@ -1,17 +1,49 @@
-use grep_regex::RegexMatcherBuilder;
+use grep_regex::{RegexMatcher, RegexMatcherBuilder};
 use grep_searcher::{BinaryDetection, Searcher, SearcherBuilder, Sink, SinkMatch};
 use wasm_bindgen::prelude::*;
 
 /// Search a bytes array for the given pattern. This function
 /// uses `ripgrep` under the hood.
+///
+/// Throws a JavaScript `Error` when the pattern is not something the regex
+/// engine accepts — a stray `(`, or a literal newline, both of which arrive
+/// routinely from a user's search box. It used to `unwrap()` instead, which
+/// trapped the WASM instance with `RuntimeError: unreachable`.
 #[wasm_bindgen]
-pub fn search_bytes(chunk: &[u8], pattern: &str) -> bool {
-    let matcher = RegexMatcherBuilder::new()
+pub fn search_bytes(chunk: &[u8], pattern: &str) -> Result<bool, JsError> {
+    try_search_bytes(chunk, pattern).map_err(|error| JsError::new(&error))
+}
+
+/// The engine, as plain Rust.
+///
+/// `search_bytes` above is a two-line wrapper around this, and the split is
+/// load-bearing rather than tidiness: `JsError` is a `wasm-bindgen` import, and
+/// constructing one on a native target panics with *"cannot call wasm-bindgen
+/// imported functions on non-wasm targets"*. The Rust suite in `tests/` runs
+/// natively, so anything it needs to assert about the error path has to be
+/// reachable without a `JsError` in the signature.
+///
+/// The error is a `String` rather than `grep_regex::Error` so that it can be
+/// handed on without dragging a `grep-regex` type into every caller's
+/// signature.
+pub fn try_search_bytes(chunk: &[u8], pattern: &str) -> Result<bool, String> {
+    let matcher = build_matcher(pattern)?;
+
+    Ok(search_with(&matcher, chunk))
+}
+
+/// Compile a pattern with netgrep's fixed matching semantics: `\n` terminates a
+/// line, and smart case is on.
+fn build_matcher(pattern: &str) -> Result<RegexMatcher, String> {
+    RegexMatcherBuilder::new()
         .line_terminator(Some(b'\n'))
         .case_smart(true)
         .build(pattern)
-        .unwrap();
+        .map_err(|error| error.to_string())
+}
 
+/// Run a compiled matcher over one chunk of bytes.
+fn search_with(matcher: &RegexMatcher, chunk: &[u8]) -> bool {
     let mut searcher = SearcherBuilder::new()
         .binary_detection(BinaryDetection::quit(b'\x00'))
         .line_number(false)
@@ -19,7 +51,7 @@ pub fn search_bytes(chunk: &[u8], pattern: &str) -> bool {
 
     let mut sink = MemSink { match_count: 0 };
 
-    let _ = searcher.search_slice(&matcher, chunk, &mut sink);
+    let _ = searcher.search_slice(matcher, chunk, &mut sink);
 
     sink.match_count > 0
 }

--- a/packages/search/src/lib.rs
+++ b/packages/search/src/lib.rs
@@ -3,14 +3,27 @@ use grep_searcher::{BinaryDetection, Searcher, SearcherBuilder, Sink, SinkMatch}
 use std::cell::RefCell;
 use wasm_bindgen::prelude::*;
 
+/// A pattern, and what compiling it produced.
+///
+/// The failure is kept rather than discarded: an invalid pattern is exactly
+/// what a search box emits mid-typing, and without this it would re-fail once
+/// per chunk per url. It is a `String` rather than `grep_regex::Error` because
+/// it is handed out repeatedly and that type is not `Clone`.
+struct Compiled {
+    pattern: String,
+    matcher: Result<RegexMatcher, String>,
+}
+
 thread_local! {
-    /// The last pattern compiled, and what compiling it produced.
+    /// The last pattern compiled.
     ///
     /// netgrep hands the engine one `fetch` chunk at a time, so a batch over
     /// 200 files averaging four chunks each used to compile the same pattern
-    /// 800 times and throw the result away. Compilation dominates: measured
-    /// over 800 16 KB chunks, a literal took 91 ms compiling-per-chunk against
-    /// 2.2 ms compiled once, and a Unicode class 2.9 s against 21 ms.
+    /// 800 times and throw the result away. Compilation turned out to be
+    /// 97–99% of the cost; the measurements are in
+    /// [decision 0016](../../../docs/decisions/0016-compiled-matcher-memo.md),
+    /// which also records why the compiled-matcher *handle* proposed in issue
+    /// #17 was not the shape taken.
     ///
     /// ONE ENTRY IS ENOUGH. Every caller of a single `searchBatch` shares one
     /// pattern, so a single slot hits on every chunk after the first. The case
@@ -18,16 +31,11 @@ thread_local! {
     /// box whose previous keystroke has not finished — and there the slot
     /// simply thrashes back to the old behaviour, plus one string comparison.
     ///
-    /// FAILURES ARE CACHED TOO. An invalid pattern is exactly what a search box
-    /// produces mid-typing, and without this it would re-fail once per chunk
-    /// per url.
-    ///
     /// `thread_local!` rather than a `static`: wasm32 is single-threaded so
     /// this is simply the safe way to spell "global" there, and under
     /// `cargo test` — which runs a thread per test — it keeps the tests
     /// independent of each other.
-    static LAST_COMPILED: RefCell<Option<(String, Result<RegexMatcher, String>)>> =
-        const { RefCell::new(None) };
+    static LAST_COMPILED: RefCell<Option<Compiled>> = const { RefCell::new(None) };
 }
 
 /// Search a bytes array for the given pattern. This function
@@ -50,20 +58,20 @@ pub fn search_bytes(chunk: &[u8], pattern: &str) -> Result<bool, JsError> {
 /// imported functions on non-wasm targets"*. The Rust suite in `tests/` runs
 /// natively, so anything it needs to assert about the error path has to be
 /// reachable without a `JsError` in the signature.
-///
-/// The error is a `String` rather than `grep_regex::Error` because it is cached
-/// in `LAST_COMPILED` and handed out repeatedly, and that type is not `Clone`.
 pub fn try_search_bytes(chunk: &[u8], pattern: &str) -> Result<bool, String> {
     LAST_COMPILED.with_borrow_mut(|slot| {
         // Taken out and put back rather than borrowed in place: a reference
         // into `slot` cannot outlive the reassignment that replaces a stale
-        // entry, and moving the pair sidesteps that entirely.
+        // entry, and moving the whole entry sidesteps that entirely.
         let entry = match slot.take() {
-            Some((cached, compiled)) if cached == pattern => (cached, compiled),
-            _ => (pattern.to_owned(), build_matcher(pattern)),
+            Some(entry) if entry.pattern == pattern => entry,
+            _ => Compiled {
+                pattern: pattern.to_owned(),
+                matcher: build_matcher(pattern),
+            },
         };
 
-        let result = match &entry.1 {
+        let result = match &entry.matcher {
             Ok(matcher) => Ok(search_with(matcher, chunk)),
             Err(error) => Err(error.clone()),
         };
@@ -98,9 +106,10 @@ fn search_with(matcher: &RegexMatcher, chunk: &[u8]) -> bool {
     sink.found
 }
 
-/// An in-memory `Sink` implementation in order
-/// to store the matches in a structured way instead
-/// of just writing on a stdout.
+/// A `Sink` that records whether anything matched, and nothing else — chosen
+/// because ripgrep's real sinks write to a stdout that does not exist in WASM,
+/// and because a boolean is the entire public answer. See
+/// [decision 0003](../../../docs/decisions/0003-boolean-only-results.md).
 struct MemSink {
     found: bool,
 }
@@ -115,11 +124,10 @@ impl Sink for MemSink {
     ) -> Result<bool, std::io::Error> {
         self.found = true;
 
-        // `false` means "stop". netgrep answers a boolean, so every match
-        // after the first is scanned for nothing: this used to count them all,
-        // to the end of the chunk. Measured over 800 16 KB chunks in which
-        // every line matches, 16.4ms → 1.3ms. The answer is identical either
-        // way, which is also why no test can pin this.
+        // `false` means "stop". netgrep answers a boolean, so every match after
+        // the first is scanned for nothing: this used to count them all, to the
+        // end of the chunk. The answer is identical either way, which is why no
+        // test can pin it and decision 0016 carries the measurement instead.
         Ok(false)
     }
 }

--- a/packages/search/src/lib.rs
+++ b/packages/search/src/lib.rs
@@ -1,6 +1,34 @@
 use grep_regex::{RegexMatcher, RegexMatcherBuilder};
 use grep_searcher::{BinaryDetection, Searcher, SearcherBuilder, Sink, SinkMatch};
+use std::cell::RefCell;
 use wasm_bindgen::prelude::*;
+
+thread_local! {
+    /// The last pattern compiled, and what compiling it produced.
+    ///
+    /// netgrep hands the engine one `fetch` chunk at a time, so a batch over
+    /// 200 files averaging four chunks each used to compile the same pattern
+    /// 800 times and throw the result away. Compilation dominates: measured
+    /// over 800 16 KB chunks, a literal took 91 ms compiling-per-chunk against
+    /// 2.2 ms compiled once, and a Unicode class 2.9 s against 21 ms.
+    ///
+    /// ONE ENTRY IS ENOUGH. Every caller of a single `searchBatch` shares one
+    /// pattern, so a single slot hits on every chunk after the first. The case
+    /// it does not cover is two patterns interleaving — a search-as-you-type
+    /// box whose previous keystroke has not finished — and there the slot
+    /// simply thrashes back to the old behaviour, plus one string comparison.
+    ///
+    /// FAILURES ARE CACHED TOO. An invalid pattern is exactly what a search box
+    /// produces mid-typing, and without this it would re-fail once per chunk
+    /// per url.
+    ///
+    /// `thread_local!` rather than a `static`: wasm32 is single-threaded so
+    /// this is simply the safe way to spell "global" there, and under
+    /// `cargo test` — which runs a thread per test — it keeps the tests
+    /// independent of each other.
+    static LAST_COMPILED: RefCell<Option<(String, Result<RegexMatcher, String>)>> =
+        const { RefCell::new(None) };
+}
 
 /// Search a bytes array for the given pattern. This function
 /// uses `ripgrep` under the hood.
@@ -23,13 +51,27 @@ pub fn search_bytes(chunk: &[u8], pattern: &str) -> Result<bool, JsError> {
 /// natively, so anything it needs to assert about the error path has to be
 /// reachable without a `JsError` in the signature.
 ///
-/// The error is a `String` rather than `grep_regex::Error` so that it can be
-/// handed on without dragging a `grep-regex` type into every caller's
-/// signature.
+/// The error is a `String` rather than `grep_regex::Error` because it is cached
+/// in `LAST_COMPILED` and handed out repeatedly, and that type is not `Clone`.
 pub fn try_search_bytes(chunk: &[u8], pattern: &str) -> Result<bool, String> {
-    let matcher = build_matcher(pattern)?;
+    LAST_COMPILED.with_borrow_mut(|slot| {
+        // Taken out and put back rather than borrowed in place: a reference
+        // into `slot` cannot outlive the reassignment that replaces a stale
+        // entry, and moving the pair sidesteps that entirely.
+        let entry = match slot.take() {
+            Some((cached, compiled)) if cached == pattern => (cached, compiled),
+            _ => (pattern.to_owned(), build_matcher(pattern)),
+        };
 
-    Ok(search_with(&matcher, chunk))
+        let result = match &entry.1 {
+            Ok(matcher) => Ok(search_with(matcher, chunk)),
+            Err(error) => Err(error.clone()),
+        };
+
+        *slot = Some(entry);
+
+        result
+    })
 }
 
 /// Compile a pattern with netgrep's fixed matching semantics: `\n` terminates a

--- a/packages/search/tests/search.rs
+++ b/packages/search/tests/search.rs
@@ -26,9 +26,27 @@
 //! likely to change silently under a dependency bump, and knowing *which*
 //! layer moved is worth one duplicated assertion.
 
+/// Assert-friendly wrapper: bytes in, bool out, exactly as the module comment
+/// above describes.
+///
+/// The engine itself returns `Result<bool, String>` — an invalid pattern is a
+/// domain error, not a panic. Tests that are *about* a valid pattern say so by
+/// using this and letting a compile failure surface as a test failure; the two
+/// in `documented_defects` that are about the error itself call
+/// `try_search_bytes` directly.
+///
+/// These call `try_search_bytes` rather than the `#[wasm_bindgen]` export
+/// `search_bytes`, because the latter's error type cannot be constructed on a
+/// native target. See the comment on `try_search_bytes` in `lib.rs`.
+#[cfg(test)]
+fn matches(haystack: &[u8], pattern: &str) -> bool {
+    // Leading `::` because the test module below is also called `search`.
+    ::search::try_search_bytes(haystack, pattern).expect("the pattern should compile")
+}
+
 #[cfg(test)]
 mod search {
-    use search::search_bytes;
+    use super::matches;
 
     const POEM: &str = "One Wiseman came to Jhaampe-town.\n\
                         He set aside both Queen and Crown\n\
@@ -41,21 +59,21 @@ mod search {
 
     #[test]
     fn test_search_bytes() {
-        assert!(search_bytes(POEM.as_bytes(), "set aside"));
+        assert!(matches(POEM.as_bytes(), "set aside"));
     }
 
     #[test]
     fn test_absent_pattern_does_not_match() {
-        assert!(!search_bytes(POEM.as_bytes(), "dragon"));
+        assert!(!matches(POEM.as_bytes(), "dragon"));
     }
 
     #[test]
     fn test_empty_haystack_never_matches() {
-        assert!(!search_bytes(b"", "anything"));
+        assert!(!matches(b"", "anything"));
 
         // Not even the empty pattern, which matches every line of anything
         // else: there are no lines here to match.
-        assert!(!search_bytes(b"", ""));
+        assert!(!matches(b"", ""));
     }
 
     #[test]
@@ -63,19 +81,19 @@ mod search {
         // Worth pinning because it is the shape of a search box on its first
         // keystroke, and "matches everything" is a defensible answer only as
         // long as it is the deliberate one.
-        assert!(search_bytes(b"anything at all", ""));
+        assert!(matches(b"anything at all", ""));
     }
 
     #[test]
     fn test_pattern_longer_than_the_haystack() {
-        assert!(!search_bytes(b"ab", "abcdef"));
+        assert!(!matches(b"ab", "abcdef"));
     }
 
     #[test]
     fn test_matches_on_the_final_line_without_a_trailing_newline() {
         // A chunk boundary lands mid-file far more often than on a line
         // terminator, so the last line handed to the engine usually has none.
-        assert!(search_bytes(b"first\nneedle", "needle"));
+        assert!(matches(b"first\nneedle", "needle"));
     }
 
     #[test]
@@ -85,7 +103,7 @@ mod search {
         let mut haystack = vec![b'x'; 200_000];
         haystack.extend_from_slice(b"needle");
 
-        assert!(search_bytes(&haystack, "needle"));
+        assert!(matches(&haystack, "needle"));
     }
 
     // ---------------------------------------------------------------
@@ -94,20 +112,20 @@ mod search {
 
     #[test]
     fn test_search_bytes_smart_case() {
-        assert!(search_bytes(POEM.as_bytes(), "both queen and crown"));
+        assert!(matches(POEM.as_bytes(), "both queen and crown"));
     }
 
     #[test]
     fn test_smart_case_an_uppercased_pattern_is_case_sensitive() {
         // The other half of `case_smart(true)`: a capital anywhere in the
         // pattern is read as intent, and the search stops being lenient.
-        assert!(!search_bytes(b"one wiseman came", "Wiseman"));
-        assert!(search_bytes(b"One Wiseman came", "Wiseman"));
+        assert!(!matches(b"one wiseman came", "Wiseman"));
+        assert!(matches(b"One Wiseman came", "Wiseman"));
     }
 
     #[test]
     fn test_an_explicit_case_insensitive_flag_still_wins() {
-        assert!(search_bytes(b"ONE WISEMAN", "(?i)Wiseman"));
+        assert!(matches(b"ONE WISEMAN", "(?i)Wiseman"));
     }
 
     // ---------------------------------------------------------------
@@ -120,20 +138,20 @@ mod search {
 
     #[test]
     fn test_alternation_and_character_classes() {
-        assert!(search_bytes(POEM.as_bytes(), "Queen (and|or) Crown"));
-        assert!(search_bytes(POEM.as_bytes(), r"Jhaampe-\w+"));
-        assert!(search_bytes(b"order 1138 shipped", r"\d{4}"));
+        assert!(matches(POEM.as_bytes(), "Queen (and|or) Crown"));
+        assert!(matches(POEM.as_bytes(), r"Jhaampe-\w+"));
+        assert!(matches(b"order 1138 shipped", r"\d{4}"));
     }
 
     #[test]
     fn test_word_boundaries() {
-        assert!(search_bytes(b"a needle b", r"\bneedle\b"));
-        assert!(!search_bytes(b"needlepoint", r"\bneedle\b"));
+        assert!(matches(b"a needle b", r"\bneedle\b"));
+        assert!(!matches(b"needlepoint", r"\bneedle\b"));
     }
 
     #[test]
     fn test_repetition_and_anchoring_together() {
-        assert!(search_bytes(b"aaaa\nbbbb\n", "^a{4}$"));
+        assert!(matches(b"aaaa\nbbbb\n", "^a{4}$"));
     }
 
     // ---------------------------------------------------------------
@@ -147,16 +165,16 @@ mod search {
 
     #[test]
     fn test_caret_anchors_to_any_line_not_just_the_first() {
-        assert!(search_bytes(b"Needle x\nother\n", "^Needle"));
-        assert!(search_bytes(b"other\nNeedle x\n", "^Needle"));
-        assert!(search_bytes(b"a\nb\nNeedle x\n", "^Needle"));
-        assert!(!search_bytes(b"x Needle\n", "^Needle"));
+        assert!(matches(b"Needle x\nother\n", "^Needle"));
+        assert!(matches(b"other\nNeedle x\n", "^Needle"));
+        assert!(matches(b"a\nb\nNeedle x\n", "^Needle"));
+        assert!(!matches(b"x Needle\n", "^Needle"));
     }
 
     #[test]
     fn test_dollar_anchors_to_the_end_of_any_line() {
-        assert!(search_bytes(b"other\nxx Needle\n", "Needle$"));
-        assert!(!search_bytes(b"Needle xx\n", "Needle$"));
+        assert!(matches(b"other\nxx Needle\n", "Needle$"));
+        assert!(!matches(b"Needle xx\n", "Needle$"));
     }
 
     #[test]
@@ -164,8 +182,8 @@ mod search {
         // `.` excludes the line terminator, and no multiline mode is enabled,
         // so a pattern can never straddle two lines. This is the engine-level
         // half of why netgrep answers "does this pattern occur on some line".
-        assert!(!search_bytes(b"alpha\nbeta", "alpha.beta"));
-        assert!(!search_bytes(b"alpha\nbeta", "(?s)alpha.beta"));
+        assert!(!matches(b"alpha\nbeta", "alpha.beta"));
+        assert!(!matches(b"alpha\nbeta", "(?s)alpha.beta"));
     }
 
     // ---------------------------------------------------------------
@@ -174,14 +192,14 @@ mod search {
 
     #[test]
     fn test_matches_non_ascii_text() {
-        assert!(search_bytes("un café noir".as_bytes(), "café"));
-        assert!(search_bytes("naïve".as_bytes(), r"na\w+ve"));
+        assert!(matches("un café noir".as_bytes(), "café"));
+        assert!(matches("naïve".as_bytes(), r"na\w+ve"));
     }
 
     #[test]
     fn test_smart_case_applies_to_non_ascii_text() {
-        assert!(search_bytes("un CAFÉ noir".as_bytes(), "café"));
-        assert!(!search_bytes("un café noir".as_bytes(), "CAFÉ"));
+        assert!(matches("un CAFÉ noir".as_bytes(), "café"));
+        assert!(!matches("un café noir".as_bytes(), "CAFÉ"));
     }
 
     #[test]
@@ -199,16 +217,16 @@ mod search {
             utf16.extend_from_slice(&unit.to_le_bytes());
         }
 
-        assert!(search_bytes(&utf16, "needle"));
+        assert!(matches(&utf16, "needle"));
 
         // Without the BOM there is nothing to sniff, and the same text reads
         // as NUL-separated bytes.
-        assert!(!search_bytes(&utf16[2..], "needle"));
+        assert!(!matches(&utf16[2..], "needle"));
     }
 
     #[test]
     fn test_a_utf8_bom_does_not_hide_the_first_line() {
-        assert!(search_bytes(&[0xef, 0xbb, 0xbf, b'n', b'e', b'e', b'd'], "need"));
+        assert!(matches(&[0xef, 0xbb, 0xbf, b'n', b'e', b'e', b'd'], "need"));
     }
 
     #[test]
@@ -218,7 +236,7 @@ mod search {
         // because the two behaviours that DO blank a line (BOM sniffing above,
         // binary detection below) make it reasonable to assume this one does
         // too.
-        assert!(search_bytes(&[0xff, b' ', b'x', b'y'], "xy"));
+        assert!(matches(&[0xff, b' ', b'x', b'y'], "xy"));
     }
 }
 
@@ -243,25 +261,44 @@ mod search {
 /// Tracked in `docs/BACKLOG.md`.
 #[cfg(test)]
 mod documented_defects {
-    use search::search_bytes;
+    use super::matches;
+    use search::try_search_bytes;
 
     #[test]
-    #[should_panic(expected = "unclosed group")]
-    fn backlog_3c_an_invalid_pattern_panics() {
-        // `.build(pattern).unwrap()`. Patterns come straight from a user's
-        // search box, so a stray `(` traps the WASM instance — surfacing in
-        // the browser as `RuntimeError: unreachable` — instead of a catchable
-        // domain error.
-        search_bytes(b"anything", "(");
+    fn backlog_3c_fixed_an_invalid_pattern_is_an_error() {
+        // This assertion used to sit here as `#[should_panic]`, pinning a real
+        // bug: `.build(pattern).unwrap()` trapped the WASM instance —
+        // surfacing in the browser as `RuntimeError: unreachable` — for input
+        // that arrives routinely from a user's search box.
+        //
+        // `search_bytes` now returns a `Result`, so per the block comment above
+        // the assertion is inverted in the same PR that changed it. It asserts
+        // the message too: a bare `is_err()` would also pass if the pattern had
+        // failed to compile for some entirely different reason.
+        let error = try_search_bytes(b"anything", "(").expect_err("`(` is not valid regex");
+
+        assert!(
+            error.contains("unclosed group"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]
-    #[should_panic(expected = "NotAllowed")]
-    fn backlog_3c_a_pattern_containing_a_newline_panics() {
-        // The same defect by a different route, and a likelier one: the
-        // pattern is valid regex, but `line_terminator(Some(b'\n'))` forbids a
-        // literal newline in it. Pasting two lines into a search box is enough.
-        search_bytes(b"alpha\nbeta", "alpha\nbeta");
+    fn backlog_3c_fixed_a_pattern_containing_a_newline_is_an_error() {
+        // The same defect by a different route, and a likelier one: the pattern
+        // is valid regex, but `line_terminator(Some(b'\n'))` forbids a literal
+        // newline in it. Pasting two lines into a search box is enough.
+        //
+        // The `#[should_panic]` this replaces matched `NotAllowed`, the Debug
+        // name of the error variant. What a caller now receives is the Display
+        // form, which is a sentence.
+        let error = try_search_bytes(b"alpha\nbeta", "alpha\nbeta")
+            .expect_err("a literal newline is rejected by the line terminator");
+
+        assert!(
+            error.contains(r#"the literal "\n" is not allowed"#),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]
@@ -269,11 +306,11 @@ mod documented_defects {
         // `BinaryDetection::quit(b'\x00')` does not stop AT the NUL; it
         // abandons everything it was given. The match is dropped even when it
         // precedes the NUL, and even when it is on an earlier line.
-        assert!(search_bytes(b"needle here", "needle"));
+        assert!(matches(b"needle here", "needle"));
 
-        assert!(!search_bytes(b"needle here\x00tail", "needle"));
-        assert!(!search_bytes(b"needle here\n\x00tail", "needle"));
-        assert!(!search_bytes(b"\x00needle here", "needle"));
+        assert!(!matches(b"needle here\x00tail", "needle"));
+        assert!(!matches(b"needle here\n\x00tail", "needle"));
+        assert!(!matches(b"\x00needle here", "needle"));
     }
 
     #[test]
@@ -282,13 +319,13 @@ mod documented_defects {
         // character of the line and `$` sits behind it. A `$`-anchored pattern
         // therefore misses silently on any Windows-authored file, while the
         // same pattern unanchored matches fine.
-        assert!(search_bytes(b"needle\r\nnext\r\n", "needle"));
-        assert!(!search_bytes(b"needle\r\nnext\r\n", "needle$"));
+        assert!(matches(b"needle\r\nnext\r\n", "needle"));
+        assert!(!matches(b"needle\r\nnext\r\n", "needle$"));
 
         // `^` is unaffected — the CR is at the other end of the line.
-        assert!(search_bytes(b"a\r\nneedle\r\n", "^needle"));
+        assert!(matches(b"a\r\nneedle\r\n", "^needle"));
 
         // And the LF-only case, to show the anchor itself works.
-        assert!(search_bytes(b"needle\nnext\n", "needle$"));
+        assert!(matches(b"needle\nnext\n", "needle$"));
     }
 }

--- a/packages/search/tests/search.rs
+++ b/packages/search/tests/search.rs
@@ -47,6 +47,7 @@ fn matches(haystack: &[u8], pattern: &str) -> bool {
 #[cfg(test)]
 mod search {
     use super::matches;
+    use ::search::try_search_bytes;
 
     const POEM: &str = "One Wiseman came to Jhaampe-town.\n\
                         He set aside both Queen and Crown\n\
@@ -227,6 +228,47 @@ mod search {
     #[test]
     fn test_a_utf8_bom_does_not_hide_the_first_line() {
         assert!(matches(&[0xef, 0xbb, 0xbf, b'n', b'e', b'e', b'd'], "need"));
+    }
+
+    // ---------------------------------------------------------------
+    // Compiled-matcher reuse
+    //
+    // The engine keeps the last compiled pattern and reuses it, because
+    // netgrep calls it once per chunk with the same pattern every time. That
+    // cache is the only piece of state in `lib.rs`, and its failure mode is
+    // the worst one this library has: answering with the previous pattern's
+    // matcher is a wrong boolean, silently, rather than a crash.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_a_changed_pattern_is_not_answered_by_the_previous_matcher() {
+        assert!(matches(b"alpha only", "alpha"));
+        assert!(!matches(b"alpha only", "beta"));
+        assert!(matches(b"alpha only", "alpha"));
+    }
+
+    #[test]
+    fn test_two_patterns_differing_only_in_case_are_not_confused() {
+        // Sharper than the test above: smart case is decided when the pattern
+        // is COMPILED, so these two need genuinely different matchers even
+        // though they are the same length and differ by one bit.
+        assert!(matches(b"one wiseman", "wiseman"));
+        assert!(!matches(b"one wiseman", "Wiseman"));
+        assert!(matches(b"one wiseman", "wiseman"));
+    }
+
+    #[test]
+    fn test_a_failed_compile_does_not_wedge_the_next_pattern() {
+        // A search box produces invalid patterns constantly on the way to a
+        // valid one. The failure is cached — otherwise it would be recompiled
+        // once per chunk per url — so what matters is that the cache is
+        // replaced, not consulted, when the pattern changes.
+        let first = try_search_bytes(b"anything", "(").expect_err("`(` is not valid regex");
+        let second = try_search_bytes(b"anything", "(").expect_err("and still is not");
+
+        assert_eq!(first, second);
+
+        assert!(matches(b"anything", "any"));
     }
 
     #[test]

--- a/packages/search/tests/search.rs
+++ b/packages/search/tests/search.rs
@@ -304,7 +304,7 @@ mod search {
 #[cfg(test)]
 mod documented_defects {
     use super::matches;
-    use search::try_search_bytes;
+    use ::search::try_search_bytes;
 
     #[test]
     fn backlog_3c_fixed_an_invalid_pattern_is_an_error() {


### PR DESCRIPTION
Closes #17. Closes BACKLOG **3c** (P1), **12** (P3) and **13** (P3).

Issue #17 proposed a `Matcher` handle across the WASM boundary. This does not do that — it takes the third
shape that came out of the design conversation, which closes the same two items without widening the API,
without a breaking change, and without manual lifetimes in `Netgrep.ts`. Decision
[0016](docs/decisions/0016-compiled-matcher-memo.md) records why the handle was rejected.

## What changed

`packages/search/src/lib.rs`, and nothing else in either package's source:

- `search_bytes` returns `Result<bool, JsError>`. The generated TypeScript signature is **unchanged** —
  still `(chunk: Uint8Array, pattern: string): boolean` — it throws instead of trapping. **`Netgrep.ts` is
  not touched**: a throw in the promise executor (the cache early-return) rejects, and one in `handleReader`
  reaches the existing `.catch(reject)`.
- The last compiled pattern is kept in a one-entry `thread_local` and reused. Every url in a `searchBatch`
  shares one pattern, so it hits on every chunk after the first. Compile failures are cached too — an
  invalid pattern is what a search box emits on the way to a valid one.
- `Sink::matched` returns `Ok(false)`, stopping at the first match in a chunk.

## Measurements

Native, release, 800 chunks — the issue's worked example of 200 files × 4 chunks. Throwaway harness, no
dependency added (AGENTS.md §6.2), deleted afterwards.

| pattern | 16 KB chunk | 64 KB chunk |
|---|---|---|
| `needle` | 91.2ms → **2.2ms** | 79.4ms → **9.1ms** |
| `(needle\|thimble\|thread)` | 199.9ms → **2.4ms** | 216.4ms → **7.8ms** |
| `\w+dle\b` | 699.8ms → **2.9ms** | 710.6ms → **6.8ms** |
| `n\p{L}+dle` | 2.9s → **20.6ms** | 3.2s → **49.1ms** |

Compilation was **97–99% of the total cost**. Item 12 was filed as a P3 papercut and was closer to the
dominant term; the BACKLOG "Done" row says so.

Item 13, on chunks where every line matches: 16.4ms → 1.3ms at 16 KB, 61.9ms → 1.8ms at 64 KB. Neutral on a
single late match, and behaviourally unobservable — all 59 tests pass either way, which is why measurement is
the only evidence it does anything.

Reusing the `Searcher` as well was measured (a further 14–22%) and **not taken**: a `Searcher` needs `&mut`
where a `RegexMatcher` needs `&self`, so it means mutable state across calls, to save ~0.5µs against a chunk
that took milliseconds to arrive. The number is in 0016 so it is not rediscovered.

## Two things worth a reviewer's attention

**The engine is split in two, and it is not stylistic.** `try_search_bytes` is plain Rust returning
`Result<bool, String>`; `search_bytes` is a two-line wasm wrapper. `JsError` is a wasm-bindgen import that
compiles natively and then panics at runtime with *"cannot call wasm-bindgen imported functions on non-wasm
targets"*. The Rust suite runs natively — without the split, its error-path tests would still have passed,
for entirely the wrong reason.

**The cache is the only state in `lib.rs`, and its failure mode is a silently wrong boolean**, not a crash.
Three tests pin it: a changed pattern is not answered by the old matcher; two patterns differing only in case
are not confused (smart case is decided at *compile* time, so they genuinely need different matchers); a
cached failure does not wedge the valid pattern after it.

## Defect tests

Per AGENTS.md §2.1, the three assertions pinning 3c are inverted in the same PR. Two `#[should_panic]` tests
in `search.rs` become assertions on the error message; the integration test asserting
`rejects.toThrow('unreachable')` now asserts a real diagnostic **and that the same `Netgrep` instance still
answers correctly afterwards** — the thing a trap made impossible, and the claim the deleted README CAUTION
block was standing in for. A second integration test covers the batch path.

## Versions — not bumped

Per AGENTS.md §6.1. When released this wants **`@netgrep/search` 0.3.0** and a republish of
`@netgrep/netgrep` to point at it (its source is unchanged, but the dependency is `workspace:*`) — **search
first**, per §6.5.

## Verified locally

`pnpm build:wasm`, `lint`, `test:rust` (28), `test` (59 = 30 unit + 29 integration), `typecheck`, `build`,
`verify:pack` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)