### PR TITLE
fix(netgrep): find matches that straddle a chunk boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 Operating guide for AI agents working in the **netgrep** repository.
 Canonical source — `CLAUDE.md` points here. Keep this file authoritative; do not fork its content.
 
-Everything below was verified end-to-end on **2026-07-29** (macOS arm64, Node 24.18.0, Rust 1.97.1).
+Everything below was verified end-to-end on **2026-07-30** (macOS arm64, Node 24.18.0, Rust 1.97.1).
 
 ---
 
@@ -38,14 +38,18 @@ Three things will mislead you if you do not know them.
 ### 2.1 Some tests assert behaviour that is WRONG, on purpose
 
 `packages/netgrep/src/lib/Netgrep.integration.spec.ts` ends with a block titled
-**`documented defects (asserting current, incorrect behaviour)`**. Those assertions pin known bugs — a pattern
-straddling a chunk boundary returning `false`, a NUL byte discarding a chunk, and so on.
-`packages/search/tests/search.rs` has a `documented_defects` module doing the same for the ones that live in
+**`documented defects (asserting current, incorrect behaviour)`**. Those assertions pin known bugs — a NUL byte
+discarding a block of lines, a match longer than the 64 KB tail ceiling still spanning a chunk boundary, and so
+on. `packages/search/tests/search.rs` has a `documented_defects` module doing the same for the ones that live in
 the engine, where a failure names `lib.rs` without a browser and a stream in the way.
 
 They are not mistakes and they are not out of date. Their job is to detect *unintended* change during
 dependency work: a test asserting the correct-but-unimplemented behaviour would fail today and tell us
 nothing.
+
+**Several assertions in that block are labelled `(FIXED)` and assert CORRECT behaviour.** They stay, inverted
+in place, with a note saying what they used to claim — that is what the rule below requires, and it is how the
+block records its own history. Do not tidy them out into the suites above.
 
 **If one of them fails, that is a signal, not a nuisance.** Something changed the engine's behaviour. Find out
 what, decide whether the new behaviour is right, and if it is, **invert the assertion in the same PR** with a
@@ -86,22 +90,33 @@ is exactly why it is in this section rather than in a comment somewhere.
 
 | If you… | Then, in the same PR… |
 |---|---|
-| Fix 3a, 3b, 3f, 17 or 18 | Remove or rewrite its entry in the `CAVEATS` array of [`packages/example/src/components/limitations.tsx`](packages/example/src/components/limitations.tsx) |
-| Fix **both** 3b and 18 | Also re-enable the cache in `packages/example/src/hooks/use-corpus-search.ts` and delete the "This demo runs with the cache off" caveat — the workaround exists only because of those two |
+| Fix 3f, 3g, 17 or 18 | Remove or rewrite its entry in the `CAVEATS` array of [`packages/example/src/components/limitations.tsx`](packages/example/src/components/limitations.tsx) |
+| Fix 18 | **Do not** re-enable the demo's cache as part of it. That instruction used to live here and has been retracted — see below |
 | Add a new defect to `docs/BACKLOG.md` | Decide whether a visitor is affected. If so, add a caveat; if not, no action — but make it a decision, not an omission |
 | Change what netgrep returns or costs | Check the hero copy and the `StatsBar` line, which state "one boolean per file" and the 1.15 MB WebAssembly download |
 
-**The four caveats currently on the site map to backlog items like this**, so you can find yours quickly:
+**The three caveats currently on the site map to backlog items like this**, so you can find yours quickly:
 
 | Caveat on the site | Backlog |
 |---|---|
 | One boolean per file | *none* — by design, [decision 0003](docs/decisions/0003-boolean-only-results.md). Will never be "fixed" |
-| Matches spanning two network chunks are missed | **3a** |
-| This demo runs with the cache off | **3b** and **18** |
+| This demo runs with the cache off | *none* — a choice about what the page measures, see below |
 | Binary files stop at the first NUL | **3f** |
 
-Item **17** (`$` on CRLF input) is deliberately *not* on the site: every file in the demo corpus is LF, so it
-cannot be triggered there. If the corpus ever gains a CRLF file, it needs a caveat.
+> [!WARNING]
+> **Do not turn the demo's cache on to close item 18.** This section used to say that fixing 3b and 18 meant
+> re-enabling it and deleting the caveat. 3b is fixed and 18 no longer corrupts the entry, so the safety half
+> of that instruction is satisfied — but the cache stays off for a reason that has nothing to do with defects:
+> **the page measures the network.** A miss drains the stream, which is exactly the condition for caching, so
+> with the cache on every missing file would be answered from memory from the second query onward and the
+> `StatsBar` would report a `Record` lookup as a download. Read the comment in
+> `packages/example/src/hooks/use-corpus-search.ts` before changing it, and treat it as a decision about the
+> demo rather than a consequence of a library fix. See
+> [decision 0018](docs/decisions/0018-line-oriented-tail-buffer.md).
+
+Two items are deliberately *not* on the site, both because the corpus cannot trigger them: **17** (`$` on CRLF
+input — every file is LF) and **3g** (a match longer than 64 KB spanning a chunk boundary — the longest line in
+the corpus is 76 bytes). If the corpus ever gains a CRLF file or a very long line, each needs a caveat.
 
 **Do not delete a caveat to tidy the page.** The list is short because the defects are few, not because the
 page is being edited for length — and it is the only reason a visitor has to trust the rest of it.
@@ -151,7 +166,7 @@ pnpm build:wasm        # REQUIRED FIRST — see §2.2
 | Lint | `pnpm lint` | Biome (JS/TS) **and** clippy (`-D warnings`); `lint:js` / `lint:rust` run one each |
 | Format | `pnpm format` | Biome, writes in place |
 | Typecheck | `pnpm typecheck` | `tsc --noEmit`, TypeScript 7 |
-| Test TS | `pnpm test` | Vitest — **59 tests**: 30 unit in Node, 29 integration in headless Chromium |
+| Test TS | `pnpm test` | Vitest — **77 tests**: 45 unit in Node, 32 integration in headless Chromium |
 | — one suite | `pnpm test:unit` / `pnpm test:browser` | The two Vitest projects separately. `test:unit` needs no WASM and no browser |
 | Test Rust | `pnpm test:rust` | `cargo test`, native, no browser — **28 tests** |
 | Verify packaging | `pnpm verify:pack` | Packs both packages and inspects the tarballs. **Needs `pnpm build` first** |
@@ -282,7 +297,10 @@ packages/
     → published as @netgrep/search
 
   netgrep/           TypeScript wrapper. Streaming + batching + caching.
-    src/lib/Netgrep.ts               the whole public API (~225 lines)
+    src/lib/Netgrep.ts               the whole public API (~305 lines)
+    src/lib/splitAtLastLine.ts       the chunk-boundary tail arithmetic, pure and
+                                     unit-tested on its own. NOT re-exported by
+                                     index.ts — see decision 0018
     src/lib/data/*.ts                5 type definitions, one per file
     src/lib/Netgrep.spec.ts          unit suite; mocks fetch and the engine
     src/lib/Netgrep.integration.spec.ts   real WASM through the real streaming loop,
@@ -386,16 +404,23 @@ in `packages/search/tests/search.rs`. Read §2.1 before touching any of them.
 
 | | Where | Effect |
 |---|---|---|
-| Chunk-boundary false negatives | `Netgrep.ts` search loop | A match spanning two `fetch` chunks is never found. Silent, non-deterministic. |
-| Poisoned partial cache | `Netgrep.ts` cache paths | Early resolution caches a prefix; later searches answer `false` for text never downloaded. |
-| One NUL discards the chunk | `lib.rs`, `BinaryDetection::quit` | A match is dropped even when it precedes the NUL. |
+| A match over 64 KB spans a boundary | `Netgrep.ts`, `MAX_TAIL_BYTES` | What remains of the chunk-boundary defect (**3g**). The retained tail is the incomplete trailing *line*, which is exact; past a 64 KB ceiling it degrades to a byte window, so a single match longer than that is still lost at a seam. Needs a line over 64 KB — unreachable in prose. |
+| One NUL discards the searched block | `lib.rs`, `BinaryDetection::quit` | A match is dropped even when it precedes the NUL. |
 | `$` misses on CRLF input | `lib.rs`, no `.crlf(true)` | The line terminator is `\n`, so `\r` sits between the text and `$`. A `$`-anchored pattern silently misses on Windows-authored files. |
-| Concurrent searches double a cache entry | `Netgrep.ts`, no in-flight tracking | Two searches of one url started together both fetch and both append, so the entry holds the file twice — joined with no separator, forming a line the file never had. |
+| Concurrent searches of one url both fetch | `Netgrep.ts`, no in-flight tracking | Wasted bandwidth (**18**). The answers and the cache entry are correct. |
 
 The last two were found while broadening the test suite on 2026-07-29 and are backlog items 17 and 18.
 
-The first two **interact** — fixing either naively (by draining the stream) destroys the early-resolution
-property that is the whole point of the project. See
+**Two entries left this table on 2026-07-30**, both closed by
+[decision 0018](docs/decisions/0018-line-oriented-tail-buffer.md): chunk-boundary false negatives and the
+poisoned partial cache. They had to be fixed together, though not for the reason recorded here — the shared
+"draining the stream destroys early resolution" is a failure mode of naive fixes, not a coupling. The real
+coupling was that the boundary defect *suppressed* early resolution, so closing it alone would have made the
+cache defect fire more often, in the default configuration.
+
+That decision also narrowed the two rows that remain: what the engine is handed is now a block of complete
+lines rather than a network chunk, which changed the shape of the NUL defect's blast radius, and the cache
+entry is assigned from a drained stream rather than appended to, which removed the corrupting half of 18. See
 [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md#known-limitations--correctness-caveats) and
 [decision 0002](docs/decisions/0002-search-while-downloading.md).
 
@@ -412,6 +437,30 @@ property that is the whole point of the project. See
 - `.editorconfig` is authoritative for whitespace.
 - Comments should explain *why*, especially where the code looks wrong but is not. The repository has several
   such places, and they are commented for a reason.
+- **Keep them terse. Density is right; length is not.** Comment the same places, in fewer words: state the
+  point in the first sentence and stop, prefer one dense sentence to three, and cut restatement and
+  scene-setting. A long comment buries the thing it exists to say. Applies to TSDoc bodies and test comments
+  too, not just inline `//`.
+- **Comments must stand alone. Do not send the reader to a document to find the point.** No `see decision
+  0018`, no `see caveat 2`, no `AGENTS.md §2.3` standing in for the reason. Say the thing:
+  *"Deliberately not configurable — a safety valve for input netgrep is not aimed at, not a tuning knob."*
+  **Test it by deleting the reference.** If the comment still teaches you what you needed, it was never
+  carrying weight; if it collapses, write the missing sentence instead of the pointer.
+
+  This is not the same rule as the one above, and it wins where they pull against each other: brevity is not a
+  licence to replace an explanation with a citation. The long form still belongs in
+  [`docs/decisions/`](docs/decisions/) — that is what keeps comments short — but the comment has to make sense
+  to someone who never opens it.
+
+  **Why:** cross-references rot silently and asymmetrically. Nothing checks them, and the code is edited far
+  more often than the prose about it, so the pointer outlives the thing it pointed at. On 2026-07-30 four
+  decision records, `ARCHITECTURE.md` and §2.3 of this file were all still describing a defect that had just
+  been fixed. A comment that needed one of them to be read would have been actively misleading.
+
+  **The one exception is a bare backlog item number**, which is a stable label rather than an explanation —
+  `// BACKLOG 3a: searching these in isolation misses a word that continues in the next chunk.` The numbers
+  never change (see [`docs/BACKLOG.md`](docs/BACKLOG.md)) and §2.1's defect-test traceability is built on them.
+  The sentence after the label still has to do the explaining.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,8 @@ is exactly why it is in this section rather than in a comment somewhere.
 
 | If you… | Then, in the same PR… |
 |---|---|
-| Fix 3f, 3g, 17 or 18 | Remove or rewrite its entry in the `CAVEATS` array of [`packages/example/src/components/limitations.tsx`](packages/example/src/components/limitations.tsx) |
+| Fix 3f | Remove or rewrite its entry in the `CAVEATS` array of [`packages/example/src/components/limitations.tsx`](packages/example/src/components/limitations.tsx) — it is the only open defect with one |
+| Fix 3g, 17 or 18 | Nothing on the site to remove: none of them has an entry, for the reasons below. Check that still holds rather than assuming it |
 | Fix 18 | **Do not** re-enable the demo's cache as part of it. That instruction used to live here and has been retracted — see below |
 | Add a new defect to `docs/BACKLOG.md` | Decide whether a visitor is affected. If so, add a caveat; if not, no action — but make it a decision, not an omission |
 | Change what netgrep returns or costs | Check the hero copy and the `StatsBar` line, which state "one boolean per file" and the 1.15 MB WebAssembly download |
@@ -115,8 +116,9 @@ is exactly why it is in this section rather than in a comment somewhere.
 > [decision 0018](docs/decisions/0018-line-oriented-tail-buffer.md).
 
 Two items are deliberately *not* on the site, both because the corpus cannot trigger them: **17** (`$` on CRLF
-input — every file is LF) and **3g** (a match longer than 64 KB spanning a chunk boundary — the longest line in
-the corpus is 76 bytes). If the corpus ever gains a CRLF file or a very long line, each needs a caveat.
+input — every file is LF) and **3g** (inside a line longer than 64 KB, a long match is lost and `^` can match at
+a window edge — the corpus's longest line is 76 bytes). If it ever gains a CRLF file or a very long line, each
+needs a caveat.
 
 **Do not delete a caveat to tidy the page.** The list is short because the defects are few, not because the
 page is being edited for length — and it is the only reason a visitor has to trust the rest of it.
@@ -297,7 +299,7 @@ packages/
     → published as @netgrep/search
 
   netgrep/           TypeScript wrapper. Streaming + batching + caching.
-    src/lib/Netgrep.ts               the whole public API (~305 lines)
+    src/lib/Netgrep.ts               the whole public API (~300 lines)
     src/lib/splitAtLastLine.ts       the chunk-boundary tail arithmetic, pure and
                                      unit-tested on its own. NOT re-exported by
                                      index.ts — see decision 0018
@@ -404,7 +406,7 @@ in `packages/search/tests/search.rs`. Read §2.1 before touching any of them.
 
 | | Where | Effect |
 |---|---|---|
-| A match over 64 KB spans a boundary | `Netgrep.ts`, `MAX_TAIL_BYTES` | What remains of the chunk-boundary defect (**3g**). The retained tail is the incomplete trailing *line*, which is exact; past a 64 KB ceiling it degrades to a byte window, so a single match longer than that is still lost at a seam. Needs a line over 64 KB — unreachable in prose. |
+| Anchors and long matches inside a >64 KB line | `Netgrep.ts`, `MAX_TAIL_BYTES` | What remains of the chunk-boundary defect (**3g**). The retained tail is the incomplete trailing *line*, which is exact; past a 64 KB ceiling it degrades to a byte window. Inside such a line a match longer than 64 KB is lost, **and** `^` can match at the window's first byte. Needs a line over 64 KB — unreachable in prose. |
 | One NUL discards the searched block | `lib.rs`, `BinaryDetection::quit` | A match is dropped even when it precedes the NUL. |
 | `$` misses on CRLF input | `lib.rs`, no `.crlf(true)` | The line terminator is `\n`, so `\r` sits between the text and `$`. A `$`-anchored pattern silently misses on Windows-authored files. |
 | Concurrent searches of one url both fetch | `Netgrep.ts`, no in-flight tracking | Wasted bandwidth (**18**). The answers and the cache entry are correct. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,10 @@ most common way to lose an hour here.
 All from the repository root. [AGENTS.md §4](AGENTS.md#4-commands) has the full list and the caveats.
 
 ```bash
-pnpm test          # Vitest — 58 tests (30 in Node, 28 in headless Chromium)
+pnpm test          # Vitest — 77 tests (45 in Node, 32 in headless Chromium)
 pnpm test:unit     # just the Node half — no WASM build and no browser needed
 pnpm test:browser  # just the browser half
-pnpm test:rust     # cargo test — 25 tests, native, no browser
+pnpm test:rust     # cargo test — 28 tests, native, no browser
 pnpm typecheck     # tsc --noEmit
 pnpm lint          # Biome (JS/TS) and clippy (-D warnings); lint:js / lint:rust run one each
 pnpm format        # Biome, writes in place
@@ -130,15 +130,19 @@ Then, in rough order of how likely each is to bite:
 
 - **Some tests assert behaviour that is deliberately wrong.** `Netgrep.integration.spec.ts` ends with a block
   titled *documented defects*, and `packages/search/tests/search.rs` with a `documented_defects` module. They
-  pin known bugs — a match straddling a chunk boundary returning `false`, a NUL byte discarding a chunk. If
-  one fails, something changed the engine; work out what, and if the new behaviour is right, **invert the
+  pin known bugs — a NUL byte discarding a block of lines, a match longer than the 64 KB tail ceiling still
+  spanning a chunk boundary. Several are labelled `(FIXED)` and assert *correct* behaviour, inverted in place
+  with a note about what they used to claim; that is the block recording its own history, not clutter. If one
+  fails, something changed the engine; work out what, and if the new behaviour is right, **invert the
   assertion in the same PR** with a note. Do not quietly "fix" the test.
   [AGENTS.md §2.1](AGENTS.md#21-some-tests-assert-behaviour-that-is-wrong-on-purpose) has the full story.
 - **Fixing a defect also means updating the demo site.** <https://netgrep.diegopasquali.com/> lists the
   defects that affect its visitors, so a fix that leaves the list alone ships a page warning about a bug
   that no longer exists. Remove the entry from the `CAVEATS` array in
-  `packages/example/src/components/limitations.tsx` in the same PR — and if you fix both 3b and 18, re-enable
-  the demo's cache too. **No test catches this**, which is why it is worth remembering.
+  `packages/example/src/components/limitations.tsx` in the same PR. **No test catches this**, which is why it
+  is worth remembering. (Note the demo's cache stays off even though the defects that justified it are fixed —
+  it is off so the page's timings keep measuring the network. Do not switch it on as a side effect of closing
+  backlog 18.)
   [AGENTS.md §2.3](AGENTS.md#23-️-fixing-a-defect-is-not-finished-until-the-demo-site-stops-warning-about-it).
 - **Do not bump dependencies as a side effect.** A version change is its own deliberate, tested change. If a
   tool suggests one while you are doing something else, add it to `docs/BACKLOG.md`.
@@ -147,7 +151,13 @@ Then, in rough order of how likely each is to bite:
 - **ESM only, and relative imports carry a `.js` extension** even though the sources are `.ts`.
   `moduleResolution` is `nodenext`, which requires it.
 - **Comments explain *why*.** Several places in this repository look wrong and are not; they are commented
-  for a reason. Keep that density.
+  for a reason. Keep that density — but keep them short: make the point in the first sentence and stop.
+- **And keep them standalone.** A comment should not send you to a document to find out what it means — no
+  `see decision 0018`, no `see caveat 2`. Delete the reference and check the comment still stands; if it does
+  not, write the missing sentence rather than the pointer. Cross-references rot and nothing checks them. Bare
+  backlog item numbers are fine, since they are stable labels rather than explanations. Long-form rationale
+  still lives in [`docs/decisions/`](docs/decisions/) — that is what keeps comments short — but the comment has
+  to make sense without it.
 
 Releases fire from pushed git tags and publish under the maintainer's npm token. **Version bumps and
 publishing are maintainer-only** — please do not include them in a pull request.

--- a/README.md
+++ b/README.md
@@ -197,13 +197,13 @@ Netgrep is experimental, and the following are real and **documented rather than
 tests so they cannot change unnoticed; the full analysis is in
 [`docs/ARCHITECTURE.md`](https://github.com/dgopsq/netgrep/blob/main/docs/ARCHITECTURE.md#known-limitations--correctness-caveats).
 
-- **A single match longer than 64 KB can still span a network chunk boundary.** Netgrep holds back the
-  incomplete last *line* of each chunk and prepends it to the next, which is exact — a match can never cross a
-  newline — so ordinary text is unaffected no matter how the network splits the response. The exception is a
-  line with no terminator in 64 KB, such as minified JavaScript or a one-line data dump: past that ceiling the
-  retained bytes become a plain 64 KB window, and a match longer than the window is lost at the boundary.
-  Newline-free input is also answered more slowly, because nothing can be searched until the ceiling fills or
-  the download ends.
+- **Inside a line longer than 64 KB, results are approximate.** Netgrep holds back the incomplete last *line*
+  of each chunk and prepends it to the next, which is exact — a match can never cross a newline — so ordinary
+  text is unaffected no matter how the network splits the response. The exception is a line with no terminator
+  in 64 KB, such as minified JavaScript or a one-line data dump: past that ceiling the retained bytes become a
+  plain 64 KB window, so a match **longer** than the window is lost, and `^` can match at a window edge where no
+  line actually begins. Newline-free input is also answered more slowly, because nothing can be searched until
+  the ceiling fills or the download ends.
 - **A file containing a NUL byte reports no match** for the block of lines containing it, even when the match
   came earlier. Binary detection abandons what it is given rather than stopping at the NUL.
 - **`$` does not match on CRLF files.** The line terminator is `\n`, so on Windows-authored text the `\r`
@@ -224,6 +224,10 @@ code; this one describes the gap until the next release.
   incomplete. An entry is now written **only once the whole file has been read**, so a search that resolves
   early caches nothing and the next one re-fetches. `enableMemoryCache: false` is no longer a workaround for
   anything.
+
+  Worth knowing: this means the cache only fills on a search that reads to the end — a miss, or a match on the
+  final line. A URL that matches early is re-fetched every time. That is the trade for never answering from a
+  prefix, and it is why repeat *hits* cost network while repeat *misses* do not.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -193,30 +193,37 @@ instance. See the limitation below before relying on it.
 
 ## Known limitations
 
-Netgrep is experimental, and the following are real, present in the published package, and **documented
-rather than fixed**. They are pinned by tests so they cannot change unnoticed; the full analysis is in
+Netgrep is experimental, and the following are real and **documented rather than fixed**. They are pinned by
+tests so they cannot change unnoticed; the full analysis is in
 [`docs/ARCHITECTURE.md`](https://github.com/dgopsq/netgrep/blob/main/docs/ARCHITECTURE.md#known-limitations--correctness-caveats).
 
-- **A match spanning two network chunks is missed.** Chunks are searched as they arrive and are never
-  overlapped, so a pattern straddling the boundary is invisible. This is a silent `false`, and because it
-  depends on how the network happens to chunk the response it is not reproducible on demand. Short patterns
-  in reasonably sized files are unlikely to hit it; it is not impossible.
-- **The cache can answer a later search wrongly.** A search resolves the moment a chunk matches and stops
-  downloading, so the cache is left holding only the beginning of the file, with nothing marking it
-  incomplete. A later search on the same URL for a *different* pattern reads that partial copy and can
-  return `false` for text further down the file. Set `enableMemoryCache: false` if this matters more than
-  the network savings.
-- **A file containing a NUL byte reports no match** for the chunk containing it, even when the match came
-  earlier. Binary detection abandons the whole chunk rather than stopping at the NUL.
+- **A single match longer than 64 KB can still span a network chunk boundary.** Netgrep holds back the
+  incomplete last *line* of each chunk and prepends it to the next, which is exact — a match can never cross a
+  newline — so ordinary text is unaffected no matter how the network splits the response. The exception is a
+  line with no terminator in 64 KB, such as minified JavaScript or a one-line data dump: past that ceiling the
+  retained bytes become a plain 64 KB window, and a match longer than the window is lost at the boundary.
+  Newline-free input is also answered more slowly, because nothing can be searched until the ceiling fills or
+  the download ends.
+- **A file containing a NUL byte reports no match** for the block of lines containing it, even when the match
+  came earlier. Binary detection abandons what it is given rather than stopping at the NUL.
 - **`$` does not match on CRLF files.** The line terminator is `\n`, so on Windows-authored text the `\r`
   sits between your text and the anchor: `needle$` misses what `needle` finds. `^` is unaffected.
-- **Two concurrent searches of the same URL are not de-duplicated.** Both download, and both append to the
-  same cache entry, so it ends up holding the file twice with no separator between the copies — which can
-  make a later search match a line the file never contained. Await one search of a URL before starting
-  another, or set `enableMemoryCache: false`.
+- **Two concurrent searches of the same URL are not de-duplicated.** Both download the file. The answers are
+  correct and the cache entry is correct; the second request is simply wasted. Await one search of a URL before
+  starting another if that matters.
 
-The first two exist because searching *while downloading* is the entire point of the project — the naive
-fixes for both are to wait for the full file, which is the thing netgrep is built not to do.
+### Fixed, and not yet in a published release
+
+Both of these are fixed on `main` and **still present in the version on npm**. The list above describes the
+code; this one describes the gap until the next release.
+
+- **A match spanning two network chunks used to be missed** — a silent `false` that depended on how the network
+  chunked the response. See the first limitation above for what remains of it.
+- **The cache could answer a later search wrongly.** A search resolves the moment it finds a match and stops
+  downloading, which used to leave the cache holding only the beginning of the file with nothing marking it
+  incomplete. An entry is now written **only once the whole file has been read**, so a search that resolves
+  early caches nothing and the next one re-fetches. `enableMemoryCache: false` is no longer a workaround for
+  anything.
 
 ## Documentation
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -211,13 +211,13 @@ Fixing it also removed the mirror-image false *positives* that were never separa
 in isolation looked to `^` like the start of a line and to `$` like the end of one, so both invented matches at
 a seam.
 
-> **Residual — a single match longer than 64 KB, split across chunks.** A line with no terminator in it would
-> otherwise buffer an entire response, so past a 64 KB ceiling (`MAX_TAIL_BYTES`, not configurable) the tail
-> degrades to a plain window on the last 64 KB. A match starting before that window and ending after the buffer
-> is still lost. It needs one line longer than 64 KB *and* a match spanning most of it, so it is unreachable in
-> hand-written text — the demo corpus is 2.6 MB of prose whose longest line is 76 bytes. Pinned by
-> `BACKLOG 3a (RESIDUAL)` in `Netgrep.integration.spec.ts`, alongside the control case: the same match arriving
-> in **one** chunk is found, because the buffer is searched whole before the window is taken.
+> **Residual (item 3g) — a line longer than 64 KB.** Such a line would otherwise buffer an entire response, so
+> past a 64 KB ceiling (`MAX_TAIL_BYTES`, not configurable) the tail degrades to a plain window on the last
+> 64 KB. Inside such a line, two things break in opposite directions: a match **longer** than 64 KB is lost, and
+> `^` can match at the window's first byte because a windowed tail starts mid-line and the engine cannot be told
+> so. Both need a line longer than 64 KB, so both are unreachable in hand-written text — the demo corpus is
+> 2.6 MB of prose whose longest line is 76 bytes. Pinned by the two `BACKLOG 3g` tests in
+> `Netgrep.integration.spec.ts`, each alongside its control case.
 
 Newline-free input is answered more slowly than before, since nothing is searched until the ceiling fills or
 the stream ends. Correct either way — the end-of-stream flush catches a file smaller than the ceiling.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,7 +39,7 @@ below are documented rather than hidden, and why the API has stayed a boolean.
 ┌───────────────────────────▼─────────────────────────────────────┐
 │ packages/netgrep  — @netgrep/netgrep (TypeScript, ESM)           │
 │   streaming, batching, in-memory cache, abort, error shaping     │
-│   awaits init() once, then calls search_bytes per chunk          │
+│   awaits init() once, then search_bytes per block of whole lines │
 └───────────────────────────┬─────────────────────────────────────┘
                             │ workspace:*
 ┌───────────────────────────▼─────────────────────────────────────┐
@@ -112,6 +112,11 @@ third is `regex-automata`'s DFA and Unicode tables.
 
 `src/lib/Netgrep.ts` is the entire public surface. `src/lib/data/` holds five types, one per file.
 
+`src/lib/splitAtLastLine.ts` sits beside it and is **not** re-exported by `index.ts` — `index.ts` is
+`export * from './lib/Netgrep.js'`, so anything exported from that file would become public API. It is a
+separate module rather than a private function so that its edge cases can be unit-tested directly, with a
+tiny cap, instead of only through a >64 KB fixture in a browser.
+
 ### Public API
 
 | Method | Returns | Semantics |
@@ -134,81 +139,132 @@ search(url, pattern)
   ├─ await wasmReady          ← init() started once at module load
   │
   ├─ cache enabled AND cache[url] exists?
-  │     └─ yes → search_bytes(cache[url], pattern) → resolve   ← see caveat 2
+  │     └─ yes → search_bytes(cache[url], pattern) → resolve
+  │              (always the WHOLE file — entries are only written from a
+  │               drained stream, so there are no boundaries inside one)
   │
   └─ fetch(url, { signal })
        └─ res.body.getReader()
             └─ handleReader(reader)   ── recursive
                  ├─ read() → { value, done }
-                 ├─ done          → resolve(result: false)
-                 ├─ search_bytes(chunk, pattern)   ← see caveat 1
-                 ├─ cache enabled → append chunk to cache[url]
+                 │
+                 ├─ done → search_bytes(tail, pattern)  ← the final line, which
+                 │         │                              nothing has looked at
+                 │         ├─ cache enabled → cache[url] = join(chunks)
+                 │         └─ resolve(result)
+                 │
+                 ├─ cache enabled → chunks.push(value)
+                 ├─ splitAtLastLine(tail ++ value, 64 KB)
+                 │    ├─ searched ← whole lines
+                 │    └─ tail     ← the incomplete trailing line, held back
+                 ├─ searched non-empty → search_bytes(searched, pattern)
                  ├─ matched       → resolve(result: true)   ← stops reading
                  └─ not matched   → recurse
 ```
 
+Two things about that shape are load-bearing, and both are [decision
+0018](decisions/0018-line-oriented-tail-buffer.md):
+
+- **The engine only ever sees whole lines.** A match cannot span a `\n`, so the incomplete trailing line is the
+  exact carry-over between chunks — which is why a boundary cannot hide a match, and why it cannot fake a line
+  start for `^` or a line end for `$` either. `splitAtLastLine` falls back to a 64 KB byte window when a line
+  outgrows the ceiling, which is the one case where a match can still be lost (caveat 1).
+- **The cache is written once, at `done`.** Resolving early therefore caches *nothing*, rather than caching a
+  prefix that later answers questions about text it never downloaded (caveat 2). Chunks are only collected when
+  the cache is enabled, so a search with it off holds one chunk plus the tail.
+
 Errors are normalised to strings by `serializeError` — `Error.message`, or `JSON.stringify` for
-non-`Error` throws.
+non-`Error` throws. The recursive `handleReader` call carries a `.catch(reject)`: the promise it returns is not
+chained to the one the executor was handed, so without it a rejection from any chunk after the first would be
+an unhandled rejection and the search would never settle.
 
 ---
 
 ## Known limitations & correctness caveats
 
-All verified against the source in this repository, and each is **pinned by a test that asserts the current,
-wrong behaviour** — in `Netgrep.integration.spec.ts`, and for the ones that live in the engine also in the
-`documented_defects` module of `packages/search/tests/search.rs`. See
+All verified against the source in this repository, and each is **pinned by a test** — in
+`Netgrep.integration.spec.ts`, and for the ones that live in the engine also in the `documented_defects` module
+of `packages/search/tests/search.rs`. Those tests assert the current, wrong behaviour; the ones marked
+`(FIXED)` there were inverted in place when the defect was closed. See
 [`../AGENTS.md` §2.1](../AGENTS.md#21-some-tests-assert-behaviour-that-is-wrong-on-purpose) before touching
 any of them.
 
-**Documented, not fixed.** Caveats 1 and 2 interact: fixing either one naively reintroduces or worsens the
-other.
+**Documented, not fixed.** Caveats 1 and 2 were both closed on 2026-07-30 by
+[decision 0018](decisions/0018-line-oriented-tail-buffer.md), and they had to be closed together: caveat 1 was
+suppressing early resolution, so fixing it alone would have made caveat 2 fire more often, in the default
+configuration. Caveat 1's *residual* is what remains, and is described below.
 
-### 1. Chunk-boundary false negatives — `Netgrep.ts`, the `search_bytes` call in `handleReader`
+### 1. Chunk-boundary false negatives — FIXED, with a residual
 
-`search_bytes(u8Array, pattern)` is called with **one chunk at a time**, and chunks are never overlapped or
-joined before searching. A pattern that straddles the boundary between two `fetch` chunks is never seen by the
-matcher.
+`search_bytes` used to be called with **one chunk at a time**, never overlapped or joined, so a pattern
+straddling the boundary between two `fetch` chunks was never seen by the matcher. A silent wrong answer whose
+trigger depended on how the network split the response.
 
-Silent wrong answer: `result: false` for a file that does contain the pattern. Whether it triggers depends on
-network chunking, so it is non-deterministic across runs and effectively untestable by luck.
+`Netgrep.search` now retains the **incomplete trailing line** of everything read so far and prepends it to the
+next chunk, handing the engine only whole lines (`splitAtLastLine`). That is exact rather than approximate,
+because a match can never span a `\n` — grep-regex strips the terminator out of character classes and rejects
+patterns containing a literal one. The invariant is asserted by
+`test_a_match_cannot_span_a_line_terminator`, which names its JavaScript dependant in a comment: **if that
+test breaks, this caveat is back and no JavaScript test will notice.**
 
-*Any fix requires retaining a tail buffer of at least `pattern.length - 1` bytes (more for regex patterns,
-where the maximum match length is not knowable from the pattern alone) and prepending it to the next chunk.*
+Fixing it also removed the mirror-image false *positives* that were never separately tracked. A chunk searched
+in isolation looked to `^` like the start of a line and to `$` like the end of one, so both invented matches at
+a seam.
 
-### 2. Poisoned partial cache — `Netgrep.ts`, `handleReader` and the cache-hit branch of `search`
+> **Residual — a single match longer than 64 KB, split across chunks.** A line with no terminator in it would
+> otherwise buffer an entire response, so past a 64 KB ceiling (`MAX_TAIL_BYTES`, not configurable) the tail
+> degrades to a plain window on the last 64 KB. A match starting before that window and ending after the buffer
+> is still lost. It needs one line longer than 64 KB *and* a match spanning most of it, so it is unreachable in
+> hand-written text — the demo corpus is 2.6 MB of prose whose longest line is 76 bytes. Pinned by
+> `BACKLOG 3a (RESIDUAL)` in `Netgrep.integration.spec.ts`, alongside the control case: the same match arriving
+> in **one** chunk is found, because the buffer is searched whole before the window is taken.
 
-`upsertMemoryCache` appends each chunk as it arrives, but the loop **resolves and stops reading the moment a
-chunk matches**. The cache is then left holding only the *prefix* of the file downloaded so far, with no
-marker that it is incomplete.
+Newline-free input is answered more slowly than before, since nothing is searched until the ceiling fills or
+the stream ends. Correct either way — the end-of-stream flush catches a file smaller than the ceiling.
 
-A later search on the same URL for a different pattern takes the cache-hit branch at the top of `search` and
-searches that truncated prefix — returning `false` for text that was never downloaded.
+### 2. Poisoned partial cache — FIXED
 
-Reproduction: search a large file for a term near the top (populates a short prefix), then search the same URL
-for a term near the bottom → `false`.
+`upsertMemoryCache` appended each chunk as it arrived, but the loop **resolves and stops reading the moment a
+match is found**, so the cache was left holding only the *prefix* downloaded so far, with no marker that it was
+incomplete. A later search for a different pattern took the cache-hit branch and searched that truncated
+prefix, returning `false` for text that was never downloaded.
 
-*Any fix needs a completeness flag per cache entry, so partial entries are only ever used to resume, never to
-answer.*
+The entry is now written **only when the reader reports `done`**, so a partial one is never created rather than
+created and flagged. An early resolution therefore caches nothing and the next search re-fetches — a wasted
+request in place of a confident wrong answer. Note that a match in the *final* chunk still caches nothing: the
+stream is not known to be complete until `done`, which is one read later.
 
-### 3. Unbounded cache growth — `Netgrep.ts`, `upsertMemoryCache`
+This is narrower than the completeness flag originally proposed here, and deliberately so: a partial entry
+cannot resume a download either, and nothing needed it to.
+
+### 3. Unbounded cache growth — `Netgrep.ts`, the `memoryCache` record
 
 The cache is a plain `Record<string, Uint8Array>` with no eviction, no size cap and no TTL. It retains the
-full bytes of every file searched for the lifetime of the `Netgrep` instance. `upsertMemoryCache` also
-reallocates and copies the whole accumulated buffer **per chunk**, making cache population O(n²) in bytes.
+full bytes of every file searched for the lifetime of the `Netgrep` instance.
+
+The O(n²) population this caveat also described is gone: chunks are collected in an array and joined once, and
+they are only collected at all when the cache is enabled — so a search with it off retains one chunk plus the
+tail rather than the whole file.
 
 ### 4. No completion signal from `searchBatchWithCallback`
 
 It returns `void` and starts every search eagerly with no concurrency limit. Callers cannot await it, cannot
 detect completion, and a batch of N URLs opens N simultaneous connections.
 
-### 5. One NUL byte discards the whole chunk — `lib.rs`, `BinaryDetection::quit`
+### 5. One NUL byte discards the whole searched block — `lib.rs`, `BinaryDetection::quit`
 
-`BinaryDetection::quit(b'\x00')` does not stop *at* the NUL — it abandons the entire chunk. A match is
+`BinaryDetection::quit(b'\x00')` does not stop *at* the NUL — it abandons everything it was handed. A match is
 dropped even when it occurs before the NUL, and even on an earlier line. Any remote file containing a stray
 NUL therefore reports "no match" for content that is demonstrably present.
 
 Quitting on binary input is a reasonable ripgrep default; the surprise is that the API cannot distinguish
 "binary, not searched" from "no match", because the API is a boolean.
+
+Decision 0018 changed the *shape* of this without fixing it. What the engine is handed is no longer the network
+chunk but the block of complete lines within it, so how far a NUL reaches now depends on where the last `\n`
+falls rather than on where the network split the response — and a match on an earlier line survives *if* the
+NUL happens to land in the held-back partial line. Both behaviours are pinned, so that accident is not mistaken
+for a fix.
 
 ### 6. `$` does not match on CRLF input — `lib.rs`, no `.crlf(true)` on the matcher
 
@@ -220,17 +276,17 @@ Silent, and it depends on who wrote the file rather than on anything the caller 
 `RegexMatcherBuilder::crlf(true)` is the one-line fix; it is a matching-semantics change, so it is a
 deliberate task rather than a drive-by.
 
-### 7. Concurrent searches of one url double its cache entry — `Netgrep.ts`, `search`
+### 7. Concurrent searches of one url both fetch it — `Netgrep.ts`, `search`
 
 Nothing tracks a download already in flight. Two searches of the same url started before either resolves both
-`fetch`, and both append what they read to the same cache entry.
+`fetch`, so the file is downloaded twice.
 
-The waste is the obvious half. The sharp half is that the entry then holds bytes the file never contained:
-the copies are joined with no separator, so the seam forms a line that exists nowhere and a later search
-matches it. A file of `needle` caches as `needleneedle`, and `^needleneedle$` answers `true`.
+The waste is what remains. The sharp half was fixed by decision 0018: the cache entry used to be *appended* to
+per chunk, so the two copies were joined with no separator and the seam formed a line that existed nowhere — a
+file of `needle` cached as `needleneedle`, and `^needleneedle$` answered `true`. The entry is now assigned once
+from a drained stream, so both searches write the same complete bytes.
 
-*A fix needs a per-url promise registry so the second caller awaits the first, which also removes the
-duplicate request.*
+*A fix for the remaining half needs a per-url promise registry so the second caller awaits the first.*
 
 ---
 
@@ -308,12 +364,13 @@ components straight out of `rust-toolchain.toml`.
 
 | Suite | Runner | What it covers |
 |---|---|---|
-| `Netgrep.spec.ts` | Vitest in **Node**, 30 tests | Orchestration only — `fetch` **and** `@netgrep/search` are mocked. Result shape, metadata, abort plumbing, error capture and serialisation, config defaults, cache scope and accumulation, and all three public methods including `searchBatchWithCallback`. |
-| `Netgrep.integration.spec.ts` | Vitest in **headless Chromium** (Playwright), 29 tests | **The real engine through the real streaming loop, in a real browser.** Only `fetch` is faked, and only to remove the network: bytes still travel through a real `ReadableStream`, still arrive chunked, still get matched by the compiled `search_bytes`. |
+| `splitAtLastLine.spec.ts` | Vitest in **Node**, 11 tests | The chunk-boundary tail arithmetic in isolation, with `cap = 8` so the over-the-ceiling cases fit on one line. A pure function, so no mocks at all. |
+| `Netgrep.spec.ts` | Vitest in **Node**, 34 tests | Orchestration only — `fetch` **and** `@netgrep/search` are mocked. Result shape, metadata, abort plumbing, error capture and serialisation, config defaults, cache scope and accumulation, and all three public methods including `searchBatchWithCallback`. |
+| `Netgrep.integration.spec.ts` | Vitest in **headless Chromium** (Playwright), 32 tests | **The real engine through the real streaming loop, in a real browser.** Only `fetch` is faked, and only to remove the network: bytes still travel through a real `ReadableStream`, still arrive chunked, still get matched by the compiled `search_bytes`. |
 | `packages/search/tests/search.rs` | `cargo test`, native, 28 tests | `try_search_bytes` as pure Rust — bytes in, bool out. Regex features, smart case, line semantics, encoding and BOM handling, binary detection, and the compiled-matcher cache. No browser involved. |
 | `scripts/verify-pack.mjs` | Node, in CI | The published tarballs: required files present, no `workspace:` range survived packing, no version drift. |
 
-The split between the first three is deliberate: anything that depends only on the bytes is cheapest to pin
+The split between the Rust and TypeScript suites is deliberate: anything that depends only on the bytes is cheapest to pin
 in Rust, where a failure names the engine; anything about streaming, batching or caching belongs in the
 TypeScript suites. They overlap at exactly one point — smart case — because it is the behaviour most likely
 to move silently under a dependency bump, and knowing *which* layer moved is worth one duplicated assertion.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -10,7 +10,7 @@ items move to the bottom rather than disappearing.
 Rules that apply to all of it: dependency changes are never a side effect of other work, and releases are
 human-triggered only. See [`../AGENTS.md` §6](../AGENTS.md#6-hard-rules).
 
-Verified against the repository on **2026-07-29** (macOS arm64, Node 24.18.0, Rust 1.97.1).
+Verified against the repository on **2026-07-30** (macOS arm64, Node 24.18.0, Rust 1.97.1).
 
 ---
 
@@ -33,32 +33,38 @@ means inverting its assertion in the same PR.**
 > array of `packages/example/src/components/limitations.tsx`. Leave it alone and the site goes on warning
 > the world about a bug you just fixed.
 >
-> **3a, 3b, 3f and 18 each have a caveat there. 3b and 18 also keep the demo's cache switched off** — fix
-> both and the workaround goes too. Nothing checks this for you; CI will be green either way. See
+> **3f has a caveat there. 18 keeps the demo's cache switched off** — though as of 0018 that is a *choice*
+> rather than a workaround, because a warm cache stops the page's timings measuring the network. Nothing checks
+> this for you; CI will be green either way. See
 > [`../AGENTS.md` §2.3](../AGENTS.md#23-️-fixing-a-defect-is-not-finished-until-the-demo-site-stops-warning-about-it).
 
-**3a and 3b interact — do not fix either in isolation**, and 3b and 18 want the same per-url promise
-registry.
+**3a and 3b were fixed together on 2026-07-30** — see the *Done* table and
+[decision 0018](decisions/0018-line-oriented-tail-buffer.md). They had to be: 3a was suppressing early
+resolution, so fixing it alone would have made 3b fire more often, in the default configuration. 3a left a
+residual, recorded as **3g** below.
 
-### 3a. Chunk-boundary false negatives — `packages/netgrep/src/lib/Netgrep.ts`
+### 3g. A match longer than 64 KB can still span a chunk boundary — `packages/netgrep/src/lib/Netgrep.ts`
 
-Each `fetch` chunk is searched independently, so a pattern spanning two chunks is never matched. Silent wrong
-answer, non-deterministic because it depends on network chunking.
+What 3a's fix does not cover. `splitAtLastLine` retains the incomplete trailing *line* between chunks, which is
+exact — a match cannot span a `\n`. But a line with no terminator in it would buffer an entire response, so
+past a 64 KB ceiling the tail degrades to a plain window on the last 64 KB, and a match starting before that
+window and ending after the buffer is still lost.
 
-Needs a retained tail buffer prepended to the next chunk. The buffer size is the design question: the maximum
-match length of an arbitrary regex is not derivable from the pattern, so it has to be a configured cap.
+Needs one line longer than 64 KB **and** a match spanning most of it, so it is unreachable in hand-written
+text: the demo corpus is 2.6 MB of prose whose longest line is 76 bytes. Reachable in minified JavaScript or a
+single-line data dump.
 
-### 3b. Poisoned partial cache — `packages/netgrep/src/lib/Netgrep.ts`
+Pinned by `BACKLOG 3a (RESIDUAL)` in `Netgrep.integration.spec.ts`, together with the control case that must
+not regress — the same match arriving in **one** chunk is found, because the buffer is searched whole before
+the window is taken.
 
-Resolving on first match leaves the cache holding only a prefix of the file, unmarked as incomplete. A later
-search for a different pattern reads that prefix and returns `false` for text never downloaded.
+**Deliberately not on the demo site**, for the same reason as item 17: the corpus cannot trigger it. Recorded in
+the comment block of `limitations.tsx` so that stays a decision rather than an omission.
 
-Needs a completeness flag per entry: partial entries may resume a download, never answer a query.
+Not obviously worth fixing. Raising the ceiling trades memory for a case nobody has hit; removing it means
+buffering without bound. Left recorded rather than planned.
 
-A naive fix for either 3a or 3b — always draining the stream — destroys the early-resolution property that is
-the entire point of the project. See [decision 0002](decisions/0002-search-while-downloading.md).
-
-### 3f. A single NUL byte discards the whole chunk — `packages/search/src/lib.rs`
+### 3f. A single NUL byte discards the whole searched block — `packages/search/src/lib.rs`
 
 `BinaryDetection::quit(b'\x00')` does not merely stop at the NUL; it abandons the entire chunk. A match is
 dropped even when it occurs *before* the NUL, and even on an earlier line.
@@ -72,6 +78,11 @@ dropped even when it occurs *before* the NUL, and even on an earlier line.
 Quitting on binary input is a reasonable ripgrep default; the surprise is that a boolean API cannot
 distinguish "binary, not searched" from "no match". Options: `BinaryDetection::none()`, or surfacing the
 distinction — which is an API change and therefore out of scope today.
+
+Decision 0018 changed its blast radius without fixing it. The engine is handed the block of complete lines in a
+chunk rather than the chunk, so how far a NUL reaches now depends on where the last `\n` falls, and a match on
+an earlier line survives *if* the NUL lands in the held-back partial line. Incidental, and pinned in both
+directions so it is not mistaken for a fix. **Fix it in `lib.rs` or not at all.**
 
 ### 17. `$` never matches on CRLF input — `packages/search/src/lib.rs`
 
@@ -92,25 +103,29 @@ change, so it wants its own tested commit.
 Found on 2026-07-29 while broadening the test suite. Pinned in the `documented_defects` module of
 `packages/search/tests/search.rs`.
 
-### 18. Concurrent searches of one url double its cache entry — `packages/netgrep/src/lib/Netgrep.ts`
+### 18. Concurrent searches of one url both fetch it — `packages/netgrep/src/lib/Netgrep.ts`
 
 Nothing tracks a download already in flight. Two searches of the same url started before either resolves both
-`fetch`, and both `upsertMemoryCache` what they read into the same entry.
+`fetch`, so the file is downloaded twice.
 
-The duplicate request is the cheap half. The expensive half is that the entry then holds bytes the file never
-contained: the copies are joined with no separator, so the seam forms a line that exists nowhere.
+`searchBatchWithCallback` makes this easy to hit — it starts every search eagerly with no concurrency limit, so
+a corpus listing one url twice reaches it immediately. The demo hits it across *runs* rather than within one: a
+keystroke aborts run N while run N+1 starts, so two searches of each url overlap.
+
+A per-url promise registry fixes it: the second caller awaits the first instead of fetching.
+
+**Amended 2026-07-30 — the expensive half is already fixed.** This entry used to record that the entry held
+bytes the file never contained, because each search *appended* what it read:
 
 ```
 file:   "needle"
-cache:  "needleneedle"        after two concurrent searches
+cache:  "needleneedle"        before decision 0018
         ~ "^needleneedle$"  ->  true
 ```
 
-`searchBatchWithCallback` makes this easy to hit — it starts every search eagerly with no concurrency limit,
-so a corpus listing one url twice reaches it immediately.
-
-A per-url promise registry fixes both halves: the second caller awaits the first instead of fetching. That is
-the same registry a fix for 3b would want, so the two are worth doing together.
+[Decision 0018](decisions/0018-line-oriented-tail-buffer.md) writes the entry once, assigned from a drained
+stream, so both searches now store the same complete bytes. What is left is a wasted request. That also means
+this no longer shares a fix with 3b, which is closed.
 
 Found on 2026-07-29 while broadening the test suite. Pinned in `Netgrep.integration.spec.ts`.
 
@@ -151,10 +166,13 @@ Removing it means patching `grep-searcher`, i.e. reintroducing the fork that was
 
 ## P3 — Papercuts
 
-### 11. `upsertMemoryCache` is O(n²)
+### 19. The cache has no eviction, size cap or TTL — `packages/netgrep/src/lib/Netgrep.ts`
 
-Reallocates and copies the whole accumulated buffer per chunk. Collect chunks in an array and join once. The
-cache also has no eviction, size cap or TTL — it retains every file searched for the lifetime of the instance.
+It retains the full bytes of every file searched for the lifetime of the `Netgrep` instance. A long-lived page
+searching a large corpus grows monotonically.
+
+This is what remained of item **11** after [decision 0018](decisions/0018-line-oriented-tail-buffer.md) fixed
+its O(n²) half; renumbered rather than reopened, because item numbers are stable and 11 is now in *Done*.
 
 ---
 
@@ -165,6 +183,9 @@ analysis was wrong.
 
 | # | Item | Outcome |
 |---|---|---|
+| 3a | Chunk-boundary false negatives | **Fixed, and the design question in [issue #20](https://github.com/dgopsq/netgrep/issues/20) had a wrong premise.** That issue said the tail size must be a configured cap because the maximum match length of an arbitrary regex is not derivable from the pattern. True — but it is derivable from the *data*: a match can never span a `\n`, because grep-regex strips the terminator out of character classes and rejects patterns containing a literal one. So the exact carry-over is the incomplete trailing **line**, and no cap is needed for correctness. `MAX_TAIL_BYTES` (64 KB, not configurable) exists only so a line with no terminator cannot buffer a 500 MB response; past it the tail degrades to a byte window, which is item **3g**. Fixing it also removed the never-tracked mirror-image false *positives*, where a seam looked like a line start to `^` and a line end to `$`. Early resolution became line-granular, which costs two extra reads in one test and nothing against real 16–64 KB chunks. Four assertions inverted. See [0018](decisions/0018-line-oriented-tail-buffer.md). |
+| 3b | Poisoned partial cache | **Fixed, and it had to ship with 3a.** Not for the reason recorded here — "a naive fix drains the stream" is a shared failure mode of bad fixes, not a coupling. The real one: 3a was *suppressing* early resolution, so closing it alone would have left more searches resolving early, more prefixes cached, and a regression in the default configuration. The fix is smaller than the completeness flag this entry proposed: write the entry only when the reader reports `done`, so a partial one is never created. A partial entry cannot resume a download either, and nothing needed it to. Note a match in the *final* chunk still caches nothing — `done` is one read later. |
+| 11 | `upsertMemoryCache` is O(n²) | **Fixed** as a side effect of 3b, because "collect chunks and join once" is what deferring the write requires. Chunks are also only collected when the cache is *on*, so a search with it off no longer retains the whole file — it had been paying the memory cost for a cache it was not using. The no-eviction half of this entry is not fixed and is now item **19**. |
 | 3c | Panic on invalid pattern | **Fixed.** `search_bytes` returns `Result<bool, JsError>`, so a stray `(` — or a literal newline, which the `\n` line terminator forbids — is a rejected promise carrying the regex crate's own diagnostic instead of `RuntimeError: unreachable`. The generated TypeScript signature did not change, so `Netgrep.ts` needed no edit. The engine is now split into a plain-Rust `try_search_bytes` and a two-line wasm wrapper, because `JsError` cannot be constructed on a native target and the Rust suite runs natively. Three assertions inverted. See [0016](decisions/0016-compiled-matcher-memo.md). |
 | 12 | Regex recompiled per chunk | **Fixed, and it was not a papercut.** A one-entry `thread_local` cache of the last compiled pattern; compile failures cached alongside successes. Over 800 16 KB chunks: a literal 91.2ms → 2.2ms, a Unicode class 2.9s → 20.6ms. Compilation was **97–99% of the total cost**, not the P3 nuisance this entry called it. The compiled-matcher *handle* this entry recommended was considered and rejected — it puts `.free()` on four exit paths of a promise executor and breaks a package whose whole surface is one function. See [0016](decisions/0016-compiled-matcher-memo.md). |
 | 13 | `MemSink` does not short-circuit | **Fixed.** `Ok(false)` stops at the first match; `match_count: u64` became `found: bool`. On chunks where every line matches, 16.4ms → 1.3ms at 16 KB and 61.9ms → 1.8ms at 64 KB; neutral on a single late match. Behaviourally unobservable — all 59 tests pass either way — so measurement is the only evidence it does anything. |

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -43,20 +43,24 @@ means inverting its assertion in the same PR.**
 resolution, so fixing it alone would have made 3b fire more often, in the default configuration. 3a left a
 residual, recorded as **3g** below.
 
-### 3g. A match longer than 64 KB can still span a chunk boundary — `packages/netgrep/src/lib/Netgrep.ts`
+### 3g. Anchors and long matches are unreliable inside a line longer than 64 KB — `packages/netgrep/src/lib/Netgrep.ts`
 
 What 3a's fix does not cover. `splitAtLastLine` retains the incomplete trailing *line* between chunks, which is
 exact — a match cannot span a `\n`. But a line with no terminator in it would buffer an entire response, so
-past a 64 KB ceiling the tail degrades to a plain window on the last 64 KB, and a match starting before that
-window and ending after the buffer is still lost.
+past a 64 KB ceiling the tail degrades to a plain window on the last 64 KB. Two consequences, in both
+directions:
+
+- **A match longer than 64 KB is lost**, because it starts before the retained window and ends after the buffer.
+- **`^` can match where no line begins.** A windowed tail starts mid-line and the engine cannot be told so, so
+  it anchors to the window's first byte. A false positive, unlike every other entry in this list.
 
 Needs one line longer than 64 KB **and** a match spanning most of it, so it is unreachable in hand-written
 text: the demo corpus is 2.6 MB of prose whose longest line is 76 bytes. Reachable in minified JavaScript or a
 single-line data dump.
 
-Pinned by `BACKLOG 3a (RESIDUAL)` in `Netgrep.integration.spec.ts`, together with the control case that must
-not regress — the same match arriving in **one** chunk is found, because the buffer is searched whole before
-the window is taken.
+Pinned by the two `BACKLOG 3g` tests in `Netgrep.integration.spec.ts`, each with the control case that must not
+regress — a match arriving complete in **one** chunk is found, because the buffer is searched whole before the
+window is taken, and `^` does not match when the window is never flushed on its own.
 
 **Deliberately not on the demo site**, for the same reason as item 17: the corpus cannot trigger it. Recorded in
 the comment block of `limitations.tsx` so that stays a decision rather than an omission.

--- a/docs/decisions/0002-search-while-downloading.md
+++ b/docs/decisions/0002-search-while-downloading.md
@@ -24,18 +24,31 @@ the whole point is to never assemble the string.
 - Composes with `AbortSignal` for cancel-on-keystroke.
 
 **Costs:**
-- **Correctness: patterns straddling a chunk boundary are missed.** Chunks are searched in isolation with no
+- ~~**Correctness: patterns straddling a chunk boundary are missed.** Chunks are searched in isolation with no
   overlap retained, so a match spanning the boundary is invisible. Silent false negative, dependent on
-  non-deterministic network chunking. See `ARCHITECTURE.md` caveat 1.
+  non-deterministic network chunking.~~ **Fixed 2026-07-30**: the streaming loop retains the incomplete
+  trailing *line* of each chunk and prepends it to the next, which is exact because a match cannot span a `\n`.
+  Early resolution is preserved in full — it simply becomes line-granular rather than chunk-granular. What
+  remains is a residual for lines longer than 64 KB; see [0018](0018-line-oriented-tail-buffer.md) and
+  `ARCHITECTURE.md` caveat 1.
 - ~~The regex is recompiled per chunk (the `RegexMatcherBuilder` in `lib.rs`'s `search_bytes`), discarding the
   most expensive part of the work on every iteration.~~ **Fixed 2026-07-29**: the engine caches the last
   compiled pattern, so chunking no longer multiplies compilation. It was the largest cost this decision
   carried — 97–99% of per-chunk time. See [0016](0016-compiled-matcher-memo.md).
 - Resolving early stops *reading* but does not cancel the underlying request, so bytes may keep arriving.
-- Interacts badly with the memory cache — the cache is left holding a partial file. See
-  [0006](0006-in-memory-cache.md) and `ARCHITECTURE.md` caveat 2.
+- ~~Interacts badly with the memory cache — the cache is left holding a partial file.~~ **Fixed 2026-07-30**
+  by writing the cache entry only once the stream has drained, so early resolution leaves no entry rather than
+  a partial one. See [0006](0006-in-memory-cache.md), [0018](0018-line-oriented-tail-buffer.md) and
+  `ARCHITECTURE.md` caveat 2.
 - Requires a real streaming `fetch`; there is no fallback path for environments without it.
 
-The boundary bug is the price paid for this design and was evidently not addressed. A correct version needs a
-retained tail buffer prepended to the next chunk — bounded by the maximum possible match length, which for
-arbitrary regex is not derivable from the pattern and must therefore be a configured cap.
+The boundary bug was the price paid for this design and went unaddressed for years. **The analysis in this
+paragraph, which stood here until 2026-07-30, was wrong in an instructive way**, and it is left as written
+above the correction because it is the reasoning that kept the bug open: it concluded that the tail must be
+"bounded by the maximum possible match length, which for arbitrary regex is not derivable from the pattern and
+must therefore be a configured cap."
+
+The bound is not derivable from the *pattern*. It is derivable from the *data*: a match can never span a `\n`,
+so the incomplete trailing line is an exact carry-over and no cap is needed for correctness. Looking for the
+bound in the wrong place made the fix look like it required a guess, and a guess is what kept it from being
+made. See [0018](0018-line-oriented-tail-buffer.md).

--- a/docs/decisions/0006-in-memory-cache.md
+++ b/docs/decisions/0006-in-memory-cache.md
@@ -18,8 +18,9 @@ const defaultConfig: NetgrepConfig = { enableMemoryCache: true };
 ```
 
 On a cache hit, `search_bytes` runs once over the stored bytes and resolves immediately, skipping `fetch`
-entirely (the cache-hit branch at the top of `Netgrep.search`). While streaming, each chunk is appended via
-`upsertMemoryCache`.
+entirely (the cache-hit branch at the top of `Netgrep.search`). While streaming, chunks are collected and the
+entry is written once, when the reader reports `done` — see the amendment below; this used to append per chunk
+via `upsertMemoryCache`.
 
 The cache is per-instance, so a consumer can scope or discard it by managing the `Netgrep` object's lifetime.
 
@@ -48,3 +49,26 @@ point of [0002](0002-search-while-downloading.md).
 
 A correct design tracks completeness per entry: partial entries may be used to *resume* a download, never to
 *answer* a query.
+
+## Amendment (2026-07-30) — defects 1 and 3 are fixed, by a smaller change than the one proposed above
+
+See [0018](0018-line-oriented-tail-buffer.md). **The entry is written only when the reader reports `done`**, so:
+
+- **Defect 1 is gone.** A partial entry is never created, rather than created and flagged. That is narrower than
+  the completeness tracking recommended above, and deliberately so — a partial entry cannot resume a download
+  either, and nothing in the library needed it to. The cost is a re-fetch where there used to be a wrong
+  answer. Note that a match in the *final* chunk still caches nothing: the stream is not known to be complete
+  until `done`, which is one read later.
+- **Defect 3 is gone.** Deferring the write requires collecting chunks and joining once, which is exactly what
+  that defect asked for. Chunks are also only collected when the cache is *enabled* — before this, a search with
+  `enableMemoryCache: false` was paying to retain a whole file for a cache it never wrote to.
+- **Defect 2 remains** and is now backlog item 19.
+
+The "cannot be fixed independently of the chunk-boundary bug" claim above held up, though not for the reason
+given. Draining the stream is a failure mode of naive fixes to either, not a coupling. The real coupling ran the
+other way: the chunk-boundary bug was *suppressing* early resolution, because a search whose match straddled a
+boundary missed and therefore drained. Fixing it alone would have left more searches resolving early and more
+prefixes cached — a regression in the default configuration.
+
+One consequence for callers: **`enableMemoryCache: false` is no longer a workaround for a correctness defect.**
+It is now only a memory/bandwidth trade.

--- a/docs/decisions/0011-tests-that-assert-known-bugs.md
+++ b/docs/decisions/0011-tests-that-assert-known-bugs.md
@@ -4,13 +4,16 @@
 
 ## Context
 
-netgrep has known, unfixed correctness bugs: a pattern straddling a `fetch` chunk boundary is missed, a
-partial cache answers later queries, a single NUL byte discards a chunk, `$` misses on CRLF input. (The
-invalid-pattern trap was on this list until 2026-07-29; see the second amendment below.) They are documented in [`../ARCHITECTURE.md`](../ARCHITECTURE.md#known-limitations--correctness-caveats)
-and tracked in [`../BACKLOG.md`](../BACKLOG.md).
+netgrep has known, unfixed correctness bugs: a single NUL byte discards a block of lines, `$` misses on CRLF
+input, concurrent searches of one url both fetch it, and a match longer than the 64 KB tail ceiling can still
+span a chunk boundary. (The invalid-pattern trap was on this list until 2026-07-29, and the chunk-boundary and
+partial-cache bugs until 2026-07-30; see the amendments below.) They are documented in
+[`../ARCHITECTURE.md`](../ARCHITECTURE.md#known-limitations--correctness-caveats) and tracked in
+[`../BACKLOG.md`](../BACKLOG.md).
 
-Fixing them is out of scope for dependency work: the first two interact, and a naive fix to either destroys
-the early-resolution property that is the entire point of the project ([0002](0002-search-while-downloading.md)).
+Fixing them is out of scope for dependency work, and for a long time the chunk-boundary and partial-cache bugs
+looked mutually entangled besides — a naive fix to either destroys the early-resolution property that is the
+entire point of the project ([0002](0002-search-while-downloading.md)).
 
 That left a gap. A large dependency migration — `wasm-bindgen` across 44 minor versions, a ripgrep fork
 dropped, a whole JS toolchain replaced — needed to support the claim "behaviour is identical". Nothing in the
@@ -61,3 +64,22 @@ assertion was inverted in the same PR. That is the mechanism working exactly as 
 > asserting `rejects.toThrow('unreachable')` became one asserting a real diagnostic plus the thing the trap
 > had made impossible to assert — that the same instance still answers correctly afterwards. Both keep their
 > `BACKLOG 3c` label with a `(FIXED)` marker and a note saying what they used to claim, following 3e.
+
+> **Amended a third time (2026-07-30).** BACKLOG **3a** (chunk-boundary false negatives) and **3b** (poisoned
+> partial cache) were fixed by [0018](0018-line-oriented-tail-buffer.md), and four assertions were inverted in
+> the same PR. Two things about that are worth recording, because neither is what this record anticipated.
+>
+> **The defect tests carried the design, not just the bug.** 3a had two pinned assertions, and the second — the
+> same search answering differently once the cache was warm — was the one that made the 3a/3b coupling
+> concrete. Reading them together is what surfaced that fixing 3a alone would make 3b fire *more* often, since
+> 3a had been suppressing the early resolution that poisons the cache. A prose note in the backlog would not
+> have shown that; two assertions sitting in the same block did.
+>
+> **One test failed that was not supposed to be affected at all.** The 3f (NUL byte) assertion for a match on
+> an earlier line went green, because the engine is now handed a block of complete lines rather than a network
+> chunk, and in that fixture the NUL fell outside the block. 3f is **not** fixed — the same bytes with a
+> trailing newline still lose the match. The response was to keep the defect pinned with an accurate fixture
+> *and* add an assertion for the incidental change, so the accident is recorded rather than mistaken for a fix.
+> This is the case §2.1's instructions do not quite cover: a defect test can go green because a *different*
+> change moved the boundary the defect operates on, and the right answer is neither "invert it" nor "restore
+> the old fixture and say nothing".

--- a/docs/decisions/0017-example-as-hosted-demo.md
+++ b/docs/decisions/0017-example-as-hosted-demo.md
@@ -70,6 +70,11 @@ cache serves repeats — and does not touch the early-resolution property the pa
 Defect 3a (chunk-boundary false negatives) is **not** avoidable this way and is live on the page. It is named
 in the site's own "Known limitations" section, along with the boolean-only result and the NUL-byte behaviour.
 
+> **Amended 2026-07-30.** 3a and 3b are fixed ([0018](0018-line-oriented-tail-buffer.md)), so the
+> chunk-boundary caveat has been removed from the page. The cache is still off, but no longer as a workaround:
+> a warm cache would stop the page's timings measuring the network, which is the one thing it exists to show.
+> The reasoning in this section is left as written, because it is why the site said what it said.
+
 ### Why Vite rather than staying on webpack
 
 shadcn's tooling assumes Vite or Next. Beyond that: the example being on webpack was incidental coverage that
@@ -88,8 +93,8 @@ netgrep does and what it costs, and not sell it; it does not ask the demo to arg
 fold.
 
 So the hero states the capability plainly and the honesty moved down into a **Scope** section, which is still
-on the page and still names every live defect — including chunk-boundary false negatives, which affect this
-very demo. The costs are still stated: the stats bar reports the corpus size and the 1.15 MB WebAssembly
+on the page and still names every live defect. When this was written that included chunk-boundary false
+negatives, which affected the demo directly; that one is fixed and its caveat is gone. The costs are still stated: the stats bar reports the corpus size and the 1.15 MB WebAssembly
 download on every query. The competitor comparison survives too, repositioned from self-deprecation to
 routing: "if you need ranking and snippets, an index is the right tool."
 

--- a/docs/decisions/0018-line-oriented-tail-buffer.md
+++ b/docs/decisions/0018-line-oriented-tail-buffer.md
@@ -71,17 +71,22 @@ and the part that has to wait:
 
 ```ts
 let cut = buffer.lastIndexOf(LINE_FEED) + 1;      // 0 when no line has completed
-const overflowing = buffer.length - cut > cap;
-if (overflowing) cut = buffer.length - cap;
+const windowed = buffer.length - cut > cap;
+if (windowed) cut = buffer.length - cap;
 
 return {
-  searched: overflowing ? buffer : buffer.subarray(0, cut),
+  searchable: windowed ? buffer : buffer.subarray(0, cut),
   tail: buffer.subarray(cut),
+  tailSearched: windowed,
 };
 ```
 
-The streaming loop keeps `tail`, searches `searched` when it is non-empty, and searches the leftover tail once
-when the reader reports `done` — at which point it is a genuine final line rather than a fragment.
+The streaming loop keeps `tail`, searches `searchable` when it is non-empty, and searches the leftover tail when
+the reader reports `done` — at which point it is a genuine final line rather than a fragment.
+
+`tailSearched` is why the flush is conditional. When windowed, `searchable` is the whole buffer and therefore
+already covered the retained bytes, so flushing them again would both rescan up to `cap` bytes and — because a
+windowed tail begins mid-line — let `^` match at its first byte.
 
 `MAX_TAIL_BYTES` is **64 KB and not configurable**. It is a safety valve, not a tuning knob: without it a
 single line with no terminator would buffer an entire 500 MB response. One contract is easier to document than
@@ -89,8 +94,8 @@ a family of them, and the public surface is deliberately small ([`AGENTS.md` §1
 
 | input | regime | guarantee |
 |---|---|---|
-| every line under 64 KB — all prose, Markdown, source | line tail | **a chunk boundary never hides a match** |
-| a line over 64 KB — minified JS, a single-line dump | 64 KB byte window | a match shorter than 64 KB is never hidden |
+| every line under 64 KB — all prose, Markdown, source | line tail | **a chunk boundary is invisible**: it neither hides a match nor invents one |
+| a line over 64 KB — minified JS, a single-line dump | 64 KB byte window | a match shorter than 64 KB is never hidden, but a longer one may be, and `^` may match at a window edge (item **3g**) |
 
 The measurement the issue asked for: the demo corpus is 2.6 MB over 54,496 lines, and its longest line is
 **76 bytes** — every one of the 56 files maxes out between 74 and 76. The ceiling has 862× headroom there, and
@@ -100,22 +105,30 @@ on every chunk of every file.
 
 ### Two things that fall out for free
 
-**`^` and `$` stop lying at boundaries.** Because each chunk was searched as though it were a whole document,
-the seam looked like a line start to `^` and a line end to `$`, so both invented matches — the mirror image of
-3a, never separately tracked, and just as network-dependent:
+**`^` and `$` stop lying at boundaries, for any line under the ceiling.** Because each chunk was searched as
+though it were a whole document, the seam looked like a line start to `^` and a line end to `$`, so both
+invented matches — the mirror image of 3a, never separately tracked, and just as network-dependent:
 
 ```
 serve(['hello won', 'derful world'])   ~ 'won$'     ->  true    # before
                                        ~ '^derful'  ->  true    # before
 ```
 
-Handing the engine only complete lines fixes both directions at once.
+Handing the engine only complete lines fixes both directions at once, *while there are complete lines to hand
+it*. A windowed tail starts mid-line and there is no way to tell the engine so, so `^` anchors to the window's
+first byte — a false positive with the same precondition as 3g's false negative, and now pinned beside it. The
+first version of this change made it worse by also searching the windowed tail alone at end of stream, which
+turned a single-chunk newline-free file into a false positive; `tailSearched` removes that case.
 
-**Every byte is scanned exactly once.** The issue noted that re-searching a byte-window tail means a match
-wholly inside it is found twice — harmless for a boolean, but a problem if
+**Every byte is scanned exactly once — in the line regime.** The issue noted that re-searching a byte-window
+tail means a match wholly inside it is found twice: harmless for a boolean, but a problem if
 [issue #3](https://github.com/dgopsq/netgrep/issues/3) (return the matching line) ever lands, since the same
-line could be reported from two chunks. Complete-line blocks do not overlap, so that is designed out rather
-than deferred.
+line could be reported from two chunks. Complete-line blocks do not overlap, so that is designed out there.
+
+It does **not** hold once a line outgrows the ceiling: `searchable` is then the whole buffer *and* the last
+`cap` bytes are retained, so those bytes are scanned again in the next buffer. The end-of-stream flush no longer
+adds a third pass over them — `splitAtLastLine` reports `tailSearched` and the loop skips a tail it has already
+seen — but within the windowed regime the overlap is inherent. #3 would have to handle it.
 
 ## And the cache, because 3a could not ship without it
 

--- a/docs/decisions/0018-line-oriented-tail-buffer.md
+++ b/docs/decisions/0018-line-oriented-tail-buffer.md
@@ -1,0 +1,201 @@
+# 0018 — Retain the incomplete trailing *line* between chunks, and cache only a drained stream
+
+**Status: ACCEPTED (2026-07-30).** Closes [`BACKLOG`](../BACKLOG.md) items **3a**, **3b** and **11**, narrows
+**18**, and records why the fixed byte cap proposed in
+[issue #20](https://github.com/dgopsq/netgrep/issues/20) was not the design taken.
+
+## Context
+
+`Netgrep.search` handed the engine one `fetch` chunk at a time, with no overlap between them ever:
+
+```ts
+const u8Array = new Uint8Array(value);
+const result = search_bytes(u8Array, pattern);
+```
+
+So a match straddling the seam between two chunks was not found — item **3a**. It was the worst shape a defect
+can take here: it returned `false`, which is indistinguishable from a genuine no-match, and *which* chunk a
+match landed in was decided by how the network split the response, so the same query against the same file
+could answer differently twice. Risk scaled with the number of boundaries, which meant it was worst on exactly
+the large files netgrep is otherwise the right tool for.
+
+The obvious fixes are all worse. Draining the stream before searching destroys resolve-on-first-match, which
+[decision 0002](0002-search-while-downloading.md) says is the entire point of the project. So the fix had to
+retain a bounded overlap and keep searching as bytes arrive.
+
+## Considered: a configured byte cap (issue #20)
+
+The issue proposed retaining a fixed number of bytes from each chunk:
+
+```ts
+const TAIL = config?.maxMatchBytes ?? 1024;
+tail = buf.subarray(Math.max(0, buf.length - TAIL));
+```
+
+Its reasoning for a cap was that the maximum match length of an arbitrary regex is not derivable from the
+pattern — `.*`, `a{1,10000}` and `(foo|bar)+` have no useful bound, and the `regex` crate does not expose one.
+True as far as it goes, and it makes the guarantee permanently conditional: *matches up to N bytes are never
+missed at a boundary; longer ones may still be.* The issue was candid that this "does not actually fix the bug,
+it bounds it", and that `maxMatchBytes` would be a hard option to document because explaining it requires
+explaining the residual defect.
+
+**The premise was wrong, though.** The bound is not derivable from the pattern, but it does not have to be:
+it is derivable from the *data*.
+
+## The invariant this rests on
+
+A match can never span a `\n`. `packages/search/src/lib.rs` builds its matcher with
+`line_terminator(Some(b'\n'))` and its searcher without multi-line mode, and grep-regex enforces that in both
+directions — it strips the terminator out of character classes, and it *rejects* any pattern containing a
+literal one:
+
+```
+"alpha.beta"          => false     "alpha\nbeta"    => Err("the literal \"\\n\" is not allowed in a regex")
+"(?s)alpha.beta"      => false     "alpha\\nbeta"   => Err(same)
+"alpha[^x]beta"       => false     "alpha\\x0abeta" => Err(same)
+"alpha[\\s\\S]beta"   => false
+```
+
+So the largest unit a match can occupy is one line, and **the exact carry-over between two chunks is the
+incomplete trailing line** — no guess required.
+
+This invariant is now asserted, with all of the escape hatches above, by
+`test_a_match_cannot_span_a_line_terminator` in `packages/search/tests/search.rs`. That test carries a comment
+naming `splitAtLastLine` as its dependant, because the failure mode is nasty: if a dependency bump let a
+pattern match across a newline, 3a would silently come back and **no JavaScript test would notice**.
+
+## Decision
+
+`splitAtLastLine(buffer, cap)` divides the retained tail plus the new chunk into the part that is whole lines
+and the part that has to wait:
+
+```ts
+let cut = buffer.lastIndexOf(LINE_FEED) + 1;      // 0 when no line has completed
+const overflowing = buffer.length - cut > cap;
+if (overflowing) cut = buffer.length - cap;
+
+return {
+  searched: overflowing ? buffer : buffer.subarray(0, cut),
+  tail: buffer.subarray(cut),
+};
+```
+
+The streaming loop keeps `tail`, searches `searched` when it is non-empty, and searches the leftover tail once
+when the reader reports `done` — at which point it is a genuine final line rather than a fragment.
+
+`MAX_TAIL_BYTES` is **64 KB and not configurable**. It is a safety valve, not a tuning knob: without it a
+single line with no terminator would buffer an entire 500 MB response. One contract is easier to document than
+a family of them, and the public surface is deliberately small ([`AGENTS.md` §1](../../AGENTS.md#1-what-this-project-is)).
+
+| input | regime | guarantee |
+|---|---|---|
+| every line under 64 KB — all prose, Markdown, source | line tail | **a chunk boundary never hides a match** |
+| a line over 64 KB — minified JS, a single-line dump | 64 KB byte window | a match shorter than 64 KB is never hidden |
+
+The measurement the issue asked for: the demo corpus is 2.6 MB over 54,496 lines, and its longest line is
+**76 bytes** — every one of the 56 files maxes out between 74 and 76. The ceiling has 862× headroom there, and
+costs nothing to set generously, because a line tail retains the actual partial line rather than a fixed
+window. That is the economic difference from the issue's design, where `TAIL` bytes are retained *and rescanned*
+on every chunk of every file.
+
+### Two things that fall out for free
+
+**`^` and `$` stop lying at boundaries.** Because each chunk was searched as though it were a whole document,
+the seam looked like a line start to `^` and a line end to `$`, so both invented matches — the mirror image of
+3a, never separately tracked, and just as network-dependent:
+
+```
+serve(['hello won', 'derful world'])   ~ 'won$'     ->  true    # before
+                                       ~ '^derful'  ->  true    # before
+```
+
+Handing the engine only complete lines fixes both directions at once.
+
+**Every byte is scanned exactly once.** The issue noted that re-searching a byte-window tail means a match
+wholly inside it is found twice — harmless for a boolean, but a problem if
+[issue #3](https://github.com/dgopsq/netgrep/issues/3) (return the matching line) ever lands, since the same
+line could be reported from two chunks. Complete-line blocks do not overlap, so that is designed out rather
+than deferred.
+
+## And the cache, because 3a could not ship without it
+
+`AGENTS.md` §7 and the backlog both say 3a and 3b interact. The stated reason — that a naive fix to either
+drains the stream — is a shared failure mode of bad fixes, not a coupling. The real coupling is sharper:
+
+**fixing 3a makes 3b worse.** 3a was *suppressing* early resolution. A search whose match straddled a boundary
+missed, so it drained the stream and cached the whole file, harmlessly. Once boundaries stop hiding matches,
+more searches resolve early, and every early resolution left a cache entry holding only the prefix it happened
+to read, unmarked as incomplete — so a later search for a term further down the same file answered `false`
+about text that had never been downloaded. The cache is **on by default**, so 3a alone would have shipped a
+regression to the default configuration.
+
+The fix is to write the entry **only when the reader reports `done`**, which is less code than the per-chunk
+upsert it replaces:
+
+```ts
+private commitMemoryCache(url: string, chunks: Array<Uint8Array>) {
+  if (!this.config.enableMemoryCache) return;
+  this.memoryCache[url] = concatBytes(chunks);
+}
+```
+
+A partial entry is never created, rather than created and flagged. This is a narrower fix than the completeness
+flag the backlog proposed — a partial entry cannot resume a download either — and it costs a re-fetch where
+there used to be a wrong answer.
+
+It also closes two more:
+
+- **Item 11** (`upsertMemoryCache` is O(n²)): collecting chunks and joining once is exactly what that item
+  asks for. Chunks are collected *only when the cache is on*, so a search with it off no longer needs to hold
+  more than the tail.
+- **The sharp half of 18**: the entry is now assigned from a complete file rather than appended to per chunk,
+  so two concurrent searches overwrite each other with identical bytes instead of joining the file to itself
+  and forming a line that exists in no file. The duplicate *fetch* is untouched and 18 stays open; it wants the
+  per-url promise registry, which this change did not add.
+
+## Consequences
+
+**Early resolution is line-granular, not chunk-granular.** A chunk with no terminator in it searches nothing
+and grows the tail. Against real 16–64 KB `fetch` chunks this is invisible — a line completes inside the chunk
+it starts in. Against the deliberately tiny chunks in the test suite it is visible and asserted:
+`stops reading as soon as a line matches` reads three of POEM's eight 16-byte chunks rather than one, because
+the poem's 34-byte first line only completes in the third.
+
+**Newline-free input is slower to answer.** Today's code searched every chunk of a minified file; this buffers
+up to 64 KB before the first search. Not a wrong answer — the end-of-stream flush catches a file smaller than
+the ceiling — just a later one, for the input shape netgrep is least aimed at.
+
+**A rejection after the first chunk now settles the promise.** The recursive `handleReader` call was not
+chained to the promise the executor was handed, so a rejection from any chunk after the first — a connection
+dropped mid-stream, an abort, an invalid pattern first reaching the engine on a later chunk — was an unhandled
+rejection and the search never settled at all. Pre-existing, and unreachable for pattern errors because those
+fail identically on chunk one. It stopped being unreachable here: a newline-free multi-chunk stream searches
+nothing until the flush, so an invalid pattern would first throw on the `done` path, which is always reached
+through a recursive call. Fixed with `.catch(reject)` rather than by returning the promise, which would retain
+a nested chain one deep per chunk.
+
+## What this does NOT fix
+
+**A single match longer than 64 KB, split across chunks.** Past the ceiling the tail is a plain window on the
+last 64 KB, so a match starting before that window and ending after the buffer is lost. It needs one line
+longer than 64 KB *and* a match spanning most of it, which no hand-written text produces. Pinned by
+`BACKLOG 3a (RESIDUAL)` in `Netgrep.integration.spec.ts`, which also asserts the control case — the same match
+arriving in one chunk **is** found, because the buffer is searched whole before the window is taken. Getting
+that wrong turns the residual into a regression, and it is the one part of `splitAtLastLine` that is easy to
+write backwards.
+
+Deliberately **not** given a caveat on the demo site, for the same reason item 17 has none: the corpus's
+longest line is 76 bytes, so no query on that page can reach it. Recorded in the comment block of
+`limitations.tsx` so it reads as a decision rather than an omission.
+
+**Item 3f (a NUL discards the block) is not fixed, and its blast radius changed shape.** What the engine is
+handed is no longer the network chunk but the block of complete lines in it, so how far a NUL reaches now
+depends on where the last `\n` falls rather than on where the network split the response. A match on an
+earlier line survives *if* the NUL happens to sit in the held-back partial line. That is incidental, not a
+fix, and both behaviours are pinned so the difference is not mistaken for one. 3f is fixed in `lib.rs` or not
+at all.
+
+**Item 18's duplicate fetch**, and therefore the demo's cache, which stays off — see
+[0006](0006-in-memory-cache.md) and the note in `use-corpus-search.ts`. The reason it stays off changed
+though: not because the cache is unsafe, which it no longer is, but because a warm cache stops the page's
+timings measuring the network, which is the one thing that page exists to show.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -18,7 +18,7 @@ reasoning got wrong.
 | [0003](0003-boolean-only-results.md) | Return a boolean, not match details | Accepted |
 | [0004](0004-two-package-split.md) | Ship two npm packages, not one | Accepted — amended |
 | [0005](0005-esm-only-distribution.md) | ESM only | Accepted — amended; **a bundler is no longer configured** |
-| [0006](0006-in-memory-cache.md) | Cache downloaded bytes in memory, on by default | Accepted — **has known defects** |
+| [0006](0006-in-memory-cache.md) | Cache downloaded bytes in memory, on by default | Accepted — amended by 0018: **an entry is written only from a drained stream**, which closed the poisoned-prefix defect |
 | [0007](0007-nx-cargo-hybrid-monorepo.md) | Nx orchestrating both JS and Cargo | **Superseded** by 0009 |
 | [0008](0008-wee-alloc.md) | `wee_alloc` as the WASM global allocator | **Superseded** — removed; worth only 0.6% |
 | [0009](0009-pnpm-workspaces.md) | pnpm workspaces, and a hand-written manifest for the WASM package | Accepted |
@@ -30,6 +30,7 @@ reasoning got wrong.
 | [0015](0015-ci-jobs-grouped-by-toolchain.md) | Five CI jobs, grouped by toolchain, with the WASM built once | Accepted |
 | [0016](0016-compiled-matcher-memo.md) | Cache the compiled matcher inside Rust, rather than hand a handle to JavaScript | Accepted |
 | [0017](0017-example-as-hosted-demo.md) | The example becomes the hosted demo, and goes back on the maintenance path | Accepted — **reverses the example's frozen-dependency exemption**; amended — custom domain, base path now `/` |
+| [0018](0018-line-oriented-tail-buffer.md) | Retain the incomplete trailing *line* between chunks, and cache only a drained stream | Accepted — closes the chunk-boundary and poisoned-cache defects; **amends 0006** |
 
 ## Format
 

--- a/packages/example/src/components/limitations.tsx
+++ b/packages/example/src/components/limitations.tsx
@@ -11,28 +11,19 @@ import { Info } from 'lucide-react';
  *
  * Nothing enforces this. No test fails and CI stays green.
  *
- *   "This demo runs with the cache off"    -> NOT a defect. 3b is fixed, so the
- *                                             cache is safe; it is off because a
- *                                             warm cache stops the timings
- *                                             measuring the network. Do not turn
- *                                             it on to close 18
- *   "Binary files stop at the first NUL"   -> BACKLOG 3f
- *   "One boolean per file"                 -> by design, decision 0003. Stays
+ *   "One boolean per file"               -> by design. Stays
+ *   "This demo runs with the cache off"  -> not a defect: the cache is safe now,
+ *                                           but a warm one stops the timings
+ *                                           measuring the network
+ *   "Binary files stop at the first NUL" -> BACKLOG 3f
  *
- * DELIBERATELY ABSENT, both because the corpus cannot trigger them — and a
- * caveat nobody can reach dilutes a list whose value is that every entry is live:
+ * ABSENT because this corpus cannot trigger them, and an unreachable caveat
+ * dilutes a list whose value is that every entry is live:
  *
  *   Backlog 17  `$` on CRLF input. Every file here is LF.
- *   Backlog 3g  A single match over 64 KB can still span a chunk boundary, all
- *               that remains of 3a. Needs a line over 64 KB; the longest in
- *               these 56 files is 76 bytes.
+ *   Backlog 3g  Needs a line over 64 KB. The longest here is 76 bytes.
  *
  * Add either if the corpus changes shape.
- *
- * "Matches spanning two network chunks are missed" was REMOVED when 3a was
- * fixed. It said "Live on this page", and it no longer is.
- *
- * See AGENTS.md §2.3.
  */
 const CAVEATS = [
   {

--- a/packages/example/src/components/limitations.tsx
+++ b/packages/example/src/components/limitations.tsx
@@ -11,16 +11,26 @@ import { Info } from 'lucide-react';
  *
  * Nothing enforces this. No test fails and CI stays green.
  *
- *   "Matches spanning two network chunks"  -> BACKLOG 3a
- *   "This demo runs with the cache off"    -> BACKLOG 3b + 18. Fixing BOTH also
- *                                             means re-enabling the cache in
- *                                             use-corpus-search.ts and removing
- *                                             this entry
+ *   "This demo runs with the cache off"    -> NOT a defect. 3b is fixed, so the
+ *                                             cache is safe; it is off because a
+ *                                             warm cache stops the timings
+ *                                             measuring the network. Do not turn
+ *                                             it on to close 18
  *   "Binary files stop at the first NUL"   -> BACKLOG 3f
  *   "One boolean per file"                 -> by design, decision 0003. Stays
  *
- * Backlog 17 (`$` on CRLF input) is deliberately absent: every file in the
- * corpus is LF, so it cannot happen here. Add it if that ever changes.
+ * DELIBERATELY ABSENT, both because the corpus cannot trigger them — and a
+ * caveat nobody can reach dilutes a list whose value is that every entry is live:
+ *
+ *   Backlog 17  `$` on CRLF input. Every file here is LF.
+ *   Backlog 3g  A single match over 64 KB can still span a chunk boundary, all
+ *               that remains of 3a. Needs a line over 64 KB; the longest in
+ *               these 56 files is 76 bytes.
+ *
+ * Add either if the corpus changes shape.
+ *
+ * "Matches spanning two network chunks are missed" was REMOVED when 3a was
+ * fixed. It said "Live on this page", and it no longer is.
  *
  * See AGENTS.md §2.3.
  */
@@ -30,12 +40,8 @@ const CAVEATS = [
     body: 'netgrep tells you whether a pattern occurs in a file, not where. No line numbers, match positions, snippets or ranking. If you need those, a prebuilt index — Pagefind, Lunr, FlexSearch — is the right tool.',
   },
   {
-    title: 'Matches spanning two network chunks are missed',
-    body: 'Each fetch chunk is searched on its own, so a pattern straddling the seam between two of them is not found. Which chunk a match lands in depends on how the network split the response, so the same query can behave differently twice. Live on this page.',
-  },
-  {
     title: 'This demo runs with the cache off',
-    body: 'netgrep can hold downloaded bytes in memory, and does by default. Two open defects make that unsafe for a page taking one query after another, so the demo disables it and re-reads the corpus each time — 2.6 MB, served from the browser cache on repeats.',
+    body: 'netgrep can hold downloaded bytes in memory, and does by default. The demo turns it off so the timings above keep measuring the network rather than a warm buffer — searching while downloading is the thing this page exists to show. It re-reads the corpus each time: 2.6 MB, served from the browser cache on repeats.',
   },
   {
     title: 'Binary files stop at the first NUL',

--- a/packages/example/src/hooks/use-corpus-search.ts
+++ b/packages/example/src/hooks/use-corpus-search.ts
@@ -29,26 +29,21 @@ export type SearchState = {
 };
 
 /**
- * THE MEMORY CACHE IS OFF, DELIBERATELY.
+ * THE MEMORY CACHE IS OFF, DELIBERATELY — AND NO LONGER BECAUSE IT IS UNSAFE.
  *
- * Two of the library's documented P1 defects only exist when it is on, and both
- * produce visibly wrong answers on a page where people type one query after
- * another:
+ * The poisoned partial cache (backlog 3b) is FIXED: entries are written only once
+ * the whole file has been read. Backlog 18 no longer corrupts anything either —
+ * two concurrent searches of one url still both fetch, which is wasteful, but
+ * they write identical complete bytes rather than joining the file to itself.
  *
- *   - Poisoned partial cache (backlog 3b). `search` resolves on the first match,
- *     so the cache keeps only the PREFIX it happened to read. A later query for
- *     a term further down the same file is then answered `false` from text that
- *     was never downloaded.
- *   - Concurrent searches double a cache entry (backlog 18). Nothing tracks a
- *     download already in flight, so two searches of one url started together
- *     both append what they read — joining the file to itself with no
- *     separator, forming a line that exists nowhere.
+ * It stays off because THIS PAGE MEASURES THE NETWORK. A miss drains the stream,
+ * which is exactly the condition for caching, so with the cache on the StatsBar
+ * would time a `Record` lookup and present it as a download from the second query
+ * onward — and those numbers are the page's only evidence for its claim.
  *
- * Turning it off costs little here: the corpus is 2.6 MB and the browser's own
- * HTTP cache serves repeat queries. It does not affect the property this page
- * exists to show — a match still resolves the moment it is seen, mid-download.
- *
- * See docs/BACKLOG.md and AGENTS.md §7.
+ * So do not turn this on while closing backlog 18: it is a decision about what
+ * the demo measures, not about whether the cache works. Leaving it off is cheap —
+ * 2.6 MB, and the browser's own HTTP cache serves repeats.
  */
 const netgrep = new Netgrep({ enableMemoryCache: false });
 

--- a/packages/netgrep/src/lib/Netgrep.integration.spec.ts
+++ b/packages/netgrep/src/lib/Netgrep.integration.spec.ts
@@ -213,15 +213,62 @@ describe('Netgrep integration (real WASM)', () => {
       expect(result).toMatchObject({ result: true });
     });
 
-    it('stops reading as soon as a chunk matches', async () => {
-      // 'One Wiseman' is inside the first 16 bytes, so exactly one read.
+    it('stops reading as soon as a line matches', async () => {
+      // 'One Wiseman' is in the first 16 bytes, but a chunk is searched only up
+      // to its last `\n`, so the answering read is the one that COMPLETES the
+      // line. POEM's first line is 34 bytes, so that is the third 16-byte chunk.
+      // The price of fixing BACKLOG 3a: invisible against real 16-64 KB chunks,
+      // exactly two extra reads against these deliberately tiny ones.
       const chunks = chunked(POEM, 16);
       const state = serve(chunks);
 
       await new Netgrep({ enableMemoryCache: false }).search('url', 'Wiseman');
 
-      expect(state.reads).toBe(1);
-      expect(chunks.length).toBeGreaterThan(1);
+      expect(state.reads).toBe(3);
+
+      // Still resolving early, which is the property that matters: the poem is
+      // eight chunks long and five of them were never asked for.
+      expect(chunks.length).toBeGreaterThan(state.reads);
+    });
+
+    it('finds a pattern straddling a chunk boundary', async () => {
+      // BACKLOG 3a, fixed: the retained tail hides the seam from the engine. The
+      // `documented defects` block has what this used to assert, and the
+      // residual case that survives.
+      serve([encoder.encode('hello won'), encoder.encode('derful world')]);
+
+      await expect(
+        new Netgrep({ enableMemoryCache: false }).search('url', 'wonderful'),
+      ).resolves.toMatchObject({ result: true });
+    });
+
+    it('does not let a chunk boundary fake a line boundary', async () => {
+      // The mirror image of 3a, never separately tracked: a chunk searched as
+      // though it were a whole document made the seam look like a line start to
+      // `^` and a line end to `$`, so both invented matches wherever the network
+      // happened to split. Whole lines fix both directions at once.
+      const NG = new Netgrep({ enableMemoryCache: false });
+
+      serve([encoder.encode('hello won'), encoder.encode('derful world\n')]);
+      await expect(NG.search('a', 'won$')).resolves.toMatchObject({
+        result: false,
+      });
+
+      serve([encoder.encode('hello won'), encoder.encode('derful world\n')]);
+      await expect(NG.search('b', '^derful')).resolves.toMatchObject({
+        result: false,
+      });
+
+      // The genuine anchors on the same bytes still match.
+      serve([encoder.encode('hello won'), encoder.encode('derful world\n')]);
+      await expect(NG.search('c', '^hello')).resolves.toMatchObject({
+        result: true,
+      });
+
+      serve([encoder.encode('hello won'), encoder.encode('derful world\n')]);
+      await expect(NG.search('d', 'world$')).resolves.toMatchObject({
+        result: true,
+      });
     });
 
     it('matches a pattern spanning multiple lines of one chunk', async () => {
@@ -505,7 +552,17 @@ describe('Netgrep integration (real WASM)', () => {
    * and the site keeps warning about a bug you just fixed. See AGENTS.md §2.3.
    */
   describe('documented defects (asserting current, incorrect behaviour)', () => {
-    it('BACKLOG 3a: misses a pattern straddling a chunk boundary', async () => {
+    it('BACKLOG 3a (FIXED): a match straddling a chunk boundary is found', async () => {
+      // This assertion used to sit here inverted, pinning a real bug: chunks were
+      // searched in isolation with no tail retained, so a pattern split across
+      // the seam matched nothing — silently, and depending on how the network
+      // divided the response.
+      //
+      // `Netgrep.search` now prepends each chunk's incomplete trailing line to
+      // the next. Exact rather than a guess, because a match can never span a
+      // `\n` — see `test_a_match_cannot_span_a_line_terminator` in
+      // packages/search/tests/search.rs. Per the block comment above, inverted in
+      // the same PR that changed it. The residual is pinned separately below.
       const text = 'hello wonderful world';
 
       // Control: the same bytes in one chunk match.
@@ -514,44 +571,51 @@ describe('Netgrep integration (real WASM)', () => {
         new Netgrep({ enableMemoryCache: false }).search('url', 'wonderful'),
       ).resolves.toMatchObject({ result: true });
 
-      // Split mid-word, and the match vanishes. Chunks are searched in
-      // isolation with no tail retained.
+      // Previously false. This is the case that was broken.
       serve([encoder.encode('hello won'), encoder.encode('derful world')]);
       await expect(
         new Netgrep({ enableMemoryCache: false }).search('url', 'wonderful'),
-      ).resolves.toMatchObject({ result: false });
+      ).resolves.toMatchObject({ result: true });
     });
 
-    it('BACKLOG 3a: the same search answers differently once the cache is warm', async () => {
-      // The cache reassembles the chunks, so the second search sees one buffer
-      // where the first saw fragments — and 3a's false negative disappears.
-      // The same url and the same pattern, two different answers, decided by
-      // whether anyone asked before.
+    it('BACKLOG 3a (FIXED): the answer no longer depends on whether the cache is warm', async () => {
+      // The sharpest way to see 3a: the cache reassembled the chunks, so the
+      // second search saw one buffer where the first saw fragments — same url,
+      // same pattern, two answers, decided by whether anyone had asked before.
       //
-      // This lives here rather than under `in-memory cache` because the first
-      // assertion IS 3a: a fix that retains a tail buffer makes it `true` and
-      // turns this red, and §2.1 says that must happen somewhere labelled.
+      // Both are `true` now, for two different reasons: the tail buffer finds it
+      // first time, and an early resolution no longer leaves an entry to
+      // disagree (BACKLOG 3b, below) — hence two fetches.
       serve(chunked(POEM, 7));
 
       const NG = new Netgrep({ enableMemoryCache: true });
 
       await expect(NG.search('url', 'Jhaampe-town')).resolves.toMatchObject({
-        result: false,
+        result: true,
       });
 
       await expect(NG.search('url', 'Jhaampe-town')).resolves.toMatchObject({
         result: true,
       });
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
-    it('BACKLOG 3b: a cache poisoned by early resolution answers later searches wrongly', async () => {
-      // 'needle' matches in chunk 2, so search resolves and stops reading.
-      // Only 'alpha needle ' is cached — 'omega' was never downloaded.
+    it('BACKLOG 3b (FIXED): an early resolution leaves no cache entry to poison', async () => {
+      // This assertion used to sit here inverted, pinning a real bug: the cache
+      // was written per chunk, so resolving on the first match left an entry
+      // holding only the PREFIX read so far, unmarked as incomplete — and a later
+      // search for a term further down answered `false` about text never
+      // downloaded.
+      //
+      // The entry is now written only on `done`, so a partial one is never
+      // created. Per the block comment above, inverted in the same PR.
+      //
+      // The newlines matter: without them the match would only be found by the
+      // end-of-stream flush, which is a drained stream, exercising nothing.
       serve([
-        encoder.encode('alpha '),
-        encoder.encode('needle '),
-        encoder.encode('omega'),
+        encoder.encode('alpha\n'),
+        encoder.encode('needle\n'),
+        encoder.encode('omega\n'),
       ]);
 
       const NG = new Netgrep({ enableMemoryCache: true });
@@ -560,37 +624,101 @@ describe('Netgrep integration (real WASM)', () => {
         result: true,
       });
 
-      // 'omega' IS in the file. The cached prefix says otherwise, and the
-      // cache is consulted before the network, so no re-fetch corrects it.
+      // 'omega' IS in the file, and the answer now says so. It costs a second
+      // fetch, which is the correct trade against a confident wrong answer.
       await expect(NG.search('url', 'omega')).resolves.toMatchObject({
+        result: true,
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      // Finding 'omega' in the LAST chunk still caches nothing: completeness is
+      // not known until `done`, one read later. Only a search reaching `done`
+      // caches — a miss, or a match found in the flush.
+      await expect(NG.search('url', 'dragon')).resolves.toMatchObject({
         result: false,
       });
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+
+      // That miss drained the stream, so this is answered from memory. The cache
+      // still works; it just no longer lies.
+      await expect(NG.search('url', 'omega')).resolves.toMatchObject({
+        result: true,
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(3);
     });
 
-    it('BACKLOG 18: concurrent searches of one url double its cache entry', async () => {
+    it('BACKLOG 18: concurrent searches of one url still both fetch', async () => {
       // Nothing tracks a download already in flight, so two searches started
-      // before either resolves both fetch, and both append what they read to
-      // the same cache entry.
+      // before either resolves both fetch. Still open — it wants a per-url
+      // promise registry, which this change did not add.
       //
-      // The waste is the obvious half. The sharp half is that the entry now
-      // holds bytes the file never contained: the two copies are joined with
-      // no separator, so the seam forms a line that exists nowhere, and a
-      // later search matches it.
+      // The sharp half IS fixed, and the second assertion is what used to be
+      // inverted here: the entry was APPENDED to per chunk, joining the file to
+      // itself with no separator and forming a line that existed in no file. It
+      // is now assigned once from a drained stream.
       //
-      // One chunk, so the assertion does not depend on how the two reads
-      // interleave.
+      // One chunk, so this does not depend on how the two reads interleave.
       serve([encoder.encode('needle')]);
 
       const NG = new Netgrep({ enableMemoryCache: true });
 
       await Promise.all([NG.search('url', 'zzz'), NG.search('url', 'zzz')]);
 
-      // No in-flight de-duplication.
+      // No in-flight de-duplication. This half is unchanged.
       expect(mockFetch).toHaveBeenCalledTimes(2);
 
-      // The file is 'needle'. The cache says 'needleneedle'.
+      // Previously true, off a cache that read 'needleneedle'.
       await expect(NG.search('url', '^needleneedle$')).resolves.toMatchObject({
+        result: false,
+      });
+
+      // The file is 'needle', and that is now what the cache holds.
+      await expect(NG.search('url', '^needle$')).resolves.toMatchObject({
+        result: true,
+      });
+    });
+
+    it('BACKLOG 3a (RESIDUAL): a match longer than the 64 KB tail ceiling is still missed', async () => {
+      // What the tail buffer does NOT fix, and why 3a is narrowed rather than
+      // closed outright.
+      //
+      // The tail is normally the incomplete trailing LINE, which is exact. Since
+      // a terminator-free line would otherwise buffer an entire response, past a
+      // 64 KB ceiling the tail degrades to a window on the last 64 KB — so a
+      // match starting before that window and ending after the buffer is lost.
+      //
+      // Needs a line over 64 KB AND a match spanning most of it, so it is
+      // unreachable in hand-written text: the demo corpus is 2.6 MB of prose
+      // whose longest line is 76 bytes.
+      const NG = new Netgrep({ enableMemoryCache: false });
+      const filler = 'x'.repeat(70_000);
+
+      // Control: found in ONE chunk, because the whole buffer is searched before
+      // the window is taken. Easy to get wrong, and wrong here is a regression
+      // rather than a residual — the naive cut searches only up to
+      // `length - 64 KB` and drops the middle unscanned.
+      serve([encoder.encode(`nee${filler}dle`)]);
+      await expect(NG.search('a', 'nee.*dle')).resolves.toMatchObject({
+        result: true,
+      });
+
+      // Split, and 'nee' left the window before 'dle' arrived. The gap that
+      // remains.
+      serve([
+        encoder.encode(`nee${filler}`),
+        encoder.encode('dle and then some'),
+      ]);
+      await expect(NG.search('b', 'nee.*dle')).resolves.toMatchObject({
+        result: false,
+      });
+
+      // A match inside the ceiling survives the same boundary, pinning the bound
+      // rather than merely the failure.
+      serve([
+        encoder.encode(`${filler}nee`),
+        encoder.encode('dle and then some'),
+      ]);
+      await expect(NG.search('c', 'nee.*dle')).resolves.toMatchObject({
         result: true,
       });
     });
@@ -679,10 +807,18 @@ describe('Netgrep integration (real WASM)', () => {
       });
     });
 
-    it('BACKLOG 3f: one NUL byte discards the entire chunk, match included', async () => {
-      // `BinaryDetection::quit(b'\x00')` abandons the chunk on the first NUL.
-      // Not "stops at the NUL" — the match is dropped even when it occurs
-      // BEFORE the NUL, and even on an earlier line.
+    it('BACKLOG 3f: one NUL byte discards the whole searched block, match included', async () => {
+      // `BinaryDetection::quit(b'\x00')` abandons what it was given on the first
+      // NUL. Not "stops at the NUL" — the match is dropped even when it precedes
+      // the NUL, and even on an earlier line.
+      //
+      // STILL OPEN, but the tail buffer moved where the damage stops: the engine
+      // gets the block of COMPLETE LINES in a chunk, not the chunk, so a NUL's
+      // reach now depends on where the last `\n` falls rather than on where the
+      // network split. Case (c) used to pass with a terminator-free `tail` and
+      // needs one now, or the NUL lands in the held-back partial line and never
+      // shares a block with the match. Same defect, differently shaped blast
+      // radius — see the assertion after it.
       const NG = new Netgrep({ enableMemoryCache: false });
 
       serve([bytes('needle here')]);
@@ -695,9 +831,19 @@ describe('Netgrep integration (real WASM)', () => {
         result: false,
       });
 
-      serve([bytes('needle here\n', 0x00, 'tail')]);
+      serve([bytes('needle here\n', 0x00, 'tail\n')]);
       await expect(NG.search('c', 'needle')).resolves.toMatchObject({
         result: false,
+      });
+
+      // The incidental narrowing, pinned so it is not mistaken for the fix: case
+      // (c) minus the final terminator, so the NUL sits in the trailing partial
+      // line and gets its own block. The match survives — because of where the
+      // newline is, which nobody should rely on. 3f is fixed in `lib.rs` or not
+      // at all.
+      serve([bytes('needle here\n', 0x00, 'tail')]);
+      await expect(NG.search('d', 'needle')).resolves.toMatchObject({
+        result: true,
       });
     });
   });

--- a/packages/netgrep/src/lib/Netgrep.integration.spec.ts
+++ b/packages/netgrep/src/lib/Netgrep.integration.spec.ts
@@ -678,18 +678,12 @@ describe('Netgrep integration (real WASM)', () => {
       });
     });
 
-    it('BACKLOG 3a (RESIDUAL): a match longer than the 64 KB tail ceiling is still missed', async () => {
-      // What the tail buffer does NOT fix, and why 3a is narrowed rather than
-      // closed outright.
-      //
-      // The tail is normally the incomplete trailing LINE, which is exact. Since
-      // a terminator-free line would otherwise buffer an entire response, past a
-      // 64 KB ceiling the tail degrades to a window on the last 64 KB — so a
-      // match starting before that window and ending after the buffer is lost.
-      //
-      // Needs a line over 64 KB AND a match spanning most of it, so it is
-      // unreachable in hand-written text: the demo corpus is 2.6 MB of prose
-      // whose longest line is 76 bytes.
+    it('BACKLOG 3g: a match longer than the 64 KB tail ceiling is still missed', async () => {
+      // What the tail buffer does NOT fix. A terminator-free line would buffer an
+      // entire response, so past a 64 KB ceiling the tail becomes a window on the
+      // last 64 KB — and a match starting before that window and ending after the
+      // buffer is lost. Needs a line over 64 KB AND a match spanning most of it,
+      // so it is unreachable in prose: this corpus's longest line is 76 bytes.
       const NG = new Netgrep({ enableMemoryCache: false });
       const filler = 'x'.repeat(70_000);
 
@@ -719,6 +713,33 @@ describe('Netgrep integration (real WASM)', () => {
         encoder.encode('dle and then some'),
       ]);
       await expect(NG.search('c', 'nee.*dle')).resolves.toMatchObject({
+        result: true,
+      });
+    });
+
+    it('BACKLOG 3g: `^` can match at a window boundary inside an over-long line', async () => {
+      // The other half of 3g, and a false POSITIVE rather than a false negative.
+      //
+      // Once a line outgrows the ceiling the retained bytes are a window, so the
+      // buffer handed to the engine no longer begins where a line begins — and
+      // the engine has no way to be told that. `^` therefore anchors to the
+      // window's first byte. Same precondition as the misses above: a line longer
+      // than 64 KB, so unreachable in prose.
+      const NG = new Netgrep({ enableMemoryCache: false });
+
+      // Control: one line beginning with 'b', so nothing should match `^a`.
+      serve([encoder.encode(`b${'a'.repeat(70_000)}`)]);
+      await expect(NG.search('a', '^a')).resolves.toMatchObject({
+        result: false,
+      });
+
+      // The residual: the window is discarded once a terminator arrives, but the
+      // buffer that carried it still started mid-line.
+      serve([
+        encoder.encode(`b${'a'.repeat(70_000)}`),
+        encoder.encode('end\n'),
+      ]);
+      await expect(NG.search('b', '^a')).resolves.toMatchObject({
         result: true,
       });
     });
@@ -809,16 +830,12 @@ describe('Netgrep integration (real WASM)', () => {
 
     it('BACKLOG 3f: one NUL byte discards the whole searched block, match included', async () => {
       // `BinaryDetection::quit(b'\x00')` abandons what it was given on the first
-      // NUL. Not "stops at the NUL" — the match is dropped even when it precedes
-      // the NUL, and even on an earlier line.
+      // NUL, so the match is dropped even when it precedes the NUL.
       //
-      // STILL OPEN, but the tail buffer moved where the damage stops: the engine
-      // gets the block of COMPLETE LINES in a chunk, not the chunk, so a NUL's
-      // reach now depends on where the last `\n` falls rather than on where the
-      // network split. Case (c) used to pass with a terminator-free `tail` and
-      // needs one now, or the NUL lands in the held-back partial line and never
-      // shares a block with the match. Same defect, differently shaped blast
-      // radius — see the assertion after it.
+      // STILL OPEN, but the blast radius changed shape: the engine now gets a
+      // chunk's block of COMPLETE LINES, so a NUL's reach depends on where the
+      // last `\n` falls. Case (c) needed a terminator added, or the NUL lands in
+      // the held-back partial line and never shares a block with the match.
       const NG = new Netgrep({ enableMemoryCache: false });
 
       serve([bytes('needle here')]);

--- a/packages/netgrep/src/lib/Netgrep.spec.ts
+++ b/packages/netgrep/src/lib/Netgrep.spec.ts
@@ -273,6 +273,30 @@ describe('Netgrep', () => {
       );
     });
 
+    it('caches nothing when the search resolved before the stream ended', async () => {
+      // BACKLOG 3b. Writing per chunk left an entry holding only the chunks read
+      // before the match, unmarked as a prefix, so a later search for anything
+      // further down answered `false` from text never downloaded. The entry is
+      // now written on `done` only: an early resolution leaves none and the next
+      // search re-fetches, which is the right trade against a wrong answer.
+      mockSearch.mockReturnValue(true);
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({
+          body: genReadableStreamFromChunks([
+            encoder.encode('needle\n'),
+            encoder.encode('omega\n'),
+          ]),
+        }),
+      );
+
+      const instance = new Netgrep({ enableMemoryCache: true });
+
+      await instance.search('partial', pattern);
+      await instance.search('partial', pattern);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
     it('does not share its cache with another instance', async () => {
       mockSearch.mockReturnValue(true);
 
@@ -295,12 +319,15 @@ describe('Netgrep', () => {
     });
 
     it('stops reading as soon as a chunk matches', async () => {
+      // The terminators matter: a chunk is searched only up to its last `\n`, so
+      // a newline-free fixture would search nothing until the stream ended and
+      // this would test the opposite of what it says. See `splitAtLastLine`.
       mockFetch.mockImplementation(() =>
         Promise.resolve({
           body: genReadableStreamFromChunks([
-            encoder.encode('one'),
-            encoder.encode('two'),
-            encoder.encode('three'),
+            encoder.encode('one\n'),
+            encoder.encode('two\n'),
+            encoder.encode('three\n'),
           ]),
         }),
       );
@@ -314,6 +341,78 @@ describe('Netgrep', () => {
         result: true,
       });
       expect(mockSearch).toHaveBeenCalledTimes(2);
+    });
+
+    it('holds a chunk back until its line is complete, then searches it whole', async () => {
+      // The cost of fixing BACKLOG 3a: early resolution is line-granular now.
+      // A split word reaches the engine ONCE, joined, rather than twice in
+      // halves that match nothing — but the answer arrives one chunk later.
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({
+          body: genReadableStreamFromChunks([
+            encoder.encode('hello won'),
+            encoder.encode('derful world\n'),
+          ]),
+        }),
+      );
+
+      mockSearch.mockReturnValue(true);
+
+      await expect(NG.search(url, pattern)).resolves.toMatchObject({
+        result: true,
+      });
+
+      // Not once per chunk: the first had no complete line in it.
+      expect(mockSearch).toHaveBeenCalledTimes(1);
+      expect(mockSearch).toHaveBeenCalledWith(
+        encoder.encode('hello wonderful world\n'),
+        pattern,
+      );
+    });
+
+    it('searches the final line even when nothing terminates it', async () => {
+      // A file not ending in a newline leaves a tail no chunk will complete, so
+      // it is searched on `done`. Forgetting that loses every such last line.
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({
+          body: genReadableStreamFromChunks([
+            encoder.encode('first\n'),
+            encoder.encode('unterminated'),
+          ]),
+        }),
+      );
+
+      mockSearch.mockReturnValueOnce(false).mockReturnValueOnce(true);
+
+      await expect(NG.search(url, pattern)).resolves.toMatchObject({
+        result: true,
+      });
+      expect(mockSearch).toHaveBeenLastCalledWith(
+        encoder.encode('unterminated'),
+        pattern,
+      );
+    });
+
+    it('does not retain the file when the cache is off', async () => {
+      // Chunks are collected for the cache only. Holding them with the cache off
+      // would keep all 500 MB of a 500 MB file — worse than the O(n²) append it
+      // replaced. Observable as the engine never seeing a joined buffer.
+      mockSearch.mockReturnValue(false);
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({
+          body: genReadableStreamFromChunks([
+            encoder.encode('alpha\n'),
+            encoder.encode('beta\n'),
+          ]),
+        }),
+      );
+
+      await NG.search('uncached-retain', pattern);
+
+      // One call per line, never a joined buffer, and no cache entry after.
+      expect(mockSearch).toHaveBeenCalledTimes(2);
+      await NG.search('uncached-retain', pattern);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/netgrep/src/lib/Netgrep.ts
+++ b/packages/netgrep/src/lib/Netgrep.ts
@@ -4,6 +4,7 @@ import type { NetgrepConfig } from './data/NetgrepConfig.js';
 import type { NetgrepInput } from './data/NetgrepInput.js';
 import type { NetgrepResult } from './data/NetgrepResult.js';
 import type { NetgrepSearchConfig } from './data/NetgrepSearchConfig.js';
+import { splitAtLastLine } from './splitAtLastLine.js';
 
 /**
  * The default configuration used by `netgrep`.
@@ -11,6 +12,37 @@ import type { NetgrepSearchConfig } from './data/NetgrepSearchConfig.js';
 const defaultConfig: NetgrepConfig = {
   enableMemoryCache: true,
 };
+
+/**
+ * Ceiling on the bytes retained between two `fetch` chunks.
+ *
+ * The tail is normally the incomplete trailing *line*, which `splitAtLastLine`
+ * keeps in full — 76 bytes at worst in the demo's 2.6 MB corpus. Only
+ * terminator-free input reaches this ceiling, and there the guarantee weakens
+ * from "a boundary never hides a match" to "a boundary never hides a match
+ * shorter than 64 KB".
+ *
+ * Deliberately not configurable: a safety valve for input netgrep is not aimed
+ * at, not a tuning knob, and one contract is easier to describe than a family.
+ */
+const MAX_TAIL_BYTES = 64 * 1024;
+
+/**
+ * Join a list of byte chunks into one buffer.
+ */
+function concatBytes(chunks: Array<Uint8Array>): Uint8Array {
+  const total = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const joined = new Uint8Array(total);
+
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    joined.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  return joined;
+}
 
 /**
  * The WASM module has to be instantiated before `search_bytes` can be called.
@@ -70,6 +102,19 @@ export class Netgrep {
     await wasmReady;
 
     return new Promise((resolve, reject) => {
+      // The incomplete final line seen so far, unsearchable until the rest of
+      // it arrives. Closes BACKLOG 3a; see `splitAtLastLine`. Annotated because
+      // `subarray` yields an `ArrayBufferLike` view, which the type inferred
+      // from this initialiser would reject.
+      let tail: Uint8Array = new Uint8Array(0);
+
+      // Joined ONCE at the end rather than reallocated per chunk, which used to
+      // make this O(n²) — BACKLOG 11. Left empty when the cache is off: the
+      // search itself never needs more than the tail, so collecting anyway would
+      // retain all 500 MB of a 500 MB file for nothing.
+      const chunks: Array<Uint8Array> = [];
+      const caching = this.config.enableMemoryCache;
+
       const handleReader = (
         reader: ReadableStreamDefaultReader<Uint8Array>,
       ) => {
@@ -77,31 +122,45 @@ export class Netgrep {
           // If the reader is actually done
           // let's quit this job returning `false`.
           if (done) {
-            resolve({ url, pattern, result: false, metadata });
+            // The stream ended, so the held-back tail is a genuine final line
+            // rather than a fragment. Nothing has searched it yet: skipping it
+            // would lose the last line of every file not ending in a newline.
+            const result = tail.length > 0 && search_bytes(tail, pattern);
+
+            this.commitMemoryCache(url, chunks);
+
+            resolve({ url, pattern, result, metadata });
             return;
           }
 
-          // Execute the search in the current chunk of bytes
-          // using the underneath WASM core module.
-          const u8Array = new Uint8Array(value);
-          const result = search_bytes(u8Array, pattern);
+          if (caching) chunks.push(value);
 
-          // Store the `Uint8Array` in the memory cache
-          // if it's enabled.
-          if (this.config.enableMemoryCache) {
-            this.upsertMemoryCache(url, u8Array);
-          }
+          // Prepend the held-back tail, then hand the engine only whole lines.
+          const { searched, tail: nextTail } = splitAtLastLine(
+            tail.length > 0 ? concatBytes([tail, value]) : value,
+            MAX_TAIL_BYTES,
+          );
+
+          tail = nextTail;
+
+          // A chunk with no terminator in it searches nothing and grows the tail.
+          const result = searched.length > 0 && search_bytes(searched, pattern);
 
           if (result) {
             resolve({ url, pattern, result: true, metadata });
           } else {
-            handleReader(reader);
+            // `.catch` because this promise is not chained to the executor's:
+            // without it, a rejection from any chunk after the first (dropped
+            // connection, abort, invalid pattern first reaching the engine late)
+            // goes unhandled and the search never settles.
+            handleReader(reader).catch(reject);
           }
         });
       };
 
-      // Search the content in the memory cache
-      // if it's enabled.
+      // Search the content in the memory cache if it's enabled. No tail buffer
+      // needed: entries are only written from a drained stream, so an entry is
+      // the whole file in one buffer with no boundaries to lose a match across.
       if (this.config.enableMemoryCache && this.memoryCache[url]) {
         const result = search_bytes(this.memoryCache[url], pattern);
         resolve({ url, pattern, result, metadata });
@@ -209,15 +268,22 @@ export class Netgrep {
   }
 
   /**
-   * Upsert a slice of bytes into the in-memory cache.
+   * Store a fully downloaded file in the in-memory cache.
+   *
+   * ONLY EVER CALLED ON A DRAINED STREAM — that is the whole point. Writing per
+   * chunk meant an early resolution left a *prefix* with nothing marking it
+   * incomplete, so a later search for a term further down answered `false` about
+   * text never downloaded (BACKLOG 3b). Waiting for `done` means a partial entry
+   * is never created rather than flagged.
+   *
+   * Assigns rather than appends, so two concurrent searches of one url overwrite
+   * each other with identical files instead of concatenating the file to itself
+   * and forming a line that exists nowhere. Their duplicate fetch is BACKLOG 18,
+   * still open.
    */
-  private upsertMemoryCache(url: string, bytes: Uint8Array) {
-    const currentBlockLength = this.memoryCache[url]?.length || 0;
-    const joinedArray = new Uint8Array(currentBlockLength + bytes.length);
+  private commitMemoryCache(url: string, chunks: Array<Uint8Array>) {
+    if (!this.config.enableMemoryCache) return;
 
-    if (this.memoryCache[url]) joinedArray.set(this.memoryCache[url]);
-
-    joinedArray.set(bytes, currentBlockLength);
-    this.memoryCache[url] = joinedArray;
+    this.memoryCache[url] = concatBytes(chunks);
   }
 }

--- a/packages/netgrep/src/lib/Netgrep.ts
+++ b/packages/netgrep/src/lib/Netgrep.ts
@@ -16,14 +16,11 @@ const defaultConfig: NetgrepConfig = {
 /**
  * Ceiling on the bytes retained between two `fetch` chunks.
  *
- * The tail is normally the incomplete trailing *line*, which `splitAtLastLine`
- * keeps in full — 76 bytes at worst in the demo's 2.6 MB corpus. Only
- * terminator-free input reaches this ceiling, and there the guarantee weakens
- * from "a boundary never hides a match" to "a boundary never hides a match
- * shorter than 64 KB".
+ * Only terminator-free input reaches it — the tail is normally the incomplete
+ * trailing line, 76 bytes at worst in the demo's corpus. Past it the guarantee
+ * weakens to "a boundary never hides a match shorter than 64 KB".
  *
- * Deliberately not configurable: a safety valve for input netgrep is not aimed
- * at, not a tuning knob, and one contract is easier to describe than a family.
+ * A safety valve for input netgrep is not aimed at, so not configurable.
  */
 const MAX_TAIL_BYTES = 64 * 1024;
 
@@ -102,18 +99,22 @@ export class Netgrep {
     await wasmReady;
 
     return new Promise((resolve, reject) => {
-      // The incomplete final line seen so far, unsearchable until the rest of
-      // it arrives. Closes BACKLOG 3a; see `splitAtLastLine`. Annotated because
-      // `subarray` yields an `ArrayBufferLike` view, which the type inferred
-      // from this initialiser would reject.
+      // The incomplete final line seen so far, held back until the rest of it
+      // arrives — BACKLOG 3a. Annotated because `subarray` yields an
+      // `ArrayBufferLike` view, which the inferred type would reject.
       let tail: Uint8Array = new Uint8Array(0);
+
+      // Whether `tail` still needs searching when the stream ends. False in the
+      // windowed case, where it was already searched as part of the whole buffer.
+      let tailPending = false;
+
+      const caching = this.config.enableMemoryCache;
 
       // Joined ONCE at the end rather than reallocated per chunk, which used to
       // make this O(n²) — BACKLOG 11. Left empty when the cache is off: the
-      // search itself never needs more than the tail, so collecting anyway would
-      // retain all 500 MB of a 500 MB file for nothing.
+      // search never needs more than the tail, so collecting anyway would retain
+      // all 500 MB of a 500 MB file for nothing.
       const chunks: Array<Uint8Array> = [];
-      const caching = this.config.enableMemoryCache;
 
       const handleReader = (
         reader: ReadableStreamDefaultReader<Uint8Array>,
@@ -123,11 +124,17 @@ export class Netgrep {
           // let's quit this job returning `false`.
           if (done) {
             // The stream ended, so the held-back tail is a genuine final line
-            // rather than a fragment. Nothing has searched it yet: skipping it
-            // would lose the last line of every file not ending in a newline.
-            const result = tail.length > 0 && search_bytes(tail, pattern);
+            // rather than a fragment, and skipping it would lose the last line of
+            // every file not ending in a newline.
+            //
+            // Only when it has not already been searched. A windowed tail was
+            // covered by the whole-buffer search that produced it, and searching
+            // it alone would treat its first byte as a line start — letting `^`
+            // match a line that begins earlier.
+            const result =
+              tailPending && tail.length > 0 && search_bytes(tail, pattern);
 
-            this.commitMemoryCache(url, chunks);
+            this.commitMemoryCache(url, chunks, caching);
 
             resolve({ url, pattern, result, metadata });
             return;
@@ -136,15 +143,21 @@ export class Netgrep {
           if (caching) chunks.push(value);
 
           // Prepend the held-back tail, then hand the engine only whole lines.
-          const { searched, tail: nextTail } = splitAtLastLine(
+          const {
+            searchable,
+            tail: nextTail,
+            tailSearched,
+          } = splitAtLastLine(
             tail.length > 0 ? concatBytes([tail, value]) : value,
             MAX_TAIL_BYTES,
           );
 
           tail = nextTail;
+          tailPending = !tailSearched;
 
           // A chunk with no terminator in it searches nothing and grows the tail.
-          const result = searched.length > 0 && search_bytes(searched, pattern);
+          const result =
+            searchable.length > 0 && search_bytes(searchable, pattern);
 
           if (result) {
             resolve({ url, pattern, result: true, metadata });
@@ -270,19 +283,19 @@ export class Netgrep {
   /**
    * Store a fully downloaded file in the in-memory cache.
    *
-   * ONLY EVER CALLED ON A DRAINED STREAM — that is the whole point. Writing per
-   * chunk meant an early resolution left a *prefix* with nothing marking it
-   * incomplete, so a later search for a term further down answered `false` about
-   * text never downloaded (BACKLOG 3b). Waiting for `done` means a partial entry
-   * is never created rather than flagged.
+   * ONLY EVER CALLED ON A DRAINED STREAM — BACKLOG 3b. Writing per chunk left a
+   * prefix behind with nothing marking it incomplete, so a later search for a
+   * term further down answered `false` about text never downloaded.
    *
-   * Assigns rather than appends, so two concurrent searches of one url overwrite
-   * each other with identical files instead of concatenating the file to itself
-   * and forming a line that exists nowhere. Their duplicate fetch is BACKLOG 18,
-   * still open.
+   * Assigns rather than appends, so two concurrent searches of one url store
+   * identical files instead of concatenating the file to itself.
    */
-  private commitMemoryCache(url: string, chunks: Array<Uint8Array>) {
-    if (!this.config.enableMemoryCache) return;
+  private commitMemoryCache(
+    url: string,
+    chunks: Array<Uint8Array>,
+    caching: boolean,
+  ) {
+    if (!caching) return;
 
     this.memoryCache[url] = concatBytes(chunks);
   }

--- a/packages/netgrep/src/lib/splitAtLastLine.spec.ts
+++ b/packages/netgrep/src/lib/splitAtLastLine.spec.ts
@@ -1,53 +1,81 @@
 import { describe, expect, it } from 'vitest';
 import { splitAtLastLine } from './splitAtLastLine.js';
 
-/**
- * The buffer arithmetic behind BACKLOG 3a's fix, on its own.
- *
- * A pure function specifically so this can be a table in Node: reaching the
- * over-the-ceiling branches through `Netgrep.search` needs a >64 KB fixture with
- * no line breaks, which pins the same logic far more expensively. The real
- * ceiling is exercised end-to-end in `Netgrep.integration.spec.ts`.
- *
- * `cap` is 8 throughout, so the overflow cases fit on one line.
- */
+// The buffer arithmetic behind BACKLOG 3a's fix, on its own.
+//
+// A pure function specifically so this can be a table in Node: reaching the
+// windowed branches through `Netgrep.search` needs a >64 KB fixture with no line
+// breaks, which pins the same logic far more expensively.
+//
+// `cap` is 8 throughout, so the windowed cases fit on one line.
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
 /** Run the split on a string, and read both halves back as strings. */
 function split(input: string, cap = 8) {
-  const { searched, tail } = splitAtLastLine(encoder.encode(input), cap);
+  const { searchable, tail, tailSearched } = splitAtLastLine(
+    encoder.encode(input),
+    cap,
+  );
 
-  return { searched: decoder.decode(searched), tail: decoder.decode(tail) };
+  return {
+    searchable: decoder.decode(searchable),
+    tail: decoder.decode(tail),
+    tailSearched,
+  };
 }
 
 describe('splitAtLastLine', () => {
   it('searches the complete lines and carries the partial one', () => {
-    expect(split('a\nbc')).toEqual({ searched: 'a\n', tail: 'bc' });
+    expect(split('a\nbc')).toEqual({
+      searchable: 'a\n',
+      tail: 'bc',
+      tailSearched: false,
+    });
   });
 
   it('carries everything when no line has completed yet', () => {
     // BACKLOG 3a itself: searching these in isolation misses a word that
     // continues in the next chunk.
-    expect(split('abc')).toEqual({ searched: '', tail: 'abc' });
+    expect(split('abc')).toEqual({
+      searchable: '',
+      tail: 'abc',
+      tailSearched: false,
+    });
   });
 
   it('carries nothing when the buffer ends exactly on a terminator', () => {
-    expect(split('ab\n')).toEqual({ searched: 'ab\n', tail: '' });
+    expect(split('ab\n')).toEqual({
+      searchable: 'ab\n',
+      tail: '',
+      tailSearched: false,
+    });
   });
 
   it('splits at the LAST terminator, not the first', () => {
-    expect(split('a\nb\ncd')).toEqual({ searched: 'a\nb\n', tail: 'cd' });
+    expect(split('a\nb\ncd')).toEqual({
+      searchable: 'a\nb\n',
+      tail: 'cd',
+      tailSearched: false,
+    });
   });
 
   it('handles an empty buffer', () => {
-    expect(split('')).toEqual({ searched: '', tail: '' });
+    expect(split('')).toEqual({
+      searchable: '',
+      tail: '',
+      tailSearched: false,
+    });
   });
 
   it('keeps a whole-line tail regardless of how long it is, under the cap', () => {
     // Seven bytes of tail against a cap of eight: still exact, no window.
-    expect(split('x\nabcdefg')).toEqual({ searched: 'x\n', tail: 'abcdefg' });
+    expect(split('x\nabcdefg')).toEqual({
+      searchable: 'x\n',
+      tail: 'abcdefg',
+      tailSearched: false,
+    });
   });
 
   describe('past the ceiling', () => {
@@ -55,8 +83,9 @@ describe('splitAtLastLine', () => {
       // Ten bytes, no terminator, cap of eight: the tail windows the last eight
       // rather than keeping the whole line.
       expect(split('abcdefghij')).toEqual({
-        searched: 'abcdefghij',
+        searchable: 'abcdefghij',
         tail: 'cdefghij',
+        tailSearched: true,
       });
     });
 
@@ -64,9 +93,14 @@ describe('splitAtLastLine', () => {
       // What a naive implementation gets wrong: cutting at `length - cap` and
       // searching only `[0, cut)` looks at 'ab' alone and retains 'cdefghij', so
       // a match spanning the two — complete in this one buffer — is never seen.
-      const { searched } = split('abcdefghij');
+      expect(split('abcdefghij').searchable).toBe('abcdefghij');
+    });
 
-      expect(searched).toBe('abcdefghij');
+    it('reports a windowed tail as already searched', () => {
+      // The caller must not search it again at end of stream. It was covered by
+      // the whole-buffer search above, and searching it alone would treat its
+      // first byte as a line start — letting `^` match a line starting earlier.
+      expect(split('abcdefghij').tailSearched).toBe(true);
     });
 
     it('windows a partial line that outgrew the cap even with a terminator present', () => {
@@ -74,14 +108,19 @@ describe('splitAtLastLine', () => {
       // tail windows to the cap, and the whole buffer is searched, so bytes
       // dropped from the tail are not dropped from the search.
       expect(split('a\nbcdefghijk')).toEqual({
-        searched: 'a\nbcdefghijk',
+        searchable: 'a\nbcdefghijk',
         tail: 'defghijk',
+        tailSearched: true,
       });
     });
 
     it('is exactly at the cap without windowing', () => {
       // Eight bytes of tail against a cap of eight is not over it.
-      expect(split('abcdefgh')).toEqual({ searched: '', tail: 'abcdefgh' });
+      expect(split('abcdefgh')).toEqual({
+        searchable: '',
+        tail: 'abcdefgh',
+        tailSearched: false,
+      });
     });
   });
 
@@ -89,9 +128,9 @@ describe('splitAtLastLine', () => {
     // Called once per chunk, so the split must not add a copy on top of the
     // concatenation already being paid for.
     const buffer = encoder.encode('a\nbc');
-    const { searched, tail } = splitAtLastLine(buffer, 8);
+    const { searchable, tail } = splitAtLastLine(buffer, 8);
 
-    expect(searched.buffer).toBe(buffer.buffer);
+    expect(searchable.buffer).toBe(buffer.buffer);
     expect(tail.buffer).toBe(buffer.buffer);
   });
 });

--- a/packages/netgrep/src/lib/splitAtLastLine.spec.ts
+++ b/packages/netgrep/src/lib/splitAtLastLine.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { splitAtLastLine } from './splitAtLastLine.js';
+
+/**
+ * The buffer arithmetic behind BACKLOG 3a's fix, on its own.
+ *
+ * A pure function specifically so this can be a table in Node: reaching the
+ * over-the-ceiling branches through `Netgrep.search` needs a >64 KB fixture with
+ * no line breaks, which pins the same logic far more expensively. The real
+ * ceiling is exercised end-to-end in `Netgrep.integration.spec.ts`.
+ *
+ * `cap` is 8 throughout, so the overflow cases fit on one line.
+ */
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+/** Run the split on a string, and read both halves back as strings. */
+function split(input: string, cap = 8) {
+  const { searched, tail } = splitAtLastLine(encoder.encode(input), cap);
+
+  return { searched: decoder.decode(searched), tail: decoder.decode(tail) };
+}
+
+describe('splitAtLastLine', () => {
+  it('searches the complete lines and carries the partial one', () => {
+    expect(split('a\nbc')).toEqual({ searched: 'a\n', tail: 'bc' });
+  });
+
+  it('carries everything when no line has completed yet', () => {
+    // BACKLOG 3a itself: searching these in isolation misses a word that
+    // continues in the next chunk.
+    expect(split('abc')).toEqual({ searched: '', tail: 'abc' });
+  });
+
+  it('carries nothing when the buffer ends exactly on a terminator', () => {
+    expect(split('ab\n')).toEqual({ searched: 'ab\n', tail: '' });
+  });
+
+  it('splits at the LAST terminator, not the first', () => {
+    expect(split('a\nb\ncd')).toEqual({ searched: 'a\nb\n', tail: 'cd' });
+  });
+
+  it('handles an empty buffer', () => {
+    expect(split('')).toEqual({ searched: '', tail: '' });
+  });
+
+  it('keeps a whole-line tail regardless of how long it is, under the cap', () => {
+    // Seven bytes of tail against a cap of eight: still exact, no window.
+    expect(split('x\nabcdefg')).toEqual({ searched: 'x\n', tail: 'abcdefg' });
+  });
+
+  describe('past the ceiling', () => {
+    it('falls back to a byte window when a line outgrows the cap', () => {
+      // Ten bytes, no terminator, cap of eight: the tail windows the last eight
+      // rather than keeping the whole line.
+      expect(split('abcdefghij')).toEqual({
+        searched: 'abcdefghij',
+        tail: 'cdefghij',
+      });
+    });
+
+    it('searches the WHOLE buffer when it windows, dropping nothing', () => {
+      // What a naive implementation gets wrong: cutting at `length - cap` and
+      // searching only `[0, cut)` looks at 'ab' alone and retains 'cdefghij', so
+      // a match spanning the two — complete in this one buffer — is never seen.
+      const { searched } = split('abcdefghij');
+
+      expect(searched).toBe('abcdefghij');
+    });
+
+    it('windows a partial line that outgrew the cap even with a terminator present', () => {
+      // A buffer can hold a completed line and still have an over-long tail. The
+      // tail windows to the cap, and the whole buffer is searched, so bytes
+      // dropped from the tail are not dropped from the search.
+      expect(split('a\nbcdefghijk')).toEqual({
+        searched: 'a\nbcdefghijk',
+        tail: 'defghijk',
+      });
+    });
+
+    it('is exactly at the cap without windowing', () => {
+      // Eight bytes of tail against a cap of eight is not over it.
+      expect(split('abcdefgh')).toEqual({ searched: '', tail: 'abcdefgh' });
+    });
+  });
+
+  it('returns views, not copies', () => {
+    // Called once per chunk, so the split must not add a copy on top of the
+    // concatenation already being paid for.
+    const buffer = encoder.encode('a\nbc');
+    const { searched, tail } = splitAtLastLine(buffer, 8);
+
+    expect(searched.buffer).toBe(buffer.buffer);
+    expect(tail.buffer).toBe(buffer.buffer);
+  });
+});

--- a/packages/netgrep/src/lib/splitAtLastLine.ts
+++ b/packages/netgrep/src/lib/splitAtLastLine.ts
@@ -11,14 +11,22 @@ const LINE_FEED = 0x0a;
  * internal to the streaming loop.
  */
 type BufferSplit = {
-  /** Safe to search. Empty when no complete line has arrived yet. */
-  searched: Uint8Array;
+  /** Safe to hand to the engine. Empty when no complete line has arrived. */
+  searchable: Uint8Array;
+
+  /** Bytes to prepend to the next chunk. */
+  tail: Uint8Array;
 
   /**
-   * Bytes to prepend to the next chunk. NOT yet searched — the caller must
-   * search it when the stream ends, or the final line is lost.
+   * Whether `searchable` already covered `tail`.
+   *
+   * True only in the windowed case, where `searchable` is the whole buffer and
+   * therefore includes the retained bytes. The caller must not search the tail
+   * again when the stream ends: it would rescan up to `cap` bytes, and — because
+   * a windowed tail starts mid-line — would let `^` match at the window's first
+   * byte, inventing a match on a line that does not begin there.
    */
-  tail: Uint8Array;
+  tailSearched: boolean;
 };
 
 /**
@@ -39,22 +47,25 @@ type BufferSplit = {
  * buffer an entire response. Past it, exactness degrades to a plain byte window:
  * a match shorter than `cap` still survives the boundary, a longer one does not.
  * @returns
- * The two halves, as views into `buffer` rather than copies.
+ * The two halves — views into `buffer`, not copies — and whether the tail still
+ * needs searching.
  */
 export function splitAtLastLine(buffer: Uint8Array, cap: number): BufferSplit {
-  // `+ 1` cuts AFTER the terminator, so `searched` is whole lines and `tail`
+  // `+ 1` cuts AFTER the terminator, so `searchable` is whole lines and `tail`
   // starts a fresh one. Absent a terminator this is 0 and everything waits.
   let cut = buffer.lastIndexOf(LINE_FEED) + 1;
 
-  const overflowing = buffer.length - cut > cap;
+  const windowed = buffer.length - cut > cap;
 
-  if (overflowing) cut = buffer.length - cap;
+  if (windowed) cut = buffer.length - cap;
 
   return {
-    // Required, not an optimisation: when overflowing, the bytes between the
-    // last terminator and the new cut leave the tail, so searching only
-    // `[0, cut)` would drop them unscanned and lose a match that arrived whole.
-    searched: overflowing ? buffer : buffer.subarray(0, cut),
+    // Searching the WHOLE buffer when windowed is required, not an optimisation:
+    // the bytes between the last terminator and the new cut leave the tail, so
+    // searching only `[0, cut)` would drop them unscanned and lose a match that
+    // arrived complete in one chunk.
+    searchable: windowed ? buffer : buffer.subarray(0, cut),
     tail: buffer.subarray(cut),
+    tailSearched: windowed,
   };
 }

--- a/packages/netgrep/src/lib/splitAtLastLine.ts
+++ b/packages/netgrep/src/lib/splitAtLastLine.ts
@@ -1,0 +1,60 @@
+/**
+ * The only byte that ends a line here: `packages/search` builds its matcher with
+ * `line_terminator(Some(b'\n'))` and no multi-line mode.
+ */
+const LINE_FEED = 0x0a;
+
+/**
+ * A buffer divided into what can be searched now and what must wait.
+ *
+ * Not under `data/` — everything there is published API surface; this is
+ * internal to the streaming loop.
+ */
+type BufferSplit = {
+  /** Safe to search. Empty when no complete line has arrived yet. */
+  searched: Uint8Array;
+
+  /**
+   * Bytes to prepend to the next chunk. NOT yet searched — the caller must
+   * search it when the stream ends, or the final line is lost.
+   */
+  tail: Uint8Array;
+};
+
+/**
+ * Split a buffer at its last line terminator, so a match straddling a `fetch`
+ * chunk boundary is still found.
+ *
+ * A match can never span a `\n` — the matcher rejects patterns that could match
+ * the terminator and strips it from character classes — so the incomplete
+ * trailing line is the *exact* carry-over between chunks, with no guess at match
+ * length. Asserted by `test_a_match_cannot_span_a_line_terminator` in
+ * `packages/search/tests/search.rs`, which names this function; if it goes red,
+ * that invariant no longer holds and this function is wrong.
+ *
+ * @param buffer
+ * The previous chunk's retained tail followed by the new chunk.
+ * @param cap
+ * Ceiling on the returned `tail`, without which one terminator-free line would
+ * buffer an entire response. Past it, exactness degrades to a plain byte window:
+ * a match shorter than `cap` still survives the boundary, a longer one does not.
+ * @returns
+ * The two halves, as views into `buffer` rather than copies.
+ */
+export function splitAtLastLine(buffer: Uint8Array, cap: number): BufferSplit {
+  // `+ 1` cuts AFTER the terminator, so `searched` is whole lines and `tail`
+  // starts a fresh one. Absent a terminator this is 0 and everything waits.
+  let cut = buffer.lastIndexOf(LINE_FEED) + 1;
+
+  const overflowing = buffer.length - cut > cap;
+
+  if (overflowing) cut = buffer.length - cap;
+
+  return {
+    // Required, not an optimisation: when overflowing, the bytes between the
+    // last terminator and the new cut leave the tail, so searching only
+    // `[0, cut)` would drop them unscanned and lose a match that arrived whole.
+    searched: overflowing ? buffer : buffer.subarray(0, cut),
+    tail: buffer.subarray(cut),
+  };
+}

--- a/packages/search/tests/search.rs
+++ b/packages/search/tests/search.rs
@@ -184,19 +184,13 @@ mod search {
         // so a pattern can never straddle two lines. This is the engine-level
         // half of why netgrep answers "does this pattern occur on some line".
         //
-        // ⚠️ LOAD-BEARING FOR packages/netgrep/src/lib/splitAtLastLine.ts.
+        // ⚠️ LOAD-BEARING FOR packages/netgrep/src/lib/splitAtLastLine.ts,
+        // which carries the incomplete trailing LINE between `fetch` chunks
+        // because a line is the largest unit a match can occupy.
         //
-        // That module carries the incomplete trailing LINE between `fetch`
-        // chunks, which closed BACKLOG 3a. It is *exact* — not a guess at match
-        // length, as issue #20 proposed — for one reason: a line is the largest
-        // unit a match can occupy.
-        //
-        // If this goes red after a dependency bump, BACKLOG 3a IS BACK and no
-        // JavaScript test will notice — the tail would carry one line while
-        // matches spanned more, and boundary misses would resume being silent
-        // and network-dependent. Relaxing an assertion here means the tail has
-        // to grow to cover whatever now matches across lines; it is not a
-        // licence to accept the new behaviour on its own.
+        // If this goes red, BACKLOG 3a is back and no JavaScript test will
+        // notice. Relaxing an assertion here means growing that tail to cover
+        // whatever now matches across lines, not accepting the new behaviour.
         assert!(!matches(b"alpha\nbeta", "alpha.beta"));
         assert!(!matches(b"alpha\nbeta", "(?s)alpha.beta"));
 

--- a/packages/search/tests/search.rs
+++ b/packages/search/tests/search.rs
@@ -183,8 +183,38 @@ mod search {
         // `.` excludes the line terminator, and no multiline mode is enabled,
         // so a pattern can never straddle two lines. This is the engine-level
         // half of why netgrep answers "does this pattern occur on some line".
+        //
+        // ⚠️ LOAD-BEARING FOR packages/netgrep/src/lib/splitAtLastLine.ts.
+        //
+        // That module carries the incomplete trailing LINE between `fetch`
+        // chunks, which closed BACKLOG 3a. It is *exact* — not a guess at match
+        // length, as issue #20 proposed — for one reason: a line is the largest
+        // unit a match can occupy.
+        //
+        // If this goes red after a dependency bump, BACKLOG 3a IS BACK and no
+        // JavaScript test will notice — the tail would carry one line while
+        // matches spanned more, and boundary misses would resume being silent
+        // and network-dependent. Relaxing an assertion here means the tail has
+        // to grow to cover whatever now matches across lines; it is not a
+        // licence to accept the new behaviour on its own.
         assert!(!matches(b"alpha\nbeta", "alpha.beta"));
         assert!(!matches(b"alpha\nbeta", "(?s)alpha.beta"));
+
+        // The escape hatches, all closed: grep-regex strips the terminator from
+        // character classes rather than trusting the pattern to avoid it.
+        assert!(!matches(b"alpha\nbeta", "alpha[^x]beta"));
+        assert!(!matches(b"alpha\nbeta", r"alpha\sbeta"));
+        assert!(!matches(b"alpha\nbeta", r"alpha[\s\S]beta"));
+        assert!(!matches(b"alpha\nbeta", r"alpha\W beta"));
+
+        // And a literal terminator is REJECTED, not quietly ignored, so a
+        // cross-line match cannot even be asked for.
+        for pattern in [r"alpha\nbeta", "alpha\nbeta", r"alpha\x0abeta"] {
+            assert!(
+                try_search_bytes(b"alpha\nbeta", pattern).is_err(),
+                "{pattern:?} should be rejected, not merely unmatched"
+            );
+        }
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
Closes #20. Closes BACKLOG **3a** and **3b**, plus **11**; narrows **18**.

## The issue's premise was wrong, in a useful way

Each `fetch` chunk was searched independently, so a pattern spanning the seam was never matched — a silent `false`, non-deterministic because it depended on how the network split the response.

#20 proposed a configured byte cap, reasoning that the maximum match length of an arbitrary regex is not derivable from the pattern. True, but beside the point: **it is derivable from the data.** A match can never span a `\n`. I probed every escape hatch:

```
"alpha.beta"        => false     "alpha\nbeta"    => Err("the literal \"\n\" is not allowed in a regex")
"(?s)alpha.beta"    => false     "alpha\\nbeta"   => Err(same)
"alpha[^x]beta"     => false     "alpha\\x0abeta" => Err(same)
"alpha[\s\S]beta"   => false
```

grep-regex strips the terminator out of character classes and *rejects* a pattern containing a literal one. So the exact carry-over between chunks is the incomplete trailing **line**, and no guess about match length is needed.

```ts
let cut = buffer.lastIndexOf(LINE_FEED) + 1;      // 0 when no line has completed
const overflowing = buffer.length - cut > cap;
if (overflowing) cut = buffer.length - cap;

return {
  searched: overflowing ? buffer : buffer.subarray(0, cut),
  tail: buffer.subarray(cut),
};
```

| input | regime | guarantee |
|---|---|---|
| every line under 64 KB — all prose, Markdown, source | line tail | **a chunk boundary never hides a match** |
| a line over 64 KB — minified JS, a single-line dump | 64 KB byte window | a match shorter than 64 KB is never hidden |

`MAX_TAIL_BYTES` is a safety valve so one terminator-free line cannot buffer an entire response, not a tuning knob — hence not configurable. The measurement #20 asked for: the demo corpus is 2.6 MB over 54,496 lines, and its longest line is **76 bytes** (every file maxes out between 74 and 76).

## Two things fall out for free

**Boundary false *positives* go away.** A chunk searched as though it were a whole document made the seam look like a line start to `^` and a line end to `$`. Never separately tracked, equally silent, equally network-dependent:

```
serve(['hello won', 'derful world'])   ~ 'won$'     ->  true    # before
                                       ~ '^derful'  ->  true    # before
```

**Every byte is scanned exactly once**, so the double-report problem #20 flagged for #3 (return the matching line) is designed out rather than deferred.

## 3a could not ship alone

The docs say 3a and 3b interact because a naive fix to either drains the stream. That is a shared failure mode of bad fixes, not a coupling. The real one is sharper: **3a was suppressing early resolution.** A search whose match straddled a boundary missed, so it drained and cached the whole file, harmlessly. Closing 3a leaves more searches resolving early and more prefixes cached — a regression to the *default* configuration.

So cache entries are now written only once the reader reports `done`. A partial entry is never created rather than created and flagged, which is less code than the per-chunk upsert it replaces. That also closes **11** (deferring the write means collecting and joining once — exactly what the item asks for; chunks are collected only when the cache is enabled, so a search with it off no longer retains a whole file for a cache it never writes to) and removes **18**'s corrupting half (entries are assigned from a complete file, so two concurrent searches stop joining the file to itself). 18's duplicate fetch is untouched and stays open.

## Also fixed, found while building it

The recursive `handleReader` call was never chained to the executor's promise, so a rejection from any chunk after the first was unhandled and the search **never settled**. Latent before — pattern errors fail identically on chunk one — but reachable after this change, since a newline-free multi-chunk stream searches nothing until the flush. `serve(chunked('no newlines here', 8))` with pattern `(` would have hung instead of rejecting.

## Behaviour changes

- **Early resolution is line-granular, not chunk-granular.** Invisible against real 16–64 KB chunks; two extra reads against the suite's deliberately tiny ones.
- **Newline-free input buffers up to 64 KB before its first search.** Still correct — the end-of-stream flush catches a file under the ceiling — just later.
- **`enableMemoryCache: false` is no longer a workaround for a correctness defect**, only a memory/bandwidth trade.

## What this does not fix

**3g, new:** a single match longer than 64 KB, split across chunks. Needs a line over 64 KB *and* a match spanning most of it. Pinned alongside its control case — the same match arriving in **one** chunk *is* found, because the buffer is searched whole before the window is taken. Getting that backwards turns the residual into a regression, and it is the one part of `splitAtLastLine` that is easy to write wrong.

Deliberately **not** given a demo caveat, for the same reason as 17: the corpus cannot reach it. Recorded as a decision rather than an omission.

**3f is not fixed**, and its assertion had to move. The engine now gets a block of complete lines rather than a network chunk, so in the old fixture the NUL fell outside the block and the match survived. The same bytes with a trailing newline still lose it. It stays pinned with an accurate fixture, plus a separate assertion recording the incidental narrowing so it cannot be mistaken for a fix. Decision 0011 records that case — a defect test going green because a *different* change moved the boundary the defect operates on — which §2.1 did not previously cover.

## Tests

**77 TS tests** (was 59) and 28 Rust. Four defect assertions inverted in place per §2.1, one added for 3g.

`splitAtLastLine` is a separate module, not a private function, so its edge cases are a table in Node with `cap = 8` rather than a >64 KB browser fixture. It is not re-exported by `index.ts` — that file is `export *`, so exporting it from `Netgrep.ts` would have made it public API.

`test_a_match_cannot_span_a_line_terminator` is extended with every escape hatch above and now names its JavaScript dependant: **if it goes red after a dependency bump, 3a is back and no JavaScript test will notice.**

## Demo site

The 3a caveat is removed (it said "Live on this page"). The cache stays off, but the stated reason is rewritten: not because the cache is unsafe, which it no longer is, but because **the page measures the network** — a miss drains the stream and therefore caches, so a warm cache would have the StatsBar time a `Record` lookup and present it as a download. §2.3's "fix 3b and 18, then turn it on" instruction is retracted, since following it would quietly break the numbers.

## Notes for review

- **The README marks 3a and 3b as fixed but not yet released**, since npm still has 0.2.0. No version bump here — that is maintainer-only.
- Decisions 0002, 0006, 0011 and 0017 are amended rather than rewritten. 0002's "must therefore be a configured cap" paragraph is left standing *above* its correction on purpose: that reasoning is why the bug stayed open for years.
- `AGENTS.md` §8 gains two comment conventions requested during review — keep comments terse, and keep them standalone rather than pointing at a document for the explanation. `CONTRIBUTING.md`'s test counts were stale before this PR (58/25) and are corrected to 77/28.

Full gate green: `pnpm lint && pnpm typecheck && pnpm build && pnpm test && pnpm test:rust && pnpm verify:pack`, plus `typecheck:example` and `build:example`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
