### PR TITLE
feat(netgrep): return the first matching line, on request

### DIFF
--- a/.claude/skills/wasm-release/SKILL.md
+++ b/.claude/skills/wasm-release/SKILL.md
@@ -77,7 +77,7 @@ as ESM, copies the version out of `Cargo.toml`, **and deletes the `.gitignore` w
 `pkg/`** — that file contains `*`, npm honours it, and it is what emptied the tarball. Do not skip the
 second step.
 
-→ `packages/search/pkg/`: `index.js`, `index_bg.js`, `index_bg.wasm` (~1.15 MB), `index.d.ts`,
+→ `packages/search/pkg/`: `index.js`, `index_bg.js`, `index_bg.wasm` (~1.16 MB), `index.d.ts`,
 `package.json`. Gitignored.
 
 **What gets published is `packages/search/package.json`**, a hand-written wrapper with `"files": ["pkg"]` —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,23 +11,40 @@ Everything below was verified end-to-end on **2026-07-30** (macOS arm64, Node 24
 
 netgrep is a port of [ripgrep](https://github.com/BurntSushi/ripgrep) to WebAssembly that searches remote
 files **over HTTP while they are still downloading**. It answers exactly one question: *does this pattern
-occur in the file at this URL?* — a boolean, nothing more.
+occur in the file at this URL?* — a boolean, plus, if the caller asks for it, the first matching line
+([decision 0020](docs/decisions/0020-the-matching-line.md)). Nothing more: no line numbers, no offsets, no
+match counts, no ranking.
 
 The intended use case is a client-side search over a small, static, file-based corpus (e.g. Markdown posts
 emitted by a static site generator), instead of standing up an index-based search backend.
 
 **It is an experiment, and the README says so first.** netgrep is not claimed to be a good way to build
 search — a prebuilt index (Pagefind, Lunr, FlexSearch, a hosted service) is usually smaller, faster and more
-capable, and can rank, snippet and locate matches, none of which netgrep does. What the project explores is
-the narrower question of whether ripgrep's real engine can usefully run over HTTP against files as they
-download. Keep that framing when you touch user-facing text: describe what it does and what it costs, and do
-not sell it.
+capable, and can rank and locate matches, neither of which netgrep does. What the project explores is the
+narrower question of whether ripgrep's real engine can usefully run over HTTP against files as they download.
+Keep that framing when you touch user-facing text: describe what it does and what it costs, and do not sell
+it.
 
-**Project status: maintained, conservative.** The toolchain is current and CI is green. Keep it that way:
-fix defects, keep dependencies from rotting, keep it working for existing consumers. **Do not add features.**
-The public API is deliberately small — a boolean per URL — and widening it (match positions, line numbers,
-Node support) is a design conversation, not a task to pick up. See [`docs/BACKLOG.md`](docs/BACKLOG.md) for
-sanctioned work.
+**Project status: maintained, conservative.** The toolchain is current and CI is green. Keep it that way: fix
+defects, keep dependencies from rotting, keep it working for existing consumers. That is still the bulk of the
+work, and [`docs/BACKLOG.md`](docs/BACKLOG.md) is where it is listed.
+
+**A feature needs an issue and a decision record before it needs a diff.** This rule used to read "do not add
+features", full stop. It was changed when [0020](docs/decisions/0020-the-matching-line.md) shipped the first
+widening of the API, because a project cannot ship a feature under a document forbidding them — but the
+friction is the point and it is kept. So:
+
+- **Open an issue and argue it there first.** The proposal that became 0020 was
+  [#19](https://github.com/dgopsq/netgrep/issues/19), and the argument in it changed the design twice before
+  any code was written. Do not skip to a pull request.
+- **The record ships with the change**, in the same PR — including a *Rejected alongside* section naming what
+  the feature does **not** open the door to. Every widening makes the next ask more reasonable; writing the
+  refusals down at the moment of acceptance is the only brake this repository has.
+- **The API is still deliberately small.** A boolean per URL, plus the matching line on request. Line numbers,
+  byte offsets, match counts, all-matches, context lines, highlight ranges and ranking have each been
+  considered and refused — see 0020's table before re-opening any of them. Node support is untouched by this
+  and remains a design conversation.
+- **If it changes what a result contains or costs, §2.3 applies**: the published demo has to agree with it.
 
 ---
 
@@ -93,13 +110,13 @@ is exactly why it is in this section rather than in a comment somewhere.
 | Fix 3f | Remove or rewrite its entry in the `CAVEATS` array of [`packages/example/src/components/limitations.tsx`](packages/example/src/components/limitations.tsx) — it is the only open defect with one |
 | Fix 3g or 17 | Nothing on the site to remove: neither has an entry, for the reasons below. Check that still holds rather than assuming it |
 | Add a new defect to `docs/BACKLOG.md` | Decide whether a visitor is affected. If so, add a caveat; if not, no action — but make it a decision, not an omission |
-| Change what netgrep returns or costs | Check the hero copy and the `StatsBar` line, which state "one boolean per file" and the 1.15 MB WebAssembly download |
+| Change what netgrep returns or costs | Check the hero copy and the `StatsBar` line, which state the scope of a result and the 1.16 MB WebAssembly download |
 
 **The three caveats currently on the site map to backlog items like this**, so you can find yours quickly:
 
 | Caveat on the site | Backlog |
 |---|---|
-| One boolean per file | *none* — by design, [decision 0003](docs/decisions/0003-boolean-only-results.md). Will never be "fixed" |
+| No ranking, no positions | *none* — by design, [decision 0003](docs/decisions/0003-boolean-only-results.md) as amended by [0020](docs/decisions/0020-the-matching-line.md). Will never be "fixed". It was titled "One boolean per file" until `captureLine` made that false |
 | This demo runs with the cache off | *none* — a choice about what the page measures, see below |
 | Binary files stop at the first NUL | **3f** |
 
@@ -162,7 +179,7 @@ pnpm build:wasm        # REQUIRED FIRST — see §2.2
 |---|---|---|
 | Prepare a checkout | `pnpm bootstrap` | Install + WASM + browser. Idempotent — see §4.1 |
 | New worktree | `pnpm worktree <branch>` | `git worktree add` beside this checkout, then bootstrap it |
-| Build WASM | `pnpm build:wasm` | → `packages/search/pkg/`, ~1.15 MB `index_bg.wasm` |
+| Build WASM | `pnpm build:wasm` | → `packages/search/pkg/`, ~1.16 MB `index_bg.wasm` |
 | Build TS | `pnpm build` | → `packages/netgrep/dist/` |
 | Lint | `pnpm lint` | Biome (JS/TS) **and** clippy (`-D warnings`); `lint:js` / `lint:rust` run one each |
 | Format | `pnpm format` | Biome, writes in place |
@@ -287,9 +304,11 @@ Three packages, ~530 lines of first-party source. pnpm workspaces link them; the
 ```
 packages/
   search/            Rust → WASM core. The actual search engine.
-    src/lib.rs         ~135 lines, mostly comment. Exports one function:
-                       search_bytes(&[u8], &str) -> Result<bool, JsError>, which caches
-                       the last compiled matcher. See decision 0016
+    src/lib.rs         ~250 lines, mostly comment. Exports two functions, sharing
+                       one compiled-matcher memo (decision 0016):
+                         search_bytes(&[u8], &str) -> Result<bool, JsError>
+                         search_bytes_line(&[u8], &str, usize)
+                             -> Result<Option<String>, JsError>   see decision 0020
     tests/search.rs    plain native `cargo test` — no browser, no WebDriver.
                        Ends with a `documented_defects` module; read §2.1 first
     scripts/post_build.js   fixes up the generated pkg/ (see below)
@@ -356,7 +375,7 @@ manifests cannot drift, and **deletes the `.gitignore` wasm-pack writes into `pk
 | Goal | File |
 |---|---|
 | Matching semantics (regex flags, case sensitivity, binary handling) | `packages/search/src/lib.rs` |
-| What a result contains | `packages/search/src/lib.rs` **and** `packages/netgrep/src/lib/data/NetgrepResult.ts` |
+| What a result contains | `packages/search/src/lib.rs` **and** `packages/netgrep/src/lib/data/NetgrepResult.ts`. Read [decision 0020](docs/decisions/0020-the-matching-line.md) first — it lists what has already been refused |
 | Streaming, batching, caching, abort behaviour | `packages/netgrep/src/lib/Netgrep.ts` |
 | A config option | `packages/netgrep/src/lib/data/NetgrepConfig.ts` or `NetgrepSearchConfig.ts` |
 | Build or release steps | root `package.json` scripts, `packages/*/package.json` scripts, `.github/workflows/` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,9 +184,9 @@ pnpm build:wasm        # REQUIRED FIRST — see §2.2
 | Lint | `pnpm lint` | Biome (JS/TS) **and** clippy (`-D warnings`); `lint:js` / `lint:rust` run one each |
 | Format | `pnpm format` | Biome, writes in place |
 | Typecheck | `pnpm typecheck` | `tsc --noEmit`, TypeScript 7 |
-| Test TS | `pnpm test` | Vitest — **84 tests**: 48 unit in Node, 36 integration in headless Chromium |
+| Test TS | `pnpm test` | Vitest — **110 tests**: 63 unit in Node, 47 integration in headless Chromium |
 | — one suite | `pnpm test:unit` / `pnpm test:browser` | The two Vitest projects separately. `test:unit` needs no WASM and no browser |
-| Test Rust | `pnpm test:rust` | `cargo test`, native, no browser — **28 tests** |
+| Test Rust | `pnpm test:rust` | `cargo test`, native, no browser — **45 tests** |
 | Verify packaging | `pnpm verify:pack` | Packs both packages and inspects the tarballs. **Needs `pnpm build` first** |
 | Run the demo | `pnpm dev` | Vite, at <http://localhost:5173/>. **Needs `pnpm build` first** — see below |
 | Typecheck the demo | `pnpm typecheck:example` | Separate from `pnpm typecheck`; **needs `pnpm build` first** |
@@ -317,7 +317,7 @@ packages/
     → published as @netgrep/search
 
   netgrep/           TypeScript wrapper. Streaming + batching + caching.
-    src/lib/Netgrep.ts               the whole public API (~300 lines)
+    src/lib/Netgrep.ts               the whole public API (~510 lines)
     src/lib/splitAtLastLine.ts       the chunk-boundary tail arithmetic, pure and
                                      unit-tested on its own. NOT re-exported by
                                      index.ts — see decision 0018

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,14 @@
 # Contributing
 
 netgrep is an **experiment**, and it is maintained conservatively: fix defects, keep dependencies from
-rotting, keep it working for existing consumers. **New features are out of scope** — the public API is
-deliberately one boolean per URL, and widening it is a design conversation rather than a pull request. See
-[`docs/BACKLOG.md`](docs/BACKLOG.md) for work that is already sanctioned.
+rotting, keep it working for existing consumers. That is most of the work, and
+[`docs/BACKLOG.md`](docs/BACKLOG.md) lists what is already sanctioned.
+
+**A feature starts as an issue, not as a pull request.** The public API is deliberately small — a boolean per
+URL, plus the first matching line on request — and it has widened exactly once. Argue the case in an issue
+first; if it is accepted it lands with a decision record that also says what it does *not* open the door to.
+[Decision 0020](docs/decisions/0020-the-matching-line.md) is the worked example, and its closing table lists
+the match details that have already been refused.
 
 [`AGENTS.md`](AGENTS.md) is the authoritative guide to this repository — toolchain pins, the repository map,
 the hard rules, the known correctness caveats. This file is the short human on-ramp; where the two overlap,

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ each file resolve as it downloads. Its known limitations are listed on the page,
 > **This is an experiment, not a recommendation.** Netgrep is almost certainly not the best way to add search
 > to your site. A prebuilt index — [Pagefind](https://pagefind.app/), [Lunr](https://lunrjs.com/),
 > [FlexSearch](https://github.com/nextapps-de/flexsearch), or a hosted service — will usually be smaller,
-> faster and far more capable: it can rank results, show snippets and tell you *where* a term appears, none
-> of which netgrep does.
+> faster and far more capable: it can rank results and tell you *where* a term appears, neither of which
+> netgrep does. Netgrep can hand you the first matching line, and that is the end of what it knows.
 >
 > What this project explores is a narrower question: what happens if you take ripgrep's actual search engine,
 > compile it to WebAssembly, and run it over HTTP against files *while they are still downloading*? The
@@ -30,7 +30,7 @@ At the moment Netgrep is just going to tell whether a pattern is present on a re
 
 - **A browser.** Netgrep needs `fetch` with a readable response body stream. There is no Node.js support.
 - **ESM.** The package is distributed as ESM only — there is no CommonJS `require` entry point.
-- **A ~1.15 MB WebAssembly download** (~480 KB gzipped), fetched once per page load. Most of it is the regex
+- **A ~1.16 MB WebAssembly download** (~500 KB gzipped), fetched once per page load. Most of it is the regex
   engine's Unicode tables. This is the main cost of the approach, and it is worth weighing against your
   corpus size before adopting it.
 
@@ -124,6 +124,45 @@ A single search resolves to a result carrying the answer and whatever metadata y
 }
 ```
 
+### The matching line
+
+Pass `captureLine` and the result also carries the **first matching line** of the file. Nothing else changes,
+and a search without it costs exactly what it always did — the engine has a separate entry point, so the
+boolean path allocates nothing and copies no string out of WebAssembly.
+
+```ts
+const output = await NG.search(url, 'Sherlock', undefined, { captureLine: true });
+
+if (output.result) {
+  console.log(output.line); // `string` — no null check needed
+}
+```
+
+The flag's effect is in the type, so TypeScript tells you which shape you have:
+
+| Called with | Type of the result |
+|---|---|
+| no config, or `{ captureLine: false }` | `{ url, pattern, result: boolean, metadata? }` — **there is no `line` key**, and reading one is a compile error |
+| `{ captureLine: true }` | `result` becomes a discriminant: `{ result: true, line: string }` or `{ result: false, line: null }` |
+
+`maxLineBytes` caps it, defaulting to **4096**. The truncation happens inside WebAssembly, before the copy, so
+pointing netgrep at minified JavaScript costs you a snippet rather than a megabyte per file. The cut is taken
+on a UTF-8 character boundary, and setting the cap without `captureLine` is a compile error.
+
+Three things to know about the string:
+
+- **The line terminator is stripped** — a trailing `\n`, and a `\r` immediately before it — so you can render
+  it directly.
+- **An empty line is a match.** `line` can be `""` when the pattern matches a blank line, and `""` is falsy.
+  Branch on `result`, never on `line`.
+- **Decoding is lossy.** Bytes that are not valid UTF-8 — a latin-1 file, say — become `U+FFFD`. The match
+  itself is unaffected; the engine works on bytes.
+
+Line numbers, byte offsets, match counts, every matching line, context lines and highlight ranges are all
+deliberately absent, and each was considered and refused —
+[decision 0020](docs/decisions/0020-the-matching-line.md) says why for each. If you need them, you need an
+index.
+
 The batch methods add an `error` field, and this is the part worth reading twice:
 
 ```ts
@@ -201,16 +240,20 @@ tests so they cannot change unnoticed; the full analysis is in
   of each chunk and prepends it to the next, which is exact — a match can never cross a newline — so ordinary
   text is unaffected no matter how the network splits the response. The exception is a line with no terminator
   in 64 KB, such as minified JavaScript or a one-line data dump: past that ceiling the retained bytes become a
-  plain 64 KB window, so a match **longer** than the window is lost, and `^` can match at a window edge where no
-  line actually begins. Newline-free input is also answered more slowly, because nothing can be searched until
-  the ceiling fills or the download ends.
+  plain 64 KB window, so a match **longer** than the window is lost, `^` can match at a window edge where no
+  line actually begins, and a line captured with `captureLine` is a mid-line fragment rather than a line —
+  `result` stays correct in that last case. Newline-free input is also answered more slowly, because nothing can
+  be searched until the ceiling fills or the download ends.
 - **A file containing a NUL byte reports no match** for the block of lines containing it, even when the match
   came earlier. Binary detection abandons what it is given rather than stopping at the NUL.
 - **`$` does not match on CRLF files.** The line terminator is `\n`, so on Windows-authored text the `\r`
   sits between your text and the anchor: `needle$` misses what `needle` finds. `^` is unaffected.
-- **Two concurrent searches of the same URL are not de-duplicated.** Both download the file. The answers are
-  correct and the cache entry is correct; the second request is simply wasted. Await one search of a URL before
-  starting another if that matters.
+- **Concurrent searches of one URL are only de-duplicated when the cache is on.** With
+  `enableMemoryCache: true` the second caller waits for the first and is answered from the entry it writes.
+  With the cache off there is no entry to hand over, so both download the file — the answers are still correct,
+  the second request is simply wasted. Two residuals even with the cache on: a first caller that matches early
+  resolves without reading to the end, so it writes no entry and its waiter fetches after all; and a failed
+  download is not inherited, so the waiter retries with its own signal.
 
 ### Fixed, and not yet in a published release
 
@@ -219,6 +262,12 @@ code; this one describes the gap until the next release.
 
 - **A match spanning two network chunks used to be missed** — a silent `false` that depended on how the network
   chunked the response. See the first limitation above for what remains of it.
+- **Concurrent searches of one URL both downloaded it**, and both appended what they read to the same cache
+  entry — so the entry held the file twice, joined with no separator, forming a line the file never contained.
+  A per-URL registry of in-flight downloads now makes the second caller wait for the first. See the limitation
+  above for the case that remains.
+- **The matching line was not available at all.** `captureLine` is new; the version on npm returns a boolean
+  and nothing else.
 - **The cache could answer a later search wrongly.** A search resolves the moment it finds a match and stops
   downloading, which used to leave the cache holding only the beginning of the file with nothing marking it
   incomplete. An entry is now written **only once the whole file has been read**, so a search that resolves

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,8 +7,10 @@ How netgrep is built and why it behaves the way it does. For *decisions* and the
 
 ## Scope
 
-netgrep answers one question: **does `pattern` occur in the file at `url`?** The answer is a `boolean`.
-No line numbers, no byte offsets, no matched text, no match counts.
+netgrep answers one question: **does `pattern` occur in the file at `url`?** The answer is a `boolean`, and —
+if the caller passes `captureLine` — the **first matching line**. No line numbers, no byte offsets, no match
+counts, no ranking; [decision 0020](decisions/0020-the-matching-line.md) records why the line was the only one
+of these worth adding, and why the rest stay refused.
 
 The distinguishing property is *when* it answers: the search runs against each chunk of the HTTP response
 **as it arrives**, so a match in the first kilobyte resolves without waiting for the remaining megabytes.
@@ -18,12 +20,13 @@ bundler configuration**: since 0.2.0 the WASM is loaded through a standard
 `new URL('index_bg.wasm', import.meta.url)`, which Vite, webpack 5, Rollup, esbuild, Parcel and Bun all
 understand out of the box.
 
-**Non-goals:** indexing, ranking, snippets, highlighting, Node.js support, filesystem search, a CLI.
+**Non-goals:** indexing, ranking, highlighting, match positions, Node.js support, filesystem search, a CLI.
 
 **It is an experiment rather than a recommended way to build search**, and the public README leads with that.
 A prebuilt index will usually beat it on size, speed and capability; what netgrep tests is whether ripgrep's
 real engine is usable over HTTP against files as they download. That framing is why the correctness caveats
-below are documented rather than hidden, and why the API has stayed a boolean.
+below are documented rather than hidden, and why the API has widened exactly once, deliberately, in four
+years.
 
 ---
 
@@ -70,11 +73,21 @@ never compiled. See [decision 0001](decisions/0001-fork-ripgrep-for-wasm.md).
 
 ```rust
 pub fn search_bytes(chunk: &[u8], pattern: &str) -> Result<bool, JsError>
+pub fn search_bytes_line(chunk: &[u8], pattern: &str, max_line_bytes: usize)
+    -> Result<Option<String>, JsError>
 ```
 
-wasm-bindgen unwraps that `Result`, so the TypeScript a consumer sees is
-`search_bytes(chunk: Uint8Array, pattern: string): boolean` — it simply **throws** on a pattern the regex
-engine will not accept, rather than trapping the instance as it did until 2026.
+wasm-bindgen unwraps those `Result`s, so the TypeScript a consumer sees is
+`search_bytes(chunk: Uint8Array, pattern: string): boolean` and
+`search_bytes_line(chunk: Uint8Array, pattern: string, max_line_bytes: number): string | undefined` — both
+simply **throw** on a pattern the regex engine will not accept, rather than trapping the instance as they did
+until 2026.
+
+The second entry point exists so the first stays free. `Netgrep.ts` calls one or the other depending on
+`captureLine`, so a caller who wants only membership allocates nothing, decodes nothing and copies no string
+out of WebAssembly — the same call it has always made. `undefined` is the only no-match signal it returns: a
+pattern matching an empty line yields `""`, which is falsy. Both share one compiled-matcher memo, so their
+matching semantics cannot drift apart.
 
 Per call it:
 
@@ -103,7 +116,7 @@ The release profile (`lto`, `opt-level = 's'`, `codegen-units = 1`, `panic = 'ab
 **workspace root** `Cargo.toml`. It has to: Cargo silently ignores `[profile.*]` in a member package, and for
 most of this project's life the size-tuned profile sat in `packages/search/Cargo.toml` doing nothing at all.
 
-`index_bg.wasm` is **~1.15 MB** (1,148,922 bytes; ~480 KB gzipped) — every consumer downloads it. Roughly a
+`index_bg.wasm` is **~1.16 MB** (1,164,691 bytes; ~500 KB gzipped) — every consumer downloads it. Roughly a
 third is `regex-automata`'s DFA and Unicode tables.
 
 ---
@@ -224,11 +237,13 @@ a seam.
 
 > **Residual (item 3g) — a line longer than 64 KB.** Such a line would otherwise buffer an entire response, so
 > past a 64 KB ceiling (`MAX_TAIL_BYTES`, not configurable) the tail degrades to a plain window on the last
-> 64 KB. Inside such a line, two things break in opposite directions: a match **longer** than 64 KB is lost, and
-> `^` can match at the window's first byte because a windowed tail starts mid-line and the engine cannot be told
-> so. Both need a line longer than 64 KB, so both are unreachable in hand-written text — the demo corpus is
-> 2.6 MB of prose whose longest line is 76 bytes. Pinned by the two `BACKLOG 3g` tests in
-> `Netgrep.integration.spec.ts`, each alongside its control case.
+> 64 KB. Inside such a line, three things break: a match **longer** than 64 KB is lost; `^` can match at the
+> window's first byte, because a windowed tail starts mid-line and the engine cannot be told so; and a line
+> captured with `captureLine` begins at that same arbitrary byte, so it is a fragment rather than a line —
+> `result` stays correct, and returning `null` there was rejected in
+> [decision 0020](decisions/0020-the-matching-line.md). All three need a line longer than 64 KB, so all three
+> are unreachable in hand-written text — the demo corpus is 2.6 MB of prose whose longest line is 76 bytes.
+> Pinned by the three `BACKLOG 3g` tests in `Netgrep.integration.spec.ts`, each alongside its control case.
 
 Newline-free input is answered more slowly than before, since nothing is searched until the ceiling fills or
 the stream ends. Correct either way — the end-of-stream flush catches a file smaller than the ceiling.
@@ -269,7 +284,8 @@ dropped even when it occurs before the NUL, and even on an earlier line. Any rem
 NUL therefore reports "no match" for content that is demonstrably present.
 
 Quitting on binary input is a reasonable ripgrep default; the surprise is that the API cannot distinguish
-"binary, not searched" from "no match", because the API is a boolean.
+"binary, not searched" from "no match" — `captureLine` does not help, since a discarded block reports no match
+and therefore no line.
 
 Decision 0018 changed the *shape* of this without fixing it. What the engine is handed is no longer the network
 chunk but the block of complete lines within it, so how far a NUL reaches now depends on where the last `\n`

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,8 +1,13 @@
 # Maintenance backlog
 
 **Project status: maintained, conservative.** This list is scoped to keeping netgrep correct, buildable and
-releasable. It contains **no feature work** — no new APIs, no match details, no Node.js support. If something
-here seems to need a new feature, stop and ask rather than expanding scope.
+releasable, and everything currently *open* on it is a defect or a piece of health work.
+
+**Feature work is not planned here.** It starts as an issue, is argued there, and lands with a decision record
+that also says what it does *not* open the door to — see
+[`../AGENTS.md` §1](../AGENTS.md#1-what-this-project-is). A completed feature is recorded in *Done* below like
+anything else, so the numbering stays a single sequence. If an item here seems to need a new feature, stop and
+open an issue rather than expanding its scope.
 
 Item numbers are stable and referenced from code comments and other documents. **Do not renumber.** Completed
 items move to the bottom rather than disappearing.
@@ -47,20 +52,26 @@ residual, recorded as **3g** below.
 
 What 3a's fix does not cover. `splitAtLastLine` retains the incomplete trailing *line* between chunks, which is
 exact — a match cannot span a `\n`. But a line with no terminator in it would buffer an entire response, so
-past a 64 KB ceiling the tail degrades to a plain window on the last 64 KB. Two consequences, in both
+past a 64 KB ceiling the tail degrades to a plain window on the last 64 KB. Three consequences, in both
 directions:
 
 - **A match longer than 64 KB is lost**, because it starts before the retained window and ends after the buffer.
 - **`^` can match where no line begins.** A windowed tail starts mid-line and the engine cannot be told so, so
   it anchors to the window's first byte. A false positive, unlike every other entry in this list.
+- **A captured line is a mid-line fragment.** Added by item 19: with `captureLine` on, the string returned for
+  a match inside an over-long line begins at whatever byte the window fell on, so it is not a line. `result` is
+  still right. Returning `null` instead was rejected in [decision 0020](decisions/0020-the-matching-line.md) —
+  it would cost every consumer a null check on a branch the type has already narrowed, to describe a case only
+  minified input reaches.
 
 Needs one line longer than 64 KB **and** a match spanning most of it, so it is unreachable in hand-written
 text: the demo corpus is 2.6 MB of prose whose longest line is 76 bytes. Reachable in minified JavaScript or a
 single-line data dump.
 
-Pinned by the two `BACKLOG 3g` tests in `Netgrep.integration.spec.ts`, each with the control case that must not
-regress — a match arriving complete in **one** chunk is found, because the buffer is searched whole before the
-window is taken, and `^` does not match when the window is never flushed on its own.
+Pinned by the three `BACKLOG 3g` tests in `Netgrep.integration.spec.ts`, each with the control case that must
+not regress — a match arriving complete in **one** chunk is found, because the buffer is searched whole before
+the window is taken; `^` does not match when the window is never flushed on its own; and a line captured from a
+single chunk starts where the line starts.
 
 **Deliberately not on the demo site**, for the same reason as item 17: the corpus cannot trigger it. Recorded in
 the comment block of `limitations.tsx` so that stays a decision rather than an omission.
@@ -111,9 +122,10 @@ Found on 2026-07-29 while broadening the test suite. Pinned in the `documented_d
 
 ## P2 — Health
 
-### 14. The `.wasm` is ~1.15 MB, up 10.6% from the 2022 build
+### 14. The `.wasm` is ~1.16 MB, up 12.1% from the 2022 build
 
-1,038,608 → 1,148,922 bytes. Accounted for (all measured 2026-07-28, release builds through `wasm-pack`):
+1,038,608 → 1,164,691 bytes. Accounted for (dependency rows measured 2026-07-28, release builds through
+`wasm-pack`):
 
 | change | bytes |
 |---|---|
@@ -122,10 +134,14 @@ Found on 2026-07-29 while broadening the test suite. Pinned in the `documented_d
 | removing `wee_alloc` | +6,839 |
 | moving `[profile.release]` to the workspace root | −155,469 |
 | `codegen-units = 1`, `panic = 'abort'` | −76,166 |
-| **net** | **+110,314** |
+| `search_bytes_line` and its line post-processing (item 19, 2026-07-30) | +15,769 |
+| **net** | **+126,083** |
 
 The bulk is upstream — newer `regex-automata` carries larger DFA and Unicode tables — and is not really
-reducible without giving up the modern crates. Roughly 480 KB gzipped over the wire.
+reducible without giving up the modern crates. Roughly 502 KB gzipped over the wire.
+
+The demo's `StatsBar` states this number to visitors, so it moves when this does — see
+[`../AGENTS.md` §2.3](../AGENTS.md#23-️-fixing-a-defect-is-not-finished-until-the-demo-site-stops-warning-about-it).
 
 Remaining levers, none taken: `opt-level = 'z'` (a further ~27 KB, at some throughput cost in a
 regex-scanning hot path); `wasm-opt -Oz`; disabling `grep-regex`'s Unicode support, which would change
@@ -161,6 +177,7 @@ analysis was wrong.
 
 | # | Item | Outcome |
 |---|---|---|
+| 19 | Return the matching line alongside the boolean | **Shipped, and only because 3a landed first.** [Issue #19](https://github.com/dgopsq/netgrep/issues/19) proposed it against a `MemSink` that no longer existed — item 13 had already made it short-circuit, so the "closes 13 for free" argument was void and the sketch's ~10 lines were a diff already applied. What made it worth doing instead was [0018](decisions/0018-line-oriented-tail-buffer.md): before it, each chunk was searched alone, so a first occurrence straddling a seam was missed and the line returned was silently the file's *second* match, varying with how the network split the response. With whole lines delivered in order, the line is the file's first matching line under any chunking — pinned across six chunk sizes — and the warm cache agrees with a cold fetch. Opt-in via `captureLine`, a **second** WASM export so `search_bytes` is untouched and the boolean path allocates nothing, capped in Rust before the copy (`maxLineBytes`, default 4096), terminator stripped, decoded lossily. The flag's effect is in the type: no `line` key at all when off, and `result` is a discriminant when on. Left a residual in **3g** — inside an over-long line the "line" is a fragment. `.wasm` +15,769 bytes. 16 Rust tests, 20 TypeScript. See [0020](decisions/0020-the-matching-line.md), which also names the match details refused alongside it. |
 | 18 | Concurrent searches of one url both fetch | **Fixed, for cache-on instances only — and that is the whole design rather than a shortcut.** A per-url registry of in-flight searches; a second caller of the same url waits on the first and answers from the entry it writes. The entry *is* the handover, so with the cache **off** there is nothing to hand over: sharing would mean either retaining every chunk of a file nobody asked to keep — the cost [0018](decisions/0018-line-oriented-tail-buffer.md) had just removed — or teeing the response stream and with it the first caller's abort signal. So with the cache off both callers still fetch, deliberately, and a test pins it. Two more residuals, both pinned: a first caller that matches early resolves without draining, writes no entry, and its waiter fetches after all — one saved request is the common case, not a guarantee; and a failed download is not inherited by its waiter, which retries with its own signal. `searchBatch` and `searchBatchWithCallback` inherit the de-duplication for free, since both go through `search`. The demo is untouched: it runs with the cache off on purpose, because the page measures the network. See [0019](decisions/0019-in-flight-fetch-registry.md). |
 | 3a | Chunk-boundary false negatives | **Fixed, and the design question in [issue #20](https://github.com/dgopsq/netgrep/issues/20) had a wrong premise.** That issue said the tail size must be a configured cap because the maximum match length of an arbitrary regex is not derivable from the pattern. True — but it is derivable from the *data*: a match can never span a `\n`, because grep-regex strips the terminator out of character classes and rejects patterns containing a literal one. So the exact carry-over is the incomplete trailing **line**, and no cap is needed for correctness. `MAX_TAIL_BYTES` (64 KB, not configurable) exists only so a line with no terminator cannot buffer a 500 MB response; past it the tail degrades to a byte window, which is item **3g**. Fixing it also removed the never-tracked mirror-image false *positives*, where a seam looked like a line start to `^` and a line end to `$`. Early resolution became line-granular, which costs two extra reads in one test and nothing against real 16–64 KB chunks. Four assertions inverted. See [0018](decisions/0018-line-oriented-tail-buffer.md). |
 | 3b | Poisoned partial cache | **Fixed, and it had to ship with 3a.** Not for the reason recorded here — "a naive fix drains the stream" is a shared failure mode of bad fixes, not a coupling. The real one: 3a was *suppressing* early resolution, so closing it alone would have left more searches resolving early, more prefixes cached, and a regression in the default configuration. The fix is smaller than the completeness flag this entry proposed: write the entry only when the reader reports `done`, so a partial one is never created. A partial entry cannot resume a download either, and nothing needed it to. Note a match in the *final* chunk still caches nothing — `done` is one read later. |

--- a/docs/decisions/0003-boolean-only-results.md
+++ b/docs/decisions/0003-boolean-only-results.md
@@ -1,6 +1,9 @@
 # 0003 — Return a boolean, not match details
 
-**Status:** Accepted.
+**Status:** Accepted, then **amended by [0020](0020-the-matching-line.md)** (2026-07-30), which added the
+first matching line as an opt-in. The default is still a boolean and the reasoning below still explains why;
+what changed is that "and nothing else" became "unless you ask". Read 0020 for what is returned today, and for
+the list of match details that remain refused.
 
 ## Context
 
@@ -28,8 +31,10 @@ a remote file."*
 ## Consequences
 
 - Minimal WASM/JS boundary traffic: one pointer, one length, one bool.
-- No snippets, no highlighting, no ranking, no match counts — so netgrep cannot back a results UI that shows
-  *where* or *how often* a term appears without a second pass in JavaScript.
+- ~~No snippets, no highlighting, no ranking, no match counts — so netgrep cannot back a results UI that shows
+  *where* or *how often* a term appears without a second pass in JavaScript.~~ **Amended 2026-07-30** by
+  [0020](0020-the-matching-line.md): the first matching line is available on request, which removes the second
+  pass for the snippet case. Highlighting, ranking and match counts are still refused, and 0020 says why.
 - Because only membership is needed, the searcher can stop at the first match. Combined with
   [0002](0002-search-while-downloading.md), that is what makes early resolution possible at all.
 - ~~`MemSink` counting rather than short-circuiting is slightly wasteful — `Sink::matched` returns `Ok(true)`

--- a/docs/decisions/0020-the-matching-line.md
+++ b/docs/decisions/0020-the-matching-line.md
@@ -1,0 +1,118 @@
+# 0020 — Return the first matching line, on request
+
+**Status:** Accepted. Widens the public API for the first time, and **amends [0003](0003-boolean-only-results.md)**,
+whose decision — "the answer is a boolean" — no longer holds unconditionally.
+
+Proposed in [issue #19](https://github.com/dgopsq/netgrep/issues/19).
+
+## Context
+
+netgrep answered a boolean per url and nothing else, by the deliberate choice recorded in
+[0003](0003-boolean-only-results.md). That made it a *filter*: a page could list which files matched, but to
+show a reader **why** a file matched it had to re-fetch the file and search it again in JavaScript. The demo
+did exactly that — nothing, in fact, because it had no way to.
+
+Of the three things the README concedes to an index engine — rank, snippet, locate — the snippet is the only
+one netgrep can produce without inventing machinery it has no basis for. Ranking needs a scoring model.
+Positions need offset bookkeeping that fights early exit. **The matching line is already in hand:**
+`Sink::matched` is handed `SinkMatch::bytes()` on every hit, and it was being discarded.
+
+Two things had to be true before this was worth doing, and only one of them was true when the issue was filed.
+
+**The first is that the line has to be a line.** Before [0018](0018-line-oriented-tail-buffer.md) each `fetch`
+chunk was searched in isolation, so a first occurrence straddling a chunk seam was missed entirely and the
+"first" line returned would silently be the file's *second* match — varying run to run with how the network
+split the response. A snippet built on that would have been non-deterministic and wrong in a way a boolean
+never exposed. `splitAtLastLine` fixed it as a side effect of fixing backlog 3a: the engine is now handed
+**whole lines in file order**, so the first match it reports is the file's first matching line, whatever the
+chunking. That is what makes this feature honest, and it is why this record could not have been written two
+commits earlier.
+
+**The second is that a cache hit and a cold fetch must agree.** [0018](0018-line-oriented-tail-buffer.md) also
+made the cache write only from a drained stream, so an entry is the whole file in one buffer. The warm path
+and the cold path now return the same line rather than two different ones.
+
+The issue's own strongest argument against was that this is the top of a slope, not that it is expensive. That
+is answered below rather than dismissed.
+
+## Decision
+
+**Opt-in, per search.** `NetgrepSearchConfig.captureLine` defaults to `false`.
+
+```ts
+const res = await ng.search(url, pattern, undefined, { captureLine: true });
+if (res.result) console.log(res.line); // `string`, no null check
+```
+
+Four choices make up the decision.
+
+**A second WASM export, not a changed one.** `search_bytes` is untouched; `search_bytes_line(chunk, pattern,
+max_line_bytes) -> Option<String>` sits beside it, and both share the compiled-matcher memo of
+[0016](0016-compiled-matcher-memo.md) through a generic `with_matcher`. `@netgrep/search` therefore stays
+backwards-compatible — a minor bump, not a major — and, more importantly, the `captureLine: false` path is
+*structurally* the same call it has always been. "Zero cost when off" is a property of the code rather than a
+claim about it.
+
+**The flag's effect is in the type.** `L` is threaded from `NetgrepSearchConfig<L>` into `NetgrepResult<T, L>`,
+constrained to `boolean` so TypeScript keeps the literal:
+
+- `L = false` — the type is byte-for-byte what it was, with **no `line` key at all**. Reading one is a compile
+  error, not a silent `undefined`, and `tsc` is the proof that existing consumers are unaffected.
+- `L = true` — `result` becomes a discriminant: `{ result: true; line: string } | { result: false; line: null }`.
+  Narrowing on `result` yields a `string`, because a line exists exactly when there was a match.
+- `maxLineBytes` is typed `never` unless `captureLine` is `true`, so setting a cap that would govern nothing is
+  a compile error.
+
+Note the two opposite uses of `never` are deliberate. For the *config* the concern is writing, and `never`
+blocks it perfectly. For the *result* the concern is reading, and `never` would collapse to `undefined` and
+read silently — so there the key is genuinely absent instead.
+
+**`line`, not `snippet`.** It is one line of the file, and the name says so. `snippet` is the vocabulary of the
+index engines netgrep explicitly is not, and it would leave room to quietly change the shape later, which is
+the opposite of what this record is for.
+
+**Bounded in Rust, before the copy.** The line is trimmed of its terminator (`\n`, and a preceding `\r`),
+truncated to `maxLineBytes` on a UTF-8 character boundary, then decoded with `String::from_utf8_lossy` — in
+that order, so the cap applies to content and the lossy pass runs over at most `maxLineBytes`. Default 4096.
+Truncating on the JavaScript side would have paid the megabyte copy it exists to avoid.
+
+## Consequences
+
+- **An empty string is a match.** A pattern matching an empty line returns `""`, which is falsy. `undefined` is
+  the only no-match signal at the boundary, and `runEngine` in `Netgrep.ts` tests for it explicitly. Pinned
+  from both sides: `test_a_match_on_an_empty_line_is_an_empty_string` in `packages/search/tests/search.rs` and
+  "treats an EMPTY line as a match, not a miss" in `Netgrep.spec.ts`. This is the sharpest edge in the feature.
+- **Lossy decoding.** A latin-1 file, or any invalid UTF-8, yields `U+FFFD` in the line. Acceptable for a
+  snippet, and a new class of wrong output that a boolean API could not produce. Documented in the README.
+- **Inside a line longer than 64 KB the "line" is a fragment** — the third consequence of backlog 3g, recorded
+  there. Past `MAX_TAIL_BYTES` the retained tail degrades to a byte window, so the block handed to the engine
+  starts mid-line and the returned string begins at an arbitrary byte. `result` is still correct. Returning
+  `null` in that case was considered and rejected: it would break the `result: true ⇒ line: string` invariant
+  for every consumer, to describe a case only minified input reaches. Pinned in `Netgrep.integration.spec.ts`.
+- **The published demo now shows the line**, and `CAVEATS[0]` changed from "One boolean per file" to "No
+  ranking, no positions". Required by [AGENTS.md §2.3](../../AGENTS.md#23-️-fixing-a-defect-is-not-finished-until-the-demo-site-stops-warning-about-it):
+  the page's only value is that it is accurate, and it was asserting the absence of a feature that now exists.
+- **The `.wasm` grew 15,769 bytes** (1,148,922 → 1,164,691, +1.4%), so the `StatsBar` figure moved from 1.15 MB
+  to 1.16 MB. Backlog 14's table is updated.
+- **The project's stated posture changed.** AGENTS.md §1 said "Do not add features"; it now says feature
+  proposals go through an issue and a decision record. That rule is what made this proposal get argued
+  properly, and the replacement keeps the friction while dropping the contradiction of shipping a feature
+  under a document forbidding them.
+
+## Rejected alongside
+
+Recorded now, while the reasoning is fresh, because the issue's own best objection was the slope rather than
+the cost. Each of these is a reasonable follow-up ask, and each is more expensive than the line:
+
+| Ask | Why not |
+|---|---|
+| **Line numbers** | Requires counting terminators across every chunk, including ones early exit never reads. The count would be of *searched* lines, not file lines, so it would be wrong in exactly the cases anyone would check. |
+| **Byte offsets** | Offsets are relative to the block handed to the engine, not the file. Making them absolute means tracking a running position through the tail buffer and the windowed case, which is bookkeeping that fights [0002](0002-search-while-downloading.md). |
+| **Match counts** | Directly contradicts the short-circuit: counting means scanning the whole file, which is early exit deleted. Measured at 16.4ms → 1.3ms in [0016](0016-compiled-matcher-memo.md), in the wrong direction. |
+| **All matching lines** | Same objection, plus an unbounded result size per file. |
+| **Context lines (`-A`/`-B`)** | Needs lines the block may not contain — the preceding line can be in the previous chunk, already discarded. |
+| **Highlight ranges** | Offsets by another name, and the caller can re-run the pattern against a line it now has. |
+| **Ranking** | netgrep has no term statistics, no document frequencies and no index. There is nothing to rank *with*. The honest answer stays "use an index". |
+
+The line is the last of these that is cheap. If a future ask needs any of the above, the answer is very
+probably Pagefind.

--- a/docs/decisions/0020-the-matching-line.md
+++ b/docs/decisions/0020-the-matching-line.md
@@ -46,9 +46,12 @@ if (res.result) console.log(res.line); // `string`, no null check
 
 Four choices make up the decision.
 
-**A second WASM export, not a changed one.** `search_bytes` is untouched; `search_bytes_line(chunk, pattern,
-max_line_bytes) -> Option<String>` sits beside it, and both share the compiled-matcher memo of
-[0016](0016-compiled-matcher-memo.md) through a generic `with_matcher`. `@netgrep/search` therefore stays
+**A second WASM export, not a changed one.** `search_bytes`'s signature and behaviour are untouched;
+`search_bytes_line(chunk, pattern, max_line_bytes) -> Option<String>` sits beside it. Both share the
+compiled-matcher memo of [0016](0016-compiled-matcher-memo.md) through a generic `with_matcher`, and one
+`build_searcher` — so binary detection cannot drift between them, which would be a difference in `result`
+rather than merely in what comes back alongside it. (`try_search_bytes`'s *internals* did move onto
+`with_matcher`; what callers see did not change.) `@netgrep/search` therefore stays
 backwards-compatible — a minor bump, not a major — and, more importantly, the `captureLine: false` path is
 *structurally* the same call it has always been. "Zero cost when off" is a property of the code rather than a
 claim about it.
@@ -75,6 +78,13 @@ the opposite of what this record is for.
 truncated to `maxLineBytes` on a UTF-8 character boundary, then decoded with `String::from_utf8_lossy` — in
 that order, so the cap applies to content and the lossy pass runs over at most `maxLineBytes`. Default 4096.
 Truncating on the JavaScript side would have paid the megabyte copy it exists to avoid.
+
+`maxLineBytes` is clamped at **both** ends before it crosses. The lower bound is obvious; the upper one is
+not, and matters more: the number reaches the engine through `ToUint32`, which wraps rather than saturates, so
+`Infinity`, `NaN` and 2³² all arrive as **0** — and a cap of 0 returns an empty string for every match, which
+is precisely how a match on an empty line is reported. Left unbounded, the obvious way to spell "no cap"
+produced the one result this API cannot afford to be ambiguous about. `Infinity` is therefore read as the
+largest cap the engine can hold, and `NaN` as no request at all.
 
 ## Consequences
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -15,7 +15,7 @@ reasoning got wrong.
 |---|---|---|
 | [0001](0001-fork-ripgrep-for-wasm.md) | Depend on a fork of ripgrep to reach `wasm32` | **Superseded** — fork dropped; the problem stopped existing |
 | [0002](0002-search-while-downloading.md) | Search each HTTP chunk as it arrives | Accepted — the project's defining property |
-| [0003](0003-boolean-only-results.md) | Return a boolean, not match details | Accepted |
+| [0003](0003-boolean-only-results.md) | Return a boolean, not match details | Accepted — amended by 0020 (**the first matching line is available on request**; everything else is still refused) |
 | [0004](0004-two-package-split.md) | Ship two npm packages, not one | Accepted — amended |
 | [0005](0005-esm-only-distribution.md) | ESM only | Accepted — amended; **a bundler is no longer configured** |
 | [0006](0006-in-memory-cache.md) | Cache downloaded bytes in memory, on by default | Accepted — amended by 0018 (**an entry is written only from a drained stream**, which closed the poisoned-prefix defect) and by 0019 (**the flag now also decides whether concurrent downloads of one url are shared**) |
@@ -32,6 +32,7 @@ reasoning got wrong.
 | [0017](0017-example-as-hosted-demo.md) | The example becomes the hosted demo, and goes back on the maintenance path | Accepted — **reverses the example's frozen-dependency exemption**; amended — custom domain, base path now `/` |
 | [0018](0018-line-oriented-tail-buffer.md) | Retain the incomplete trailing *line* between chunks, and cache only a drained stream | Accepted — closes the chunk-boundary and poisoned-cache defects; **amends 0006** |
 | [0019](0019-in-flight-fetch-registry.md) | De-duplicate concurrent downloads of one url, but only when the cache is on | Accepted — closes the duplicate-fetch defect; **the cache entry is the handover**, so with the cache off both callers still fetch |
+| [0020](0020-the-matching-line.md) | Return the first matching line, opt-in per search | Accepted — **the first widening of the public API**; **amends 0003**, and names the match details still refused |
 
 ## Format
 

--- a/packages/example/index.html
+++ b/packages/example/index.html
@@ -138,7 +138,7 @@
             "@type": "SoftwareSourceCode",
             "@id": "https://netgrep.diegopasquali.com/#library",
             "name": "@netgrep/netgrep",
-            "description": "A JavaScript library that searches remote files while they download, by streaming each HTTP chunk through ripgrep's search engine compiled to WebAssembly. Returns a boolean per file; builds no index and needs no backend.",
+            "description": "A JavaScript library that searches remote files while they download, by streaming each HTTP chunk through ripgrep's search engine compiled to WebAssembly. Returns a boolean per file, and optionally the first matching line; builds no index and needs no backend.",
             "codeRepository": "https://github.com/dgopsq/netgrep",
             "programmingLanguage": ["TypeScript", "Rust"],
             "runtimePlatform": "WebAssembly",

--- a/packages/example/src/App.tsx
+++ b/packages/example/src/App.tsx
@@ -94,6 +94,7 @@ export function App() {
               <StoryCard
                 story={story}
                 status={state.statuses[story.id] ?? 'idle'}
+                line={state.lines[story.id]}
               />
             </li>
           ))}

--- a/packages/example/src/components/limitations.tsx
+++ b/packages/example/src/components/limitations.tsx
@@ -11,7 +11,10 @@ import { Info } from 'lucide-react';
  *
  * Nothing enforces this. No test fails and CI stays green.
  *
- *   "One boolean per file"               -> by design. Stays
+ *   "No ranking, no positions"           -> by design. Stays. Was "One boolean
+ *                                           per file" until captureLine landed
+ *                                           (BACKLOG 19, decision 0020) and
+ *                                           made that sentence false
  *   "This demo runs with the cache off"  -> not a defect: the cache is safe now,
  *                                           but a warm one stops the timings
  *                                           measuring the network
@@ -27,8 +30,8 @@ import { Info } from 'lucide-react';
  */
 const CAVEATS = [
   {
-    title: 'One boolean per file',
-    body: 'netgrep tells you whether a pattern occurs in a file, not where. No line numbers, match positions, snippets or ranking. If you need those, a prebuilt index — Pagefind, Lunr, FlexSearch — is the right tool.',
+    title: 'No ranking, no positions',
+    body: 'netgrep answers whether a pattern occurs in a file, and — if you ask — the first line it occurs on. That is the whole result. No line numbers, byte offsets, match counts, surrounding context or relevance ordering, so it cannot rank these cards by how well they match. If you need that, a prebuilt index — Pagefind, Lunr, FlexSearch — is the right tool.',
   },
   {
     title: 'This demo runs with the cache off',

--- a/packages/example/src/components/limitations.tsx
+++ b/packages/example/src/components/limitations.tsx
@@ -13,8 +13,7 @@ import { Info } from 'lucide-react';
  *
  *   "No ranking, no positions"           -> by design. Stays. Was "One boolean
  *                                           per file" until captureLine landed
- *                                           (BACKLOG 19, decision 0020) and
- *                                           made that sentence false
+ *                                           (BACKLOG 19) and made that false
  *   "This demo runs with the cache off"  -> not a defect: the cache is safe now,
  *                                           but a warm one stops the timings
  *                                           measuring the network

--- a/packages/example/src/components/stats-bar.tsx
+++ b/packages/example/src/components/stats-bar.tsx
@@ -64,7 +64,7 @@ export function StatsBar({ state }: { state: SearchState }) {
 
       <p className="text-muted-foreground/70 ml-auto max-w-xs text-xs leading-relaxed">
         {formatBytes(totalBytes)} of text across {stories.length} files, plus a
-        1.15 MB WebAssembly download once per page load. A query that matches
+        1.16 MB WebAssembly download once per page load. A query that matches
         nothing reads all of it.
       </p>
     </div>

--- a/packages/example/src/components/story-card.tsx
+++ b/packages/example/src/components/story-card.tsx
@@ -9,6 +9,8 @@ import { cn } from '@/lib/utils';
 type StoryCardProps = {
   story: Story;
   status: StoryStatus;
+  /** The first matching line, when this story matched. */
+  line?: string;
 };
 
 /**
@@ -21,6 +23,7 @@ type StoryCardProps = {
 export const StoryCard = memo(function StoryCard({
   story,
   status,
+  line,
 }: StoryCardProps) {
   const isMatch = status === 'match';
   const isMiss = status === 'miss';
@@ -33,6 +36,12 @@ export const StoryCard = memo(function StoryCard({
         // Explicitly NOT `transition-all`: that includes `transform`, which the
         // FLIP reorder animates directly, so the two fight and the glide stutters.
         'relative gap-0 overflow-hidden duration-300',
+        // Fill the grid cell. The `li` stretches to the row's height on its own,
+        // but the card inside it does not, so a match carrying a line made its
+        // whole row taller while every miss in that row stayed at content height
+        // — leaving them floating in a gap and reading as further faded than the
+        // 35% opacity below actually makes them.
+        'h-full',
         'transition-[opacity,border-color,background-color,box-shadow]',
         isMatch &&
           'border-primary/40 bg-primary/[0.06] shadow-[0_0_0_1px_var(--color-primary)/10,0_8px_30px_-12px_var(--color-primary)]',
@@ -80,6 +89,23 @@ export const StoryCard = memo(function StoryCard({
           <p className="text-muted-foreground/70 mt-0.5 font-mono text-[11px]">
             {story.file} · {formatBytes(story.bytes)}
           </p>
+
+          {/*
+            The matching line, rendered only on a match. `line` outlives a
+            status change — the hook keeps it while a new query is in flight —
+            so this is gated on `isMatch` rather than on the string existing,
+            or a card that has just become a miss would still be quoting.
+
+            Clamped to two rows: the library caps the line at a byte count, and
+            a byte count is not a row count in a proportional grid. Without the
+            clamp one long line would make its card taller than the rest of its
+            row.
+          */}
+          {isMatch && line !== undefined && (
+            <p className="border-primary/30 text-foreground/80 mt-2 line-clamp-2 border-l-2 pl-2 font-mono text-[11px] leading-relaxed break-words">
+              {line}
+            </p>
+          )}
         </div>
       </div>
 

--- a/packages/example/src/hooks/use-corpus-search.ts
+++ b/packages/example/src/hooks/use-corpus-search.ts
@@ -8,9 +8,28 @@ import { storyUrl } from '@/lib/story-url';
  */
 export type StoryStatus = 'idle' | 'searching' | 'match' | 'miss' | 'error';
 
+/**
+ * How much of a matching line the demo asks for.
+ *
+ * Well under the library's 4 KB default, because this page renders the line in
+ * two clamped rows and anything past that is copied out of WebAssembly only to
+ * be hidden by CSS. The corpus is prose — its longest line is 76 bytes — so in
+ * practice nothing here is ever truncated; the cap is here because a demo that
+ * ignores its own documented knobs teaches the wrong thing.
+ */
+const MAX_LINE_BYTES = 240;
+
 export type SearchState = {
   /** Status per story id. */
   statuses: Record<string, StoryStatus>;
+  /**
+   * The first matching line, per story id, for stories that matched.
+   *
+   * Kept across runs for the same reason `statuses` is — see the
+   * stale-while-revalidate note below. A card's line is replaced when that
+   * card's own new answer arrives, not when the query changes.
+   */
+  lines: Record<string, string>;
   /** The order the grid renders in — see `settle()` below. */
   order: string[];
   matched: number;
@@ -62,6 +81,7 @@ const alphabetical = stories.map((story) => story.id);
 function idleState(order: string[]): SearchState {
   return {
     statuses: {},
+    lines: {},
     order,
     matched: 0,
     resolved: 0,
@@ -170,6 +190,11 @@ export function useCorpusSearch(pattern: string): SearchState {
               ? 'match'
               : 'miss';
 
+          // Read off the discriminant rather than off `status`: narrowing
+          // `result.result` is what gives `result.line` its `string` type, and
+          // the derived `status` above carries none of that.
+          const line = result.result ? result.line : null;
+
           const statuses = { ...prev.statuses, [id]: status };
           const matched = prev.matched + (status === 'match' ? 1 : 0);
           const resolved = prev.resolved + 1;
@@ -177,6 +202,9 @@ export function useCorpusSearch(pattern: string): SearchState {
 
           return {
             statuses,
+            // A miss leaves the previous line in place, exactly as it leaves
+            // the previous status: the card is repainted by its own answer.
+            lines: line === null ? prev.lines : { ...prev.lines, [id]: line },
             order: done ? settle(statuses) : prev.order,
             matched,
             resolved,
@@ -190,7 +218,11 @@ export function useCorpusSearch(pattern: string): SearchState {
           };
         });
       },
-      { signal: controller.signal },
+      {
+        signal: controller.signal,
+        captureLine: true,
+        maxLineBytes: MAX_LINE_BYTES,
+      },
     );
 
     return () => controller.abort();

--- a/packages/netgrep/README.md
+++ b/packages/netgrep/README.md
@@ -13,6 +13,7 @@ The main `netgrep` package. See the [main README](https://github.com/dgopsq/netg
 > ripgrep's actual search engine to WebAssembly and run it over HTTP against files *while they are still
 > downloading*.
 >
-> It answers one question per URL — *does this pattern occur?* — as a boolean. No ranking, no snippets, no
-> match positions. It has [known limitations](https://github.com/dgopsq/netgrep#known-limitations),
-> including silent false negatives, that are worth reading before you build on it.
+> It answers one question per URL — *does this pattern occur?* — as a boolean, and will hand you the first
+> matching line if you pass `captureLine`. That is the whole result: no ranking, no line numbers, no match
+> positions. It has [known limitations](https://github.com/dgopsq/netgrep#known-limitations) that are worth
+> reading before you build on it.

--- a/packages/netgrep/src/lib/Netgrep.integration.spec.ts
+++ b/packages/netgrep/src/lib/Netgrep.integration.spec.ts
@@ -579,7 +579,7 @@ describe('Netgrep integration (real WASM)', () => {
   });
 
   /**
-   * `captureLine` through the real engine — BACKLOG 19, decision 0020.
+   * `captureLine` through the real engine — BACKLOG 19.
    *
    * What a line CONTAINS given a block of bytes is pinned natively in
    * `packages/search/tests/search.rs`, and the wiring is pinned with the engine
@@ -589,8 +589,9 @@ describe('Netgrep integration (real WASM)', () => {
    * that it is the FILE's first matching line rather than the first one in
    * whichever chunk happened to match.
    *
-   * That property is owed entirely to decision 0018. Before it, each chunk was
-   * searched in isolation, so a first occurrence straddling a seam was missed
+   * That property is owed entirely to the tail buffer — BACKLOG 3a. Before it,
+   * each chunk was searched in isolation, so a first occurrence straddling a seam
+   * was missed
    * and the line returned was the file's *second* match — differing run to run
    * with the network's chunking. `splitAtLastLine` means the engine now sees
    * whole lines in file order, so the answer is the same however the response

--- a/packages/netgrep/src/lib/Netgrep.integration.spec.ts
+++ b/packages/netgrep/src/lib/Netgrep.integration.spec.ts
@@ -579,6 +579,222 @@ describe('Netgrep integration (real WASM)', () => {
   });
 
   /**
+   * `captureLine` through the real engine — BACKLOG 19, decision 0020.
+   *
+   * What a line CONTAINS given a block of bytes is pinned natively in
+   * `packages/search/tests/search.rs`, and the wiring is pinned with the engine
+   * mocked in `Netgrep.spec.ts`. What only this suite can establish is the
+   * property the feature actually rests on: that the line survives the trip
+   * through `fetch`, the tail buffer, the cache and the WASM boundary — and
+   * that it is the FILE's first matching line rather than the first one in
+   * whichever chunk happened to match.
+   *
+   * That property is owed entirely to decision 0018. Before it, each chunk was
+   * searched in isolation, so a first occurrence straddling a seam was missed
+   * and the line returned was the file's *second* match — differing run to run
+   * with the network's chunking. `splitAtLastLine` means the engine now sees
+   * whole lines in file order, so the answer is the same however the response
+   * is split. The first test below is that claim, and it is the reason this
+   * feature could be built at all.
+   */
+  describe('captureLine', () => {
+    const CAPTURE = { captureLine: true } as const;
+
+    it('returns the whole line, not the matched fragment', async () => {
+      serve([encoder.encode(POEM)]);
+
+      await expect(
+        new Netgrep({ enableMemoryCache: false }).search(
+          'url',
+          'aside',
+          undefined,
+          CAPTURE,
+        ),
+      ).resolves.toMatchObject({
+        result: true,
+        line: 'He set aside both Queen and Crown',
+      });
+    });
+
+    it("returns the FILE's first match however the response is chunked", async () => {
+      // The assertion decision 0018 bought. `Wiseman` is on line 1 and again on
+      // the last line, and every chunk size below splits the first occurrence
+      // somewhere different — including straight through the middle of the word.
+      const text =
+        'One Wiseman came to Jhaampe-town.\n' +
+        'He set aside both Queen and Crown\n' +
+        'A second Wiseman followed after.\n';
+
+      const NG = new Netgrep({ enableMemoryCache: false });
+      const lines: Array<string | null> = [];
+
+      for (const size of [1, 3, 7, 16, 40, 1024]) {
+        serve(chunked(text, size));
+
+        const result = await NG.search(
+          `url-${size}`,
+          'Wiseman',
+          undefined,
+          CAPTURE,
+        );
+
+        lines.push(result.result ? result.line : null);
+      }
+
+      // One answer, six chunkings — and it is the first line, not the third.
+      expect(lines).toEqual(Array(6).fill('One Wiseman came to Jhaampe-town.'));
+    });
+
+    it('returns a line that arrived across two chunks, whole', async () => {
+      // The tail buffer holds the incomplete final line back and prepends it to
+      // the next chunk, so the engine is handed the line entire — which means
+      // the line handed BACK is entire too, seam and all.
+      serve([
+        encoder.encode('first line\nHe set aside bo'),
+        encoder.encode('th Queen and Crown\nlast line\n'),
+      ]);
+
+      await expect(
+        new Netgrep({ enableMemoryCache: false }).search(
+          'url',
+          'aside',
+          undefined,
+          CAPTURE,
+        ),
+      ).resolves.toMatchObject({
+        line: 'He set aside both Queen and Crown',
+      });
+    });
+
+    it('gives the same line from the cache as from the network', async () => {
+      // The cache path searches one whole buffer while the streaming path
+      // searches a sequence of line-aligned blocks. Different code, and the
+      // answer has to agree — otherwise a warm page would show a different
+      // snippet than a cold one, which reads as a bug rather than as a cache.
+      serve(chunked(POEM, 7));
+
+      const NG = new Netgrep({ enableMemoryCache: true });
+
+      // A miss first, so the stream drains and the entry is written.
+      await NG.search('url', 'dragon');
+
+      const cold = await new Netgrep({ enableMemoryCache: false }).search(
+        'url',
+        'bones',
+        undefined,
+        CAPTURE,
+      );
+      const warm = await NG.search('url', 'bones', undefined, CAPTURE);
+
+      expect(warm.result && warm.line).toBe(
+        'Gave his bones to the stones to keep.',
+      );
+      expect(cold.result && cold.line).toBe(warm.result && warm.line);
+    });
+
+    it('returns the final line of a file that does not end in a newline', async () => {
+      // Resolved from the held-back tail at `done`, which is a different call
+      // site from the per-chunk one and so worth its own assertion.
+      serve([
+        encoder.encode('first line\n'),
+        encoder.encode('Wiseman at the end'),
+      ]);
+
+      await expect(
+        new Netgrep({ enableMemoryCache: false }).search(
+          'url',
+          'Wiseman',
+          undefined,
+          CAPTURE,
+        ),
+      ).resolves.toMatchObject({ line: 'Wiseman at the end' });
+    });
+
+    it('carries a multi-byte character across the boundary intact', async () => {
+      // The bytes go in as a `Uint8Array` and the line comes back as a JS
+      // string, so this exercises the marshalling in the direction the boolean
+      // API never used.
+      serve(chunked('nothing\nil a bu un café noir\n', 8));
+
+      await expect(
+        new Netgrep({ enableMemoryCache: false }).search(
+          'url',
+          'café',
+          undefined,
+          CAPTURE,
+        ),
+      ).resolves.toMatchObject({ line: 'il a bu un café noir' });
+    });
+
+    it('reports a miss as `line: null`, and omits the key entirely when not asked', async () => {
+      serve([encoder.encode(POEM)]);
+      const NG = new Netgrep({ enableMemoryCache: false });
+
+      await expect(
+        NG.search('a', 'dragon', undefined, CAPTURE),
+      ).resolves.toMatchObject({ result: false, line: null });
+
+      serve([encoder.encode(POEM)]);
+
+      // Not `line: null` — no key at all, so the object agrees with the type.
+      expect(await NG.search('b', 'Wiseman')).not.toHaveProperty('line');
+    });
+
+    it('truncates at maxLineBytes, on a character boundary', async () => {
+      serve([encoder.encode(`needle ${'é'.repeat(50)}\n`)]);
+
+      const result = await new Netgrep({ enableMemoryCache: false }).search(
+        'url',
+        'needle',
+        undefined,
+        { captureLine: true, maxLineBytes: 12 },
+      );
+
+      // 'needle ' is 7 bytes, leaving 5 for two-byte characters — so two of
+      // them, not two and a half. A split would have shown as U+FFFD.
+      expect(result.result && result.line).toBe('needle éé');
+      expect(result.result && result.line).not.toContain('�');
+    });
+
+    it('carries the line through a batch, and never onto a failed url', async () => {
+      mockFetch.mockImplementation((url: string) =>
+        url === 'broken'
+          ? Promise.reject(new Error('offline'))
+          : Promise.resolve({
+              body: streamOfChunks([encoder.encode(POEM)]),
+            }),
+      );
+
+      const results = await new Netgrep({
+        enableMemoryCache: false,
+      }).searchBatch([{ url: 'hit' }, { url: 'broken' }], 'asleep', CAPTURE);
+
+      expect(results).toMatchObject([
+        {
+          url: 'hit',
+          result: true,
+          line: 'Did his task and fell asleep',
+          error: null,
+        },
+        { url: 'broken', result: false, line: null, error: 'offline' },
+      ]);
+    });
+
+    it('rejects an invalid pattern the same way the boolean path does', async () => {
+      serve([encoder.encode(POEM)]);
+
+      await expect(
+        new Netgrep({ enableMemoryCache: false }).search(
+          'url',
+          '(',
+          undefined,
+          CAPTURE,
+        ),
+      ).rejects.toThrow('unclosed group');
+    });
+  });
+
+  /**
    * ---------------------------------------------------------------------
    * DOCUMENTED DEFECTS — these assertions pin behaviour that is WRONG.
    * ---------------------------------------------------------------------
@@ -803,6 +1019,50 @@ describe('Netgrep integration (real WASM)', () => {
       await expect(NG.search('b', '^a')).resolves.toMatchObject({
         result: true,
       });
+    });
+
+    it('BACKLOG 3g: a captured line is a mid-line FRAGMENT inside an over-long line', async () => {
+      // The third consequence of 3g, and the one `captureLine` added.
+      //
+      // Once a line outgrows the 64 KB ceiling the buffer handed to the engine
+      // starts mid-line, so what comes back is not a line: it begins at an
+      // arbitrary byte decided by where the window fell. `result` is still
+      // correct — something did match — but `line` is a fragment, and the type
+      // calls it a line.
+      //
+      // Same precondition as the two 3g tests above, so equally unreachable in
+      // prose: this corpus's longest line is 76 bytes. Not fixable without
+      // either buffering without bound or teaching the engine that a block
+      // starts mid-line, which is offset bookkeeping and out of scope.
+      const NG = new Netgrep({ enableMemoryCache: false });
+      const filler = 'x'.repeat(70_000);
+
+      // Control: one chunk, so the whole line is present and the line comes
+      // back whole — capped, but starting where the line starts.
+      serve([encoder.encode(`START${filler}needle\n`)]);
+
+      const whole = await NG.search('a', 'needle', undefined, {
+        captureLine: true,
+        maxLineBytes: 16,
+      });
+
+      expect(whole.result && whole.line).toBe('STARTxxxxxxxxxxx');
+
+      // Split, and the window has long since dropped 'START'. The line now
+      // "begins" 70 KB into itself.
+      serve([
+        encoder.encode(`START${filler}`),
+        encoder.encode('needle and then some\n'),
+      ]);
+
+      const fragment = await NG.search('b', 'needle', undefined, {
+        captureLine: true,
+        maxLineBytes: 16,
+      });
+
+      expect(fragment.result).toBe(true);
+      expect(fragment.result && fragment.line).toBe('xxxxxxxxxxxxxxxx');
+      expect(fragment.result && fragment.line).not.toContain('START');
     });
 
     it('BACKLOG 3c (FIXED): an invalid pattern rejects, and the engine survives it', async () => {

--- a/packages/netgrep/src/lib/Netgrep.spec.ts
+++ b/packages/netgrep/src/lib/Netgrep.spec.ts
@@ -775,7 +775,7 @@ describe('Netgrep', () => {
   });
 
   /**
-   * `captureLine` — BACKLOG 19, decision 0020.
+   * `captureLine` — BACKLOG 19.
    *
    * What a captured line CONTAINS is the engine's business and is pinned in
    * `packages/search/tests/search.rs`; what reaches it through the real
@@ -905,6 +905,43 @@ describe('Netgrep', () => {
         }
 
         expect([capOf(0), capOf(1), capOf(2), capOf(3)]).toEqual([1, 1, 1, 1]);
+      });
+
+      it('clamps DOWN too, because the conversion wraps rather than saturates', async () => {
+        // ⚠️ The upper bound is the sharp one. The number reaches the engine
+        // through ToUint32, so 2³² and above arrive as 0 — and a cap of 0
+        // returns an empty string for every match, which is precisely how a
+        // match on an empty line is reported. Unbounded, asking for a huge cap
+        // produced the one answer this API cannot afford to be ambiguous about.
+        for (const maxLineBytes of [2 ** 32, 2 ** 40, 0xffffffff]) {
+          await NG.search(url, pattern, undefined, {
+            captureLine: true,
+            maxLineBytes,
+          });
+        }
+
+        expect([capOf(0), capOf(1), capOf(2)]).toEqual([
+          0xffffffff, 0xffffffff, 0xffffffff,
+        ]);
+      });
+
+      it('reads `Infinity` as "no cap", and `NaN` as no request at all', async () => {
+        await NG.search(url, pattern, undefined, {
+          captureLine: true,
+          maxLineBytes: Number.POSITIVE_INFINITY,
+        });
+        await NG.search(url, pattern, undefined, {
+          captureLine: true,
+          maxLineBytes: Number.NaN,
+        });
+
+        // `Infinity` is the obvious way to spell "give me the whole line", so
+        // it becomes the largest cap the engine can hold rather than silently
+        // reverting to the default and ignoring the caller.
+        expect(capOf(0)).toBe(0xffffffff);
+
+        // `NaN` is not a request for anything, so the default stands.
+        expect(capOf(1)).toBe(4096);
       });
 
       it('floors a fractional value rather than passing it on', async () => {

--- a/packages/netgrep/src/lib/Netgrep.spec.ts
+++ b/packages/netgrep/src/lib/Netgrep.spec.ts
@@ -96,20 +96,30 @@ function serveExcept(failing: string, message = 'nope') {
 // `vi.hoisted` is required, not stylistic: `vi.mock` is lifted above the module
 // body, and its factory runs while `./Netgrep.js` is being imported — before a
 // plain `const` here would have been initialised.
-const { mockSearch } = vi.hoisted(() => ({ mockSearch: vi.fn() }));
+const { mockSearch, mockSearchLine } = vi.hoisted(() => ({
+  mockSearch: vi.fn(),
+  mockSearchLine: vi.fn(),
+}));
 
 const mockFetch = vi.fn();
 
-// Mocking the `search_bytes` function. `default` stands in for the WASM
+// Mocking the engine's two entry points. `default` stands in for the WASM
 // module's `init()`, which Netgrep awaits before every search.
 //
 // The arguments are forwarded rather than dropped so that tests can assert
 // WHICH bytes reached the engine — the only way to tell a cache hit from a
-// re-fetch that happened to return the same thing.
+// re-fetch that happened to return the same thing — and, for
+// `search_bytes_line`, which cap did.
+//
+// Both are mocked even though most tests touch only one, because WHICH of them
+// a search calls is itself behaviour: `captureLine` is meant to leave the
+// boolean path untouched, and that is only assertable if the other is
+// observable.
 vi.mock('@netgrep/search', () => {
   return {
     default: () => Promise.resolve(),
     search_bytes: (...args: Array<unknown>) => mockSearch(...args),
+    search_bytes_line: (...args: Array<unknown>) => mockSearchLine(...args),
   };
 });
 
@@ -761,6 +771,226 @@ describe('Netgrep', () => {
           signal: controller.signal,
         });
       }
+    });
+  });
+
+  /**
+   * `captureLine` — BACKLOG 19, decision 0020.
+   *
+   * What a captured line CONTAINS is the engine's business and is pinned in
+   * `packages/search/tests/search.rs`; what reaches it through the real
+   * boundary is `Netgrep.integration.spec.ts`. What is left for here is the
+   * wiring, and the wiring is where this feature can go wrong quietly: calling
+   * the wrong entry point, mistaking an empty line for a miss, or handing Rust
+   * a `usize` it cannot hold.
+   */
+  describe('Netgrep::captureLine', () => {
+    const NG = new Netgrep({ enableMemoryCache: false });
+    const url = 'url';
+    const pattern = 'pattern';
+
+    beforeEach(() => {
+      mockFetch.mockClear();
+      mockSearch.mockClear();
+      mockSearchLine.mockClear();
+
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({ body: genReadableStreamFromString('test\n') }),
+      );
+    });
+
+    it('leaves the boolean path completely alone by default', async () => {
+      mockSearch.mockReturnValue(true);
+
+      const result = await NG.search(url, pattern);
+
+      // The whole promise of the opt-in: not called, so nothing was allocated,
+      // decoded or copied out of WebAssembly.
+      expect(mockSearchLine).not.toHaveBeenCalled();
+      expect(mockSearch).toHaveBeenCalled();
+
+      // And the key is absent rather than `null`, so `'line' in result` agrees
+      // with what the type says.
+      expect(result).not.toHaveProperty('line');
+    });
+
+    it('returns the line the engine found', async () => {
+      mockSearchLine.mockReturnValue('a matching line');
+
+      const result = await NG.search(url, pattern, undefined, {
+        captureLine: true,
+      });
+
+      expect(mockSearch).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        url,
+        pattern,
+        result: true,
+        line: 'a matching line',
+        metadata: undefined,
+      });
+    });
+
+    it('reports no match as `result: false` and `line: null`', async () => {
+      mockSearchLine.mockReturnValue(undefined);
+
+      await expect(
+        NG.search(url, pattern, undefined, { captureLine: true }),
+      ).resolves.toMatchObject({ result: false, line: null });
+    });
+
+    it('treats an EMPTY line as a match, not a miss', async () => {
+      // ⚠️ The trap this whole design has to survive. A pattern matching an
+      // empty line returns `''`, which is falsy — `if (line)` in the streaming
+      // loop would turn a match into a miss, silently, and only for blank
+      // lines.
+      mockSearchLine.mockReturnValue('');
+
+      await expect(
+        NG.search(url, pattern, undefined, { captureLine: true }),
+      ).resolves.toMatchObject({ result: true, line: '' });
+    });
+
+    it('answers from the memory cache with a line too', async () => {
+      const cached = new Netgrep({ enableMemoryCache: true });
+
+      // The first search must MISS. Since decision 0018 the cache is only ever
+      // written from a drained stream, so a search that resolves early leaves
+      // nothing behind — a match would re-fetch here and the assertion below
+      // would be about the wrong thing.
+      mockSearchLine.mockReturnValueOnce(undefined);
+      mockSearchLine.mockReturnValue('from the cached buffer');
+
+      await cached.search(url, pattern, undefined, { captureLine: true });
+      const second = await cached.search(url, pattern, undefined, {
+        captureLine: true,
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(second).toMatchObject({
+        result: true,
+        line: 'from the cached buffer',
+      });
+    });
+
+    describe('the cap', () => {
+      const capOf = (call: number) => mockSearchLine.mock.calls[call][2];
+
+      beforeEach(() => mockSearchLine.mockReturnValue('x'));
+
+      it('defaults to 4096', async () => {
+        await NG.search(url, pattern, undefined, { captureLine: true });
+
+        expect(capOf(0)).toBe(4096);
+      });
+
+      it('passes a caller-supplied value through', async () => {
+        await NG.search(url, pattern, undefined, {
+          captureLine: true,
+          maxLineBytes: 120,
+        });
+
+        expect(capOf(0)).toBe(120);
+      });
+
+      it('clamps values a Rust `usize` could not hold', async () => {
+        // Not rejected, because wasm-bindgen does not validate the number: a
+        // negative would be reinterpreted as an enormous positive and a
+        // fraction would be truncated somewhere less visible than here.
+        for (const maxLineBytes of [0, -1, -4096, 0.5]) {
+          await NG.search(url, pattern, undefined, {
+            captureLine: true,
+            maxLineBytes,
+          });
+        }
+
+        expect([capOf(0), capOf(1), capOf(2), capOf(3)]).toEqual([1, 1, 1, 1]);
+      });
+
+      it('floors a fractional value rather than passing it on', async () => {
+        await NG.search(url, pattern, undefined, {
+          captureLine: true,
+          maxLineBytes: 12.7,
+        });
+
+        expect(capOf(0)).toBe(12);
+      });
+    });
+
+    describe('in a batch', () => {
+      it('carries the line onto every result', async () => {
+        mockSearchLine.mockReturnValue('found here');
+
+        const results = await NG.searchBatch(
+          [{ url: 'a' }, { url: 'b' }],
+          pattern,
+          {
+            captureLine: true,
+          },
+        );
+
+        expect(results).toMatchObject([
+          { url: 'a', result: true, line: 'found here', error: null },
+          { url: 'b', result: true, line: 'found here', error: null },
+        ]);
+      });
+
+      it('gives a failed url `line: null`, never a line', async () => {
+        // An error is not a match, so a caller who narrows on `result` must not
+        // find a line waiting here.
+        mockSearchLine.mockReturnValue('found here');
+        serveExcept('broken');
+
+        const results = await NG.searchBatch(
+          [{ url: 'ok' }, { url: 'broken' }],
+          pattern,
+          { captureLine: true },
+        );
+
+        expect(results).toMatchObject([
+          { url: 'ok', result: true, line: 'found here', error: null },
+          { url: 'broken', result: false, line: null, error: 'nope' },
+        ]);
+      });
+
+      it('omits `line` from a failed url when it was never asked for', async () => {
+        mockSearch.mockReturnValue(true);
+        serveExcept('broken');
+
+        const results = await NG.searchBatch([{ url: 'broken' }], pattern);
+
+        expect(results[0]).not.toHaveProperty('line');
+      });
+    });
+
+    /**
+     * Type-level assertions. These run no code — a `@ts-expect-error` that
+     * stops being an error fails `pnpm typecheck`, which is the point: the
+     * shape of the result is the feature's main safety property, and nothing
+     * at runtime can check it.
+     */
+    it('states in the type whether a line was asked for', async () => {
+      const plain = await NG.search(url, pattern);
+      const _result: boolean = plain.result;
+      // @ts-expect-error no `line` key exists without `captureLine`
+      plain.line;
+
+      const captured = await NG.search(url, pattern, undefined, {
+        captureLine: true,
+      });
+
+      if (captured.result) {
+        // Narrowed to `string` — no null check, because a line exists exactly
+        // when there was a match.
+        const _line: string = captured.line;
+      } else {
+        const _none: null = captured.line;
+      }
+
+      // @ts-expect-error a cap governs nothing without `captureLine`
+      await NG.search(url, pattern, undefined, { maxLineBytes: 100 });
+
+      expect(true).toBe(true);
     });
   });
 });

--- a/packages/netgrep/src/lib/Netgrep.ts
+++ b/packages/netgrep/src/lib/Netgrep.ts
@@ -47,12 +47,11 @@ type EngineHit = {
 const NO_HIT: EngineHit = { result: false, line: null };
 
 /**
- * Run one block of bytes through the engine.
+ * Run one block of bytes through the engine — BACKLOG 19.
  *
- * Two entry points rather than one with a flag, so the `captureLine: false`
- * path is the same call it has always been — nothing is allocated, decoded or
- * copied out of WebAssembly for a caller who only wants membership. See
- * [decision 0020](../../../../docs/decisions/0020-the-matching-line.md).
+ * Two entry points rather than one taking a flag, so the `captureLine: false`
+ * path is the call it has always been: nothing allocated, decoded or copied out
+ * of WebAssembly for a caller who only wants membership.
  */
 function runEngine(
   block: Uint8Array,
@@ -75,16 +74,34 @@ function runEngine(
 }
 
 /**
- * Clamp a caller-supplied `maxLineBytes` into something a Rust `usize` can hold.
+ * The largest cap a Rust `usize` receives intact on wasm32.
+ */
+const MAX_LINE_BYTES_CEILING = 0xffffffff;
+
+/**
+ * Clamp a caller-supplied `maxLineBytes` into something the engine can hold.
  *
- * Clamped rather than validated: wasm-bindgen does not check the number, so a
- * negative or fractional value would be reinterpreted rather than rejected, and
- * throwing on it would be a new failure mode for a cosmetic setting.
+ * Clamped rather than validated: throwing would be a new failure mode for a
+ * cosmetic setting, and wasm-bindgen checks nothing.
+ *
+ * ⚠️ THE UPPER BOUND MATTERS AS MUCH AS THE LOWER ONE. The number crosses the
+ * boundary through ToUint32, which WRAPS rather than saturates, so `Infinity`,
+ * `NaN` and 2³² all arrive as **0** — and a cap of 0 returns an empty string
+ * for every match, which is exactly how a match on an empty line is reported.
+ * Unbounded, the obvious way to ask for no cap silently produced the one result
+ * this API cannot afford to be ambiguous about.
  */
 function resolveMaxLineBytes(requested: number | undefined): number {
-  return requested === undefined
-    ? DEFAULT_MAX_LINE_BYTES
-    : Math.max(1, Math.floor(requested));
+  // Not a request for anything.
+  if (requested === undefined || Number.isNaN(requested)) {
+    return DEFAULT_MAX_LINE_BYTES;
+  }
+
+  // `Infinity` is how a caller spells "no cap", so it becomes the largest cap
+  // rather than falling back to the default and quietly ignoring them.
+  if (requested >= MAX_LINE_BYTES_CEILING) return MAX_LINE_BYTES_CEILING;
+
+  return Math.max(1, Math.floor(requested));
 }
 
 /**
@@ -204,7 +221,7 @@ export class Netgrep {
    * boolean; the result type changes to match, so `line` is a `string` wherever
    * `result` has been narrowed to `true`.
    * @returns
-   * A promise resolving to a `NetgrepResult<T>` as soon as a match will
+   * A promise resolving to a `NetgrepResult<T, L>` as soon as a match will
    * be found in the remote file.
    */
   public async search<T extends object, L extends boolean = false>(
@@ -394,6 +411,7 @@ export class Netgrep {
    * The pattern to search for. This can be anything `ripgrep` can understand.
    * @param config
    * An optional configuration respecting the `NetgrepSearchConfig` type.
+   * `captureLine` applies to every url in the batch, and shapes every result.
    * @returns
    * A promise waiting for all the executed searches to complete.
    */
@@ -426,9 +444,10 @@ export class Netgrep {
    * The pattern to search for. This can be anything `ripgrep` can understand.
    * @param cb
    * The callback that will be triggered at every match. It takes
-   * a `BatchNetgrepResult<T>` as a parameter.
+   * a `BatchNetgrepResult<T, L>` as a parameter.
    * @param config
    * An optional configuration respecting the `NetgrepSearchConfig` type.
+   * `captureLine` applies to every url in the batch, and shapes every result.
    */
   public searchBatchWithCallback<T extends object, L extends boolean = false>(
     inputs: Array<NetgrepInput<T>>,

--- a/packages/netgrep/src/lib/Netgrep.ts
+++ b/packages/netgrep/src/lib/Netgrep.ts
@@ -1,4 +1,4 @@
-import init, { search_bytes } from '@netgrep/search';
+import init, { search_bytes, search_bytes_line } from '@netgrep/search';
 import type { BatchNetgrepResult } from './data/BatchNetgrepResult.js';
 import type { NetgrepConfig } from './data/NetgrepConfig.js';
 import type { NetgrepInput } from './data/NetgrepInput.js';
@@ -23,6 +23,113 @@ const defaultConfig: NetgrepConfig = {
  * A safety valve for input netgrep is not aimed at, so not configurable.
  */
 const MAX_TAIL_BYTES = 64 * 1024;
+
+/**
+ * Ceiling on the returned line when `captureLine` is on and the caller names no
+ * other. Far past any line of prose, and small enough that a minified bundle
+ * costs a snippet rather than a copy of itself.
+ */
+const DEFAULT_MAX_LINE_BYTES = 4096;
+
+/**
+ * What one call into the engine produced.
+ *
+ * `line` is `null` whenever no line was captured — because there was no match,
+ * or because the caller never asked for one. The two are told apart by
+ * `result`, never by inspecting `line`.
+ */
+type EngineHit = {
+  result: boolean;
+  line: string | null;
+};
+
+/** No match, and nothing to show for it. */
+const NO_HIT: EngineHit = { result: false, line: null };
+
+/**
+ * Run one block of bytes through the engine.
+ *
+ * Two entry points rather than one with a flag, so the `captureLine: false`
+ * path is the same call it has always been — nothing is allocated, decoded or
+ * copied out of WebAssembly for a caller who only wants membership. See
+ * [decision 0020](../../../../docs/decisions/0020-the-matching-line.md).
+ */
+function runEngine(
+  block: Uint8Array,
+  pattern: string,
+  captureLine: boolean,
+  maxLineBytes: number,
+): EngineHit {
+  if (!captureLine) {
+    return { result: search_bytes(block, pattern), line: null };
+  }
+
+  const line = search_bytes_line(block, pattern, maxLineBytes);
+
+  // ⚠️ `undefined` is the ONLY no-match signal. A pattern matching an empty
+  // line returns an EMPTY STRING, which is falsy — testing `if (line)` here
+  // would report a match as a miss. Pinned by
+  // `test_a_match_on_an_empty_line_is_an_empty_string` in
+  // `packages/search/tests/search.rs`.
+  return line === undefined ? NO_HIT : { result: true, line };
+}
+
+/**
+ * Clamp a caller-supplied `maxLineBytes` into something a Rust `usize` can hold.
+ *
+ * Clamped rather than validated: wasm-bindgen does not check the number, so a
+ * negative or fractional value would be reinterpreted rather than rejected, and
+ * throwing on it would be a new failure mode for a cosmetic setting.
+ */
+function resolveMaxLineBytes(requested: number | undefined): number {
+  return requested === undefined
+    ? DEFAULT_MAX_LINE_BYTES
+    : Math.max(1, Math.floor(requested));
+}
+
+/**
+ * Assemble a resolved result.
+ *
+ * The `line` key is OMITTED, not set to `null`, when nothing was captured —
+ * `NetgrepResult<T, false>` says the key does not exist, and a result carrying
+ * it anyway would make that a lie to anything reading the object rather than
+ * its type.
+ *
+ * The cast is unavoidable, and confined here and to `withError` below: the
+ * result type is a conditional on `L`, and TypeScript cannot evaluate a
+ * conditional whose parameter is still generic, so no literal built here is
+ * assignable to it. The invariant it asserts — `line` is a `string` exactly
+ * when `result` is `true` — is upheld by `runEngine` above and pinned by the
+ * type tests in `Netgrep.spec.ts`.
+ */
+function toResult<T extends object, L extends boolean>(
+  url: string,
+  pattern: string,
+  metadata: T | undefined,
+  hit: EngineHit,
+  captureLine: boolean,
+): NetgrepResult<T, L> {
+  const base = { url, pattern, result: hit.result, metadata };
+
+  return (captureLine ? { ...base, line: hit.line } : base) as NetgrepResult<
+    T,
+    L
+  >;
+}
+
+/**
+ * Attach a batch's per-url error slot to a result.
+ *
+ * Cast for the same reason as `toResult`: spreading a value whose type is a
+ * conditional on `L` produces something TypeScript cannot check against the
+ * same conditional.
+ */
+function withError<T extends object, L extends boolean>(
+  result: NetgrepResult<T, L>,
+  error: string | null,
+): BatchNetgrepResult<T, L> {
+  return { ...result, error } as BatchNetgrepResult<T, L>;
+}
 
 /**
  * Join a list of byte chunks into one buffer.
@@ -92,19 +199,31 @@ export class Netgrep {
    * An optional object that will be returned back as soon as a match
    * as been found in the file.
    * @param config
-   * An optional configuration respecting the `NetgrepSearchConfig` type.
+   * An optional configuration respecting the `NetgrepSearchConfig` type. Pass
+   * `{ captureLine: true }` to get the first matching line back alongside the
+   * boolean; the result type changes to match, so `line` is a `string` wherever
+   * `result` has been narrowed to `true`.
    * @returns
    * A promise resolving to a `NetgrepResult<T>` as soon as a match will
    * be found in the remote file.
    */
-  public async search<T extends object>(
+  public async search<T extends object, L extends boolean = false>(
     url: string,
     pattern: string,
     metadata?: T,
-    config?: NetgrepSearchConfig,
-  ): Promise<NetgrepResult<T>> {
+    config?: NetgrepSearchConfig<L>,
+  ): Promise<NetgrepResult<T, L>> {
     // Nothing below can run before the engine exists.
     await wasmReady;
+
+    // One cast, here, rather than at every read: `maxLineBytes` is typed
+    // `L extends true ? number : never`, which is not a `number` while `L` is
+    // still generic. Its runtime value is whatever the caller passed, and
+    // `resolveMaxLineBytes` treats that as untrusted anyway.
+    const captureLine = config?.captureLine === true;
+    const maxLineBytes = resolveMaxLineBytes(
+      config?.maxLineBytes as number | undefined,
+    );
 
     if (this.config.enableMemoryCache) {
       // Waited on ONCE, not until the url is quiet. Looping until no download
@@ -122,16 +241,26 @@ export class Netgrep {
       const cached = this.memoryCache[url];
 
       if (cached) {
-        return {
+        // The whole file in one buffer, so the first matching line here is the
+        // file's first matching line — the same one a cold fetch reports.
+        return toResult<T, L>(
           url,
           pattern,
-          result: search_bytes(cached, pattern),
           metadata,
-        };
+          runEngine(cached, pattern, captureLine, maxLineBytes),
+          captureLine,
+        );
       }
     }
 
-    const running = this.executeSearch<T>(url, pattern, metadata, config);
+    const running = this.executeSearch<T, L>(
+      url,
+      pattern,
+      metadata,
+      config,
+      captureLine,
+      maxLineBytes,
+    );
 
     if (this.config.enableMemoryCache) {
       this.inFlight[url] = running;
@@ -156,12 +285,14 @@ export class Netgrep {
    * Knows nothing about the cache read or the in-flight registry: `search`
    * decides whether this needs to run at all.
    */
-  private executeSearch<T extends object>(
+  private executeSearch<T extends object, L extends boolean>(
     url: string,
     pattern: string,
-    metadata?: T,
-    config?: NetgrepSearchConfig,
-  ): Promise<NetgrepResult<T>> {
+    metadata: T | undefined,
+    config: NetgrepSearchConfig<L> | undefined,
+    captureLine: boolean,
+    maxLineBytes: number,
+  ): Promise<NetgrepResult<T, L>> {
     return new Promise((resolve, reject) => {
       // The incomplete final line seen so far, held back until the rest of it
       // arrives — BACKLOG 3a. Annotated because `subarray` yields an
@@ -195,12 +326,14 @@ export class Netgrep {
             // covered by the whole-buffer search that produced it, and searching
             // it alone would treat its first byte as a line start — letting `^`
             // match a line that begins earlier.
-            const result =
-              tailPending && tail.length > 0 && search_bytes(tail, pattern);
+            const hit =
+              tailPending && tail.length > 0
+                ? runEngine(tail, pattern, captureLine, maxLineBytes)
+                : NO_HIT;
 
             this.commitMemoryCache(url, chunks, caching);
 
-            resolve({ url, pattern, result, metadata });
+            resolve(toResult<T, L>(url, pattern, metadata, hit, captureLine));
             return;
           }
 
@@ -220,11 +353,13 @@ export class Netgrep {
           tailPending = !tailSearched;
 
           // A chunk with no terminator in it searches nothing and grows the tail.
-          const result =
-            searchable.length > 0 && search_bytes(searchable, pattern);
+          const hit =
+            searchable.length > 0
+              ? runEngine(searchable, pattern, captureLine, maxLineBytes)
+              : NO_HIT;
 
-          if (result) {
-            resolve({ url, pattern, result: true, metadata });
+          if (hit.result) {
+            resolve(toResult<T, L>(url, pattern, metadata, hit, captureLine));
           } else {
             // `.catch` because this promise is not chained to the executor's:
             // without it, a rejection from any chunk after the first (dropped
@@ -262,24 +397,18 @@ export class Netgrep {
    * @returns
    * A promise waiting for all the executed searches to complete.
    */
-  public searchBatch<T extends object>(
+  public searchBatch<T extends object, L extends boolean = false>(
     inputs: Array<NetgrepInput<T>>,
     pattern: string,
-    config?: NetgrepSearchConfig,
-  ): Promise<Array<BatchNetgrepResult<T>>> {
+    config?: NetgrepSearchConfig<L>,
+  ): Promise<Array<BatchNetgrepResult<T, L>>> {
     return Promise.all(
       inputs.map((input) => {
         const { url } = input;
 
-        return this.search(url, pattern, input.metadata, config)
-          .then((res) => ({ ...res, error: null }))
-          .catch((err) => ({
-            url,
-            result: false,
-            pattern,
-            metadata: input.metadata,
-            error: this.serializeError(err),
-          }));
+        return this.search<T, L>(url, pattern, input.metadata, config)
+          .then((res) => withError<T, L>(res, null))
+          .catch((err) => this.toFailure<T, L>(input, pattern, err, config));
       }),
     );
   }
@@ -301,26 +430,38 @@ export class Netgrep {
    * @param config
    * An optional configuration respecting the `NetgrepSearchConfig` type.
    */
-  public searchBatchWithCallback<T extends object>(
+  public searchBatchWithCallback<T extends object, L extends boolean = false>(
     inputs: Array<NetgrepInput<T>>,
     pattern: string,
-    cb: (result: BatchNetgrepResult<T>) => void,
-    config?: NetgrepSearchConfig,
+    cb: (result: BatchNetgrepResult<T, L>) => void,
+    config?: NetgrepSearchConfig<L>,
   ): void {
     inputs.forEach((input) => {
-      const { url } = input;
-      this.search(url, pattern, input.metadata, config)
-        .then((res) => cb({ ...res, error: null }))
-        .catch((err) =>
-          cb({
-            url,
-            result: false,
-            pattern,
-            metadata: input.metadata,
-            error: this.serializeError(err),
-          }),
-        );
+      this.search<T, L>(input.url, pattern, input.metadata, config)
+        .then((res) => cb(withError<T, L>(res, null)))
+        .catch((err) => cb(this.toFailure<T, L>(input, pattern, err, config)));
     });
+  }
+
+  /**
+   * The result for a url that never answered.
+   *
+   * `result: false` — and therefore `line: null`, when one was asked for. An
+   * error is not a match, and it is emphatically not a match with nothing to
+   * show: a caller narrowing on `result` must not be handed a `line` here.
+   */
+  private toFailure<T extends object, L extends boolean>(
+    input: NetgrepInput<T>,
+    pattern: string,
+    err: unknown,
+    config: NetgrepSearchConfig<L> | undefined,
+  ): BatchNetgrepResult<T, L> {
+    const captureLine = config?.captureLine === true;
+
+    return withError<T, L>(
+      toResult<T, L>(input.url, pattern, input.metadata, NO_HIT, captureLine),
+      this.serializeError(err),
+    );
   }
 
   /**

--- a/packages/netgrep/src/lib/data/BatchNetgrepResult.ts
+++ b/packages/netgrep/src/lib/data/BatchNetgrepResult.ts
@@ -3,7 +3,14 @@ import type { NetgrepResult } from './NetgrepResult.js';
 /**
  * Type representing a `NetgrepResult` for a batch
  * search.
+ *
+ * `L` threads through from the search config exactly as it does for
+ * `NetgrepResult`. A url that failed comes back as `result: false` — and so,
+ * when a line was asked for, as `line: null`: an error is not a match.
  */
-export type BatchNetgrepResult<T extends object = object> = NetgrepResult<T> & {
+export type BatchNetgrepResult<
+  T extends object = object,
+  L extends boolean = false,
+> = NetgrepResult<T, L> & {
   error: string | null;
 };

--- a/packages/netgrep/src/lib/data/NetgrepResult.ts
+++ b/packages/netgrep/src/lib/data/NetgrepResult.ts
@@ -2,10 +2,43 @@
  * A result object returned for a search. The `T` generic
  * represents the metadata passed in the search method
  * used.
+ *
+ * The `L` generic mirrors `captureLine` in `NetgrepSearchConfig`, so the shape
+ * of the result states whether a line was asked for:
+ *
+ * - **`L = false`** — the default, and what every existing caller gets. The
+ *   type is exactly what it has always been: there is no `line` key at all, so
+ *   reading one is a compile error rather than a silent `undefined`.
+ * - **`L = true`** — `result` becomes a discriminant. Narrow on it and `line`
+ *   is a `string` needing no null check, because a line exists exactly when
+ *   there was a match:
+ *
+ * ```ts
+ * const res = await ng.search(url, pattern, undefined, { captureLine: true });
+ * if (res.result) console.log(res.line.toUpperCase()); // `line` is `string`
+ * ```
+ *
+ * See [decision 0020](../../../../../docs/decisions/0020-the-matching-line.md).
  */
-export type NetgrepResult<T extends object = object> = {
+export type NetgrepResult<
+  T extends object = object,
+  L extends boolean = false,
+> = {
   url: string;
   pattern: string;
-  result: boolean;
   metadata?: T;
-};
+} & (L extends true
+  ? /**
+     * `line` is the first matching line of the file, with its terminator
+     * removed and truncated to `maxLineBytes`.
+     *
+     * It can be an EMPTY STRING — a pattern matching an empty line did match,
+     * and `result` is the answer to whether it did. Do not test `line` for
+     * truthiness.
+     *
+     * Two documented ways it can be less than a line of the file: non-UTF-8
+     * bytes decode lossily, and inside a line longer than 64 KB it is a
+     * mid-line fragment rather than a line (BACKLOG 3g).
+     */
+    { result: true; line: string } | { result: false; line: null }
+  : { result: boolean });

--- a/packages/netgrep/src/lib/data/NetgrepResult.ts
+++ b/packages/netgrep/src/lib/data/NetgrepResult.ts
@@ -17,8 +17,6 @@
  * const res = await ng.search(url, pattern, undefined, { captureLine: true });
  * if (res.result) console.log(res.line.toUpperCase()); // `line` is `string`
  * ```
- *
- * See [decision 0020](../../../../../docs/decisions/0020-the-matching-line.md).
  */
 export type NetgrepResult<
   T extends object = object,

--- a/packages/netgrep/src/lib/data/NetgrepSearchConfig.ts
+++ b/packages/netgrep/src/lib/data/NetgrepSearchConfig.ts
@@ -1,11 +1,42 @@
 /**
  * The optional configuration passed in
  * a single search method.
+ *
+ * The `L` generic is inferred from `captureLine` at the call site — it is
+ * *constrained* to `boolean` rather than typed as one, which is what makes
+ * TypeScript keep the literal `true` instead of widening it — and it decides
+ * the shape of the result. See `NetgrepResult`.
  */
-export type NetgrepSearchConfig = {
+export type NetgrepSearchConfig<L extends boolean = false> = {
   /**
    * A `Signal` used to abort the remote file
    * search and download.
    */
   signal?: AbortSignal;
+
+  /**
+   * Return the first matching line alongside the boolean.
+   *
+   * Off by default, and the cost really is zero when it is off: the engine has
+   * a separate entry point for this, so nothing is allocated, decoded or copied
+   * across the WebAssembly boundary for a caller who only wants membership.
+   */
+  captureLine?: L;
+
+  /**
+   * Ceiling on the bytes of the returned line. Defaults to 4096.
+   *
+   * Truncation happens inside WebAssembly, before the copy, so a corpus
+   * containing minified JavaScript or a one-line data dump cannot move
+   * megabytes per file into JavaScript. The cut is taken on a UTF-8 character
+   * boundary, and applies to the line's content — the terminator is stripped
+   * first.
+   *
+   * Values below 1, and fractions, are clamped rather than rejected: the number
+   * becomes a Rust `usize`, and wasm-bindgen does not validate it.
+   *
+   * Typed `never` unless `captureLine` is `true`, so setting it on its own is a
+   * compile error rather than a ceiling that silently governs nothing.
+   */
+  maxLineBytes?: L extends true ? number : never;
 };

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -7,10 +7,18 @@ The WASM porting of [ripgrep](https://github.com/BurntSushi/ripgrep). See the [m
 
 This is the low-level core of [`@netgrep/netgrep`](https://www.npmjs.com/package/@netgrep/netgrep), which is
 probably the package you want — it adds the streaming, batching and caching that make the engine useful over
-HTTP. Used directly, this one exposes a single function —
-`search_bytes(chunk: Uint8Array, pattern: string): boolean` — and its default export is an `init` you must
-await before calling it. It **throws** if the pattern is not valid regex, so a stray `(` from a search box is
-an ordinary catchable error.
+HTTP. Used directly, this one exposes two functions, and its default export is an `init` you must await before
+calling either:
+
+```ts
+search_bytes(chunk: Uint8Array, pattern: string): boolean
+search_bytes_line(chunk: Uint8Array, pattern: string, maxLineBytes: number): string | undefined
+```
+
+The second returns the **first matching line** — terminator stripped, truncated to `maxLineBytes` on a UTF-8
+character boundary, decoded lossily — or `undefined` for no match. Note `undefined` is the only no-match
+signal: a pattern matching an empty line returns `""`, which is falsy. Both **throw** if the pattern is not
+valid regex, so a stray `(` from a search box is an ordinary catchable error.
 
 > [!IMPORTANT]
 > **This is an experiment, not a recommendation.** netgrep is almost certainly not the best way to add
@@ -20,6 +28,6 @@ an ordinary catchable error.
 > ripgrep's actual search engine to WebAssembly and run it over HTTP against files *while they are still
 > downloading*.
 >
-> Note also that this package is a **~1.15 MB WebAssembly binary** (~480 KB gzipped) and has
+> Note also that this package is a **~1.16 MB WebAssembly binary** (~500 KB gzipped) and has
 > [known limitations](https://github.com/dgopsq/netgrep#known-limitations) — a single NUL byte discards the
 > chunk being searched, and `$` does not match on CRLF input.

--- a/packages/search/src/lib.rs
+++ b/packages/search/src/lib.rs
@@ -50,6 +50,29 @@ pub fn search_bytes(chunk: &[u8], pattern: &str) -> Result<bool, JsError> {
     try_search_bytes(chunk, pattern).map_err(|error| JsError::new(&error))
 }
 
+/// Search a bytes array for the given pattern, returning the first matching
+/// line rather than a boolean.
+///
+/// `undefined` in JavaScript means no match; a string is the line, with its
+/// terminator removed and truncated to `max_line_bytes`. **A match on an empty
+/// line yields an empty string**, so a caller must test for `undefined` rather
+/// than for truthiness.
+///
+/// A separate export rather than a change to `search_bytes`, so a caller that
+/// only wants membership goes on paying for membership only — no allocation,
+/// no decode, no string crossing the boundary. See
+/// [decision 0020](../../../docs/decisions/0020-the-matching-line.md).
+///
+/// Throws the same way `search_bytes` does when the pattern will not compile.
+#[wasm_bindgen]
+pub fn search_bytes_line(
+    chunk: &[u8],
+    pattern: &str,
+    max_line_bytes: usize,
+) -> Result<Option<String>, JsError> {
+    try_search_bytes_line(chunk, pattern, max_line_bytes).map_err(|error| JsError::new(&error))
+}
+
 /// The engine, as plain Rust.
 ///
 /// `search_bytes` above is a two-line wrapper around this, and the split is
@@ -59,6 +82,31 @@ pub fn search_bytes(chunk: &[u8], pattern: &str) -> Result<bool, JsError> {
 /// natively, so anything it needs to assert about the error path has to be
 /// reachable without a `JsError` in the signature.
 pub fn try_search_bytes(chunk: &[u8], pattern: &str) -> Result<bool, String> {
+    with_matcher(pattern, |matcher| search_with(matcher, chunk))
+}
+
+/// `search_bytes_line`, as plain Rust. Split from the export for the same
+/// reason as `try_search_bytes`.
+pub fn try_search_bytes_line(
+    chunk: &[u8],
+    pattern: &str,
+    max_line_bytes: usize,
+) -> Result<Option<String>, String> {
+    with_matcher(pattern, |matcher| {
+        search_line_with(matcher, chunk, max_line_bytes)
+    })
+}
+
+/// Run `use_matcher` against the compiled form of `pattern`, compiling it only
+/// if the memo is not already holding it.
+///
+/// Generic over the return type so both entry points share one memo: the slot
+/// caches the *matcher*, which is the expensive part, and is indifferent to
+/// what the caller then does with it.
+fn with_matcher<T>(
+    pattern: &str,
+    use_matcher: impl FnOnce(&RegexMatcher) -> T,
+) -> Result<T, String> {
     LAST_COMPILED.with_borrow_mut(|slot| {
         // Taken out and put back rather than borrowed in place: a reference
         // into `slot` cannot outlive the reassignment that replaces a stale
@@ -72,7 +120,7 @@ pub fn try_search_bytes(chunk: &[u8], pattern: &str) -> Result<bool, String> {
         };
 
         let result = match &entry.matcher {
-            Ok(matcher) => Ok(search_with(matcher, chunk)),
+            Ok(matcher) => Ok(use_matcher(matcher)),
             Err(error) => Err(error.clone()),
         };
 
@@ -130,4 +178,98 @@ impl Sink for MemSink {
         // test can pin it and decision 0016 carries the measurement instead.
         Ok(false)
     }
+}
+
+/// Run a compiled matcher over one block of bytes, keeping the first matching
+/// line.
+fn search_line_with(matcher: &RegexMatcher, chunk: &[u8], max_line_bytes: usize) -> Option<String> {
+    let mut searcher = SearcherBuilder::new()
+        .binary_detection(BinaryDetection::quit(b'\x00'))
+        .line_number(false)
+        .build();
+
+    let mut sink = LineSink { first: None };
+
+    let _ = searcher.search_slice(matcher, chunk, &mut sink);
+
+    sink.first.map(|line| decode_line(&line, max_line_bytes))
+}
+
+/// A `Sink` that keeps the bytes of the first matching line.
+///
+/// The line is copied rather than borrowed because `SinkMatch` does not outlive
+/// the callback, and it is copied *before* any decoding or truncation so this
+/// stays the cheap half — the expensive half happens once, outside the search.
+struct LineSink {
+    first: Option<Vec<u8>>,
+}
+
+impl Sink for LineSink {
+    type Error = std::io::Error;
+
+    fn matched(
+        &mut self,
+        _searcher: &Searcher,
+        mat: &SinkMatch<'_>,
+    ) -> Result<bool, std::io::Error> {
+        self.first = Some(mat.bytes().to_vec());
+
+        // Same short-circuit as `MemSink`: only the FIRST match is wanted, so
+        // there is nothing left to look for. Unlike there, this one is
+        // observable — keep searching and the field would end up holding the
+        // last matching line instead of the first.
+        Ok(false)
+    }
+}
+
+/// Turn one matched line's raw bytes into the string that crosses the boundary.
+///
+/// Three lossy steps, in an order that matters:
+///
+/// 1. **Strip the terminator.** `SinkMatch::bytes()` includes the trailing
+///    `\n`, and a `\r` before it on Windows-authored input. Both are line
+///    *structure* rather than content, and rendering either verbatim in a UI is
+///    a defect the caller cannot fix without knowing this.
+/// 2. **Truncate**, so the cap applies to visible content rather than to
+///    content-plus-terminator, and so one minified bundle cannot copy megabytes
+///    per file into JavaScript.
+/// 3. **Decode**, last, so the lossy pass runs over at most `max_line_bytes`.
+fn decode_line(line: &[u8], max_line_bytes: usize) -> String {
+    let content = strip_terminator(line);
+    let capped = &content[..floor_char_boundary(content, max_line_bytes)];
+
+    String::from_utf8_lossy(capped).into_owned()
+}
+
+/// Drop one trailing `\n`, and a `\r` immediately before it.
+///
+/// Only as a pair: a lone `\r` in the middle of a line under netgrep's
+/// `\n`-terminator semantics is ordinary content, and a file using bare CR line
+/// endings is one line as far as this engine is concerned.
+fn strip_terminator(line: &[u8]) -> &[u8] {
+    match line.strip_suffix(b"\n") {
+        Some(rest) => rest.strip_suffix(b"\r").unwrap_or(rest),
+        None => line,
+    }
+}
+
+/// The largest index at or below `max` that does not split a UTF-8 character.
+///
+/// Truncating mid-character would turn one legitimate multi-byte character into
+/// replacement characters at the very end of every capped line — the one place
+/// a reader is most likely to notice. `str::floor_char_boundary` does this in
+/// std but is still unstable, so it is spelled out: continuation bytes are
+/// `0b10xxxxxx`, and a boundary is any byte that is not one.
+fn floor_char_boundary(bytes: &[u8], max: usize) -> usize {
+    if bytes.len() <= max {
+        return bytes.len();
+    }
+
+    let mut end = max;
+
+    while end > 0 && bytes[end] & 0xC0 == 0x80 {
+        end -= 1;
+    }
+
+    end
 }

--- a/packages/search/src/lib.rs
+++ b/packages/search/src/lib.rs
@@ -60,8 +60,7 @@ pub fn search_bytes(chunk: &[u8], pattern: &str) -> Result<bool, JsError> {
 ///
 /// A separate export rather than a change to `search_bytes`, so a caller that
 /// only wants membership goes on paying for membership only — no allocation,
-/// no decode, no string crossing the boundary. See
-/// [decision 0020](../../../docs/decisions/0020-the-matching-line.md).
+/// no decode, no string crossing the boundary.
 ///
 /// Throws the same way `search_bytes` does when the pattern will not compile.
 #[wasm_bindgen]
@@ -140,12 +139,24 @@ fn build_matcher(pattern: &str) -> Result<RegexMatcher, String> {
         .map_err(|error| error.to_string())
 }
 
-/// Run a compiled matcher over one chunk of bytes.
-fn search_with(matcher: &RegexMatcher, chunk: &[u8]) -> bool {
-    let mut searcher = SearcherBuilder::new()
+/// Build a searcher with netgrep's fixed reading semantics: quit on a NUL, and
+/// do not count lines.
+///
+/// Shared by both entry points rather than spelled out in each. They must agree
+/// — a caller who adds `captureLine` to an existing search is entitled to the
+/// same answer — and binary detection in particular decides whether a whole
+/// block is abandoned, so a divergence here would be a difference in `result`,
+/// not merely in what is returned alongside it.
+fn build_searcher() -> Searcher {
+    SearcherBuilder::new()
         .binary_detection(BinaryDetection::quit(b'\x00'))
         .line_number(false)
-        .build();
+        .build()
+}
+
+/// Run a compiled matcher over one chunk of bytes.
+fn search_with(matcher: &RegexMatcher, chunk: &[u8]) -> bool {
+    let mut searcher = build_searcher();
 
     let mut sink = MemSink { found: false };
 
@@ -183,10 +194,7 @@ impl Sink for MemSink {
 /// Run a compiled matcher over one block of bytes, keeping the first matching
 /// line.
 fn search_line_with(matcher: &RegexMatcher, chunk: &[u8], max_line_bytes: usize) -> Option<String> {
-    let mut searcher = SearcherBuilder::new()
-        .binary_detection(BinaryDetection::quit(b'\x00'))
-        .line_number(false)
-        .build();
+    let mut searcher = build_searcher();
 
     let mut sink = LineSink { first: None };
 

--- a/packages/search/tests/search.rs
+++ b/packages/search/tests/search.rs
@@ -500,6 +500,28 @@ mod matching_line {
     // ---------------------------------------------------------------
 
     #[test]
+    fn test_the_two_entry_points_share_one_searcher_configuration() {
+        // Both go through `build_searcher`, so binary detection cannot differ
+        // between them. That matters more than it looks: a NUL abandons the
+        // whole block, so a divergence would change `result` — adding
+        // `captureLine` to a working search would change its ANSWER, not just
+        // what came back alongside it.
+        //
+        // Asserted through the observable behaviour rather than the builder,
+        // because the builder is not comparable.
+        assert!(!matches(b"needle here\x00tail", "needle"));
+        assert_eq!(first_line(b"needle here\x00tail", "needle", NO_CAP), None);
+
+        // The control, so this is pinning the shared config rather than an
+        // input that never matched.
+        assert!(matches(b"needle here", "needle"));
+        assert_eq!(
+            first_line(b"needle here", "needle", NO_CAP).as_deref(),
+            Some("needle here")
+        );
+    }
+
+    #[test]
     fn test_the_two_entry_points_share_one_matcher() {
         // Both go through `with_matcher`, so a pattern compiled by one is
         // reused by the other. That is the point — but it also means a stale

--- a/packages/search/tests/search.rs
+++ b/packages/search/tests/search.rs
@@ -15,10 +15,11 @@
 //!
 //! WHAT BELONGS HERE, AND WHAT DOES NOT
 //! ------------------------------------
-//! `search_bytes` is bytes in, bool out. Everything that depends only on those
-//! bytes — regex syntax, smart case, line semantics, encoding, binary
-//! detection — is cheapest to pin here: no browser to boot, and a failure
-//! names the engine rather than the streaming loop wrapped around it.
+//! `search_bytes` is bytes in, bool out; `search_bytes_line` is bytes in, the
+//! first matching line out. Everything that depends only on those bytes — regex
+//! syntax, smart case, line semantics, encoding, binary detection, and what a
+//! returned line contains — is cheapest to pin here: no browser to boot, and a
+//! failure names the engine rather than the streaming loop wrapped around it.
 //!
 //! Anything involving `fetch`, chunking, caching or the WASM boundary belongs
 //! in `Netgrep.integration.spec.ts` instead. The two suites overlap on purpose
@@ -303,6 +304,235 @@ mod search {
         // binary detection below) make it reasonable to assume this one does
         // too.
         assert!(matches(&[0xff, b' ', b'x', b'y'], "xy"));
+    }
+}
+
+/// Assert-friendly wrapper around the line-returning entry point.
+///
+/// `None` is "no match"; `Some` carries the line. The same note as `matches`
+/// applies about calling `try_search_bytes_line` rather than the
+/// `#[wasm_bindgen]` export.
+#[cfg(test)]
+fn first_line(haystack: &[u8], pattern: &str, max_line_bytes: usize) -> Option<String> {
+    ::search::try_search_bytes_line(haystack, pattern, max_line_bytes)
+        .expect("the pattern should compile")
+}
+
+/// The matching line, rather than the boolean — BACKLOG 19.
+///
+/// Everything here is about what `search_bytes_line` returns *given* a match;
+/// whether something matches at all is `mod search` above, and is deliberately
+/// not re-asserted. The two entry points share one compiled matcher and one
+/// searcher configuration, so matching semantics cannot diverge between them —
+/// `test_the_two_entry_points_share_one_matcher` is the assertion that keeps
+/// that true.
+#[cfg(test)]
+mod matching_line {
+    use super::{first_line, matches};
+    use ::search::try_search_bytes_line;
+
+    /// Comfortably above every line used here, so a test only exercises the cap
+    /// when it says so.
+    const NO_CAP: usize = 4096;
+
+    const POEM: &str = "One Wiseman came to Jhaampe-town.\n\
+                        He set aside both Queen and Crown\n\
+                        Did his task and fell asleep\n\
+                        Gave his bones to the stones to keep.\n";
+
+    // ---------------------------------------------------------------
+    // What comes back
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_returns_the_whole_line_not_the_match() {
+        // The point of the feature: a boolean says "yes", this says what was
+        // read. The pattern is three characters and the answer is a sentence.
+        assert_eq!(
+            first_line(POEM.as_bytes(), "aside", NO_CAP).as_deref(),
+            Some("He set aside both Queen and Crown")
+        );
+    }
+
+    #[test]
+    fn test_no_match_is_none() {
+        assert_eq!(first_line(POEM.as_bytes(), "dragon", NO_CAP), None);
+    }
+
+    #[test]
+    fn test_returns_the_first_matching_line_not_the_last() {
+        // `LineSink::matched` stops at the first hit. Keep searching and this
+        // would hold the LAST matching line — the one place that short-circuit
+        // is observable rather than merely faster.
+        let haystack = b"needle one\nneedle two\nneedle three\n";
+
+        assert_eq!(
+            first_line(haystack, "needle", NO_CAP).as_deref(),
+            Some("needle one")
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Line terminators
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_the_trailing_newline_is_stripped() {
+        assert_eq!(
+            first_line(b"alpha\nbeta\n", "alpha", NO_CAP).as_deref(),
+            Some("alpha")
+        );
+    }
+
+    #[test]
+    fn test_a_carriage_return_before_the_newline_is_stripped_too() {
+        // On CRLF input the `\r` is the last byte of the line under netgrep's
+        // `\n`-terminator semantics, so without this it would render as a
+        // control character in whatever the caller displays. Note BACKLOG 17
+        // is untouched by this: `$` still cannot match here, because the
+        // stripping happens after matching, not before.
+        assert_eq!(
+            first_line(b"alpha\r\nbeta\r\n", "alpha", NO_CAP).as_deref(),
+            Some("alpha")
+        );
+    }
+
+    #[test]
+    fn test_a_lone_carriage_return_is_content() {
+        // Not a terminator here, so not structure: only the `\r\n` PAIR is
+        // dropped. A file with bare CR endings is one line to this engine, and
+        // pretending otherwise would silently truncate it.
+        assert_eq!(
+            first_line(b"alpha\rbeta\n", "alpha", NO_CAP).as_deref(),
+            Some("alpha\rbeta")
+        );
+    }
+
+    #[test]
+    fn test_an_unterminated_final_line_comes_back_whole() {
+        // The common case at a chunk boundary, and at the end of a file with no
+        // trailing newline.
+        assert_eq!(
+            first_line(b"alpha\nbeta", "beta", NO_CAP).as_deref(),
+            Some("beta")
+        );
+    }
+
+    #[test]
+    fn test_a_match_on_an_empty_line_is_an_empty_string() {
+        // ⚠️ LOAD-BEARING FOR Netgrep.ts, which must test the result against
+        // `undefined` rather than for truthiness. An empty string is a MATCH,
+        // and it is falsy in JavaScript.
+        assert_eq!(
+            first_line(b"alpha\n\nbeta\n", "^$", NO_CAP).as_deref(),
+            Some("")
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // The cap
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_a_long_line_is_truncated_to_the_cap() {
+        let mut haystack = vec![b'x'; 10_000];
+        haystack.extend_from_slice(b"needle\n");
+
+        let line = first_line(&haystack, "needle", 64).expect("it matches");
+
+        assert_eq!(line.len(), 64);
+        assert!(line.chars().all(|c| c == 'x'));
+    }
+
+    #[test]
+    fn test_the_cap_applies_to_content_not_to_the_terminator() {
+        // Stripping happens before truncation, so a line exactly at the cap
+        // survives intact rather than losing its last character to a `\n` that
+        // is not part of it.
+        assert_eq!(first_line(b"abcde\n", "abc", 5).as_deref(), Some("abcde"));
+    }
+
+    #[test]
+    fn test_truncation_does_not_split_a_utf8_character() {
+        // Five two-byte characters, cut at an odd offset. Splitting the third
+        // would produce a replacement character at the end of the line — the
+        // most visible possible place for one.
+        let line = first_line("ééééé\n".as_bytes(), "é", 5).expect("it matches");
+
+        assert_eq!(line, "éé");
+        assert!(!line.contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn test_a_cap_of_zero_yields_an_empty_string_not_none() {
+        // Degenerate, and unreachable through `Netgrep.ts`, which clamps to at
+        // least 1. Pinned so that if it ever IS reached the answer is still
+        // "matched", not "did not match".
+        assert_eq!(first_line(b"needle\n", "needle", 0).as_deref(), Some(""));
+    }
+
+    // ---------------------------------------------------------------
+    // Encoding
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_non_ascii_content_survives_intact() {
+        assert_eq!(
+            first_line("il a bu un café noir\n".as_bytes(), "café", NO_CAP).as_deref(),
+            Some("il a bu un café noir")
+        );
+    }
+
+    #[test]
+    fn test_invalid_utf8_decodes_lossily_rather_than_failing() {
+        // A latin-1 file, which the engine matches happily because it works on
+        // bytes. The line has to become a JavaScript string somehow, and a
+        // replacement character is the only answer that still returns the rest
+        // of the line. Documented, because it is a class of wrong output the
+        // boolean API could not produce.
+        let line = first_line(b"caf\xE9 noir\n", "caf", NO_CAP).expect("it matches");
+
+        assert_eq!(line, "caf\u{FFFD} noir");
+    }
+
+    // ---------------------------------------------------------------
+    // Shared state with `search_bytes`
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_the_two_entry_points_share_one_matcher() {
+        // Both go through `with_matcher`, so a pattern compiled by one is
+        // reused by the other. That is the point — but it also means a stale
+        // slot would let one entry point answer with the other's matcher, which
+        // is the same silent-wrong-answer failure `mod search` guards for
+        // `search_bytes` alone.
+        assert!(matches(b"one wiseman", "wiseman"));
+        assert_eq!(
+            first_line(b"one wiseman", "wiseman", NO_CAP).as_deref(),
+            Some("one wiseman")
+        );
+
+        // Smart case is decided at compile time, so these need different
+        // matchers despite differing by one bit.
+        assert_eq!(first_line(b"one wiseman", "Wiseman", NO_CAP), None);
+        assert!(matches(b"one wiseman", "wiseman"));
+    }
+
+    #[test]
+    fn test_an_invalid_pattern_is_an_error_here_too() {
+        let error =
+            try_search_bytes_line(b"anything", "(", NO_CAP).expect_err("`(` is not valid regex");
+
+        assert!(
+            error.contains("unclosed group"),
+            "unexpected error: {error}"
+        );
+
+        // And the memo is replaced rather than consulted afterwards.
+        assert_eq!(
+            first_line(b"anything", "any", NO_CAP).as_deref(),
+            Some("anything")
+        );
     }
 }
 


### PR DESCRIPTION
Closes #19.

Returns the bytes of the first matching line alongside the boolean, opt-in per search. This is the **first widening of the public API**, so it lands with [decision 0020](https://github.com/dgopsq/netgrep/blob/return-matching-line/docs/decisions/0020-the-matching-line.md), which amends 0003 and — more importantly — names the match details that stay refused.

```ts
const res = await ng.search(url, pattern, undefined, { captureLine: true });
if (res.result) console.log(res.line); // `string`, no null check
```

## Two of the issue's premises were stale

**"Closes backlog 13 for free" was already true.** `MemSink` returns `Ok(false)` and holds a `bool`, not a `match_count` — item 13 was done in #16. The issue's ~10-line Rust sketch was a diff that had already been applied.

**The feature only became honest two commits ago.** Before #27, each chunk was searched in isolation, so a first occurrence straddling a seam was missed and the "first" line returned was silently the file's *second* match — differing run to run with how the network split the response. A snippet built on that would have been non-deterministic and wrong in a way a boolean never exposed. `splitAtLastLine` now hands the engine whole lines in file order, so the line is the file's first matching line under **any** chunking. That claim is pinned across six chunk sizes, and #28 makes a warm cache agree with a cold fetch.

## What was decided

| | |
|---|---|
| **Opt-in** | `captureLine`, default off |
| **A second WASM export** | `search_bytes_line`, sharing the compiled-matcher memo. `search_bytes` untouched → `@netgrep/search` stays backwards-compatible, and the off path is *structurally* the same call it always was |
| **`line`, not `snippet`** | It is one line of the file. `snippet` is the vocabulary of the index engines netgrep is not |
| **Bounded in Rust** | Terminator stripped → truncated on a UTF-8 char boundary → decoded lossily, in that order. `maxLineBytes`, default 4096. Truncating in JS would pay the copy it exists to avoid |

The flag's effect is in the type. `L` threads from `NetgrepSearchConfig<L>` into `NetgrepResult<T, L>`:

- **`L = false`** — byte-for-byte today's type, with **no `line` key at all**. Reading one is a compile error, not a silent `undefined`. `tsc` is the compatibility proof.
- **`L = true`** — `result` becomes a discriminant: `{ result: true; line: string } | { result: false; line: null }`. Narrowing gives a `string`.
- `maxLineBytes` is `never` unless `captureLine` is set.

The two opposite uses of `never` are deliberate: for the *config* the concern is writing, and `never` blocks it; for the *result* the concern is reading, and `never` would collapse to `undefined` and read silently — so there the key is genuinely absent.

## Sharp edges, all pinned

- **An empty string is a match.** A pattern matching a blank line returns `""`, which is falsy. `undefined` is the only no-match signal at the boundary. Pinned in Rust *and* TypeScript, and called out at the one place in `Netgrep.ts` that could get it wrong.
- **Lossy decoding.** Invalid UTF-8 yields `U+FFFD` — a class of wrong output a boolean could not produce.
- **New residual in 3g.** Inside a line longer than the 64 KB tail ceiling the block starts mid-line, so the string is a fragment rather than a line. `result` stays correct. Returning `null` there was rejected: it would cost every consumer a null check on a branch the type has already narrowed, to describe a case only minified input reaches.

## Beyond the library

**The demo shows the line** — required by AGENTS.md §2.3, since `CAVEATS[0]` was asserting the absence of a feature that now exists. It changed from "One boolean per file" to "No ranking, no positions". Cards now fill their grid row, so a card carrying a line no longer leaves the misses beside it floating in a gap.

**The posture changed.** AGENTS.md §1 said "Do not add features"; it now says a feature needs an issue and a decision record before it needs a diff, and the record must name what it does *not* open the door to. A project cannot ship a feature under a document forbidding them — but the friction is what made this proposal get argued properly, so it is kept.

**`.wasm` +15,769 bytes (+1.4%)**, so the `StatsBar`, backlog 14, both package READMEs and ARCHITECTURE now say 1.16 MB.

## Unrelated fix, flagged

#28 fixed backlog 18 without touching `README.md`, which still claimed concurrent searches of one url are not de-duplicated. Corrected here since I was editing the file. Happy to split it out.

## Verification

Everything CI runs, locally: Biome + clippy, **44 Rust tests** (+16), **108 TypeScript tests** (+20), typecheck, build, `verify:pack`, and the demo's typecheck and build. The demo was checked in a real browser, not asserted.

No version bumps, no tags, no publish — hard rule 6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)