### PR TITLE
fix(ci): restore the parseable release PR title

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,8 +8,7 @@
   "//separate-pull-requests": "One PR covering every component. Three PRs would have to be merged in dependency order by hand, which is the ordering problem release.yml exists to remove.",
   "separate-pull-requests": false,
 
-  "//group-pull-request-title-pattern": "Titles the one merged PR the setting above produces; the default is `chore: release ${branch}`, which reads `chore: release main`. Static on purpose: the title is re-parsed with this same pattern at tagging time, and `${version}` compiles to a REQUIRED match group — no package sits at the root, so there is no version to substitute and the title would fail its own regex, tagging nothing. The `chore:` prefix has to stay: it is hidden below, which is what stops the release commit from bumping the next release.",
-  "group-pull-request-title-pattern": "chore: release netgrep",
+  "//group-pull-request-title-pattern": "Deliberately absent — left at the default `chore: release ${branch}`, which reads `chore: release main`. A FULLY STATIC title cannot be used, however much better it reads: the merged PR's title is re-parsed with this same pattern at tagging time, and a pattern carrying neither `${branch}` nor `${version}` fails its own parse (`✖ Bad pull request title`). The PR then merges having released nothing — no tags, no npm publish, no Pages deploy — and every later release PR is blocked by `untagged, merged release PRs outstanding`. That is what `chore: release netgrep` did to #33.",
 
   "//bump-minor-pre-major": "A breaking change gives 0.3.0, not 1.0.0. 1.0.0 is a claim this project does not make by accident — reaching it needs an explicit `Release-As: 1.0.0` footer.",
 


### PR DESCRIPTION
## What's wrong

Merging #33 released nothing. The `release-please` job in [run 30715909864](https://github.com/dgopsq/netgrep/actions/runs/30715909864) printed, once per package:

```
⚠ pullRequestTitlePattern miss the part of '${version}'
✖ Bad pull request title: 'chore: release netgrep'
```

so `releases_created` was `false` and `publish-search`, `publish-netgrep` and `deploy` all skipped. No `search-0.3.0` / `netgrep-0.3.0` / `example-0.2.0` tags, npm still on 0.2.0, and the demo site still serving the 07-31 build. #33 is still labelled `autorelease: pending`, which also blocks every release PR after it — the same log ends with `⚠ There are untagged, merged release PRs outstanding - aborting`.

## Why

#34 set `group-pull-request-title-pattern` to the fully static `chore: release netgrep`. The merged PR's title is re-parsed with that same pattern when release-please decides what to tag, and a pattern carrying neither `${branch}` nor `${version}` fails its own parse. The config comment there had it backwards: the problem isn't that `${version}` compiles to a required group, it's that a title with *no* placeholder never matches at all. The default `chore: release ${branch}` → `chore: release main` parsed fine, which is why #31 tagged and #33 did not.

This drops the override back to the default and records the failure mode in its place.

## Unsticking #33 (after this merges)

1. `gh pr edit 33 --title "chore: release main"` — its computed versions (search/netgrep 0.3.0, example 0.2.0, including #35's docs site) are correct; only the title is bad.
2. Re-run Release on `main`. release-please fetches the config over the API, so it picks up this fix, tags all three components, publishes both packages in order, and deploys the site.

Step 1 must happen before step 2 — until #33 is tagged, release-please aborts before opening any new release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)