### PR TITLE
ci: name the release PR after the project, not the branch

### DIFF
--- a/.claude/skills/wasm-release/SKILL.md
+++ b/.claude/skills/wasm-release/SKILL.md
@@ -5,7 +5,7 @@ description: Build, verify and prepare a release of the netgrep packages (@netgr
 
 # Releasing netgrep
 
-Releases are cut by **release-please**. It keeps a `chore: release main` pull request up to date as commits
+Releases are cut by **release-please**. It keeps a `chore: release netgrep` pull request up to date as commits
 land on `main`; merging that PR tags both packages, publishes them to npm in dependency order, and deploys
 the demo — one run, no further confirmation. This skill covers building, verifying and **preparing**.
 
@@ -149,7 +149,7 @@ first. Do not use `--local`: it runs `git checkout` in the directory you point i
 
 There are no tag commands any more. Say:
 
-> Merge the `chore: release main` pull request. That tags `search-<version>` and `netgrep-<version>`,
+> Merge the `chore: release netgrep` pull request. That tags `search-<version>` and `netgrep-<version>`,
 > publishes both packages, and deploys the demo.
 
 If a publish fails **after** the tag exists, re-running `release.yml` will not retry it — release-please

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,7 +191,7 @@ you touched, not from the scope.
 
 ## Releases
 
-Releases are cut by release-please. It keeps a "chore: release main" pull request up to date as commits land;
+Releases are cut by release-please. It keeps a "chore: release netgrep" pull request up to date as commits land;
 merging it tags, publishes both npm packages and deploys the demo, in one run and in that order.
 
 **Version bumps and publishing are maintainer-only** — please do not include them in a pull request. Do not

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,9 @@
   "//separate-pull-requests": "One PR covering every component. Three PRs would have to be merged in dependency order by hand, which is the ordering problem release.yml exists to remove.",
   "separate-pull-requests": false,
 
+  "//group-pull-request-title-pattern": "Titles the one merged PR the setting above produces; the default is `chore: release ${branch}`, which reads `chore: release main`. Static on purpose: the title is re-parsed with this same pattern at tagging time, and `${version}` compiles to a REQUIRED match group — no package sits at the root, so there is no version to substitute and the title would fail its own regex, tagging nothing. The `chore:` prefix has to stay: it is hidden below, which is what stops the release commit from bumping the next release.",
+  "group-pull-request-title-pattern": "chore: release netgrep",
+
   "//bump-minor-pre-major": "A breaking change gives 0.3.0, not 1.0.0. 1.0.0 is a claim this project does not make by accident — reaching it needs an explicit `Release-As: 1.0.0` footer.",
 
   "//changelog-sections": "`hidden` decides what RELEASES, not only what is listed: release-please skips a release whose notes come out empty, and any visible type that is not feat or breaking falls through to a patch bump. Hiding a type is therefore how `chore` and `docs` ship nothing. Set once here; every component inherits it.",


### PR DESCRIPTION
## What

Sets `group-pull-request-title-pattern` in `release-please-config.json` so the release PR is titled
`chore: release netgrep` instead of `chore: release main`.

## Why

`separate-pull-requests: false` collapses all three components into one PR, and release-please titles that
merged PR from a built-in default — `MANIFEST_PULL_REQUEST_TITLE_PATTERN = 'chore: release ${branch}'`. The
per-package `pull-request-title-pattern` never applies to it. So the title named the branch it targets rather
than the thing being released.

## Why the pattern is static

The same pattern is used to *re-parse* the merged PR's title when tagging (`strategies/base.ts` passes
`groupPullRequestTitlePattern` into `PullRequestTitle.parse`), and `${version}` compiles to a **required**
match group, `v?(?<version>[0-9].*)`. No package sits at the repository root, so the group title has no
version to substitute: it would render `chore: release netgrep` and then fail its own regex, logging
`Bad pull request title` and tagging nothing. `${component}` is empty for the same reason.

The `chore:` prefix stays deliberately — it is `hidden` in `changelog-sections`, which is what keeps the
squashed release commit from feeding the next bump.

release-please will now log `pullRequestTitlePattern miss the part of '${scope}'` (and the same for component
and version) on each run. Those are `logger.warn` only; a static group pattern is supported.

## Timing

Safe to merge now: `main` is at the tagged `chore: release main (#31)`, so there is no merged-but-untagged
release PR whose old-format title would fail to parse under the new pattern. An *open* release PR would have
been fine either way — it is matched by head branch (`release-please--branches--main`), not by title.

## Also updated

`CONTRIBUTING.md` and `.claude/skills/wasm-release/SKILL.md` both quoted the old title.

## Verified

- Round-tripped the rendered title through release-please's `generateMatchPattern` construction: renders
  `chore: release netgrep`, re-parses `true`.
- `pnpm lint:js` — clean. (No code paths touched; the change is config plus docs.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)