### PR TITLE
fix(search): search NUL-containing input instead of discarding the block

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,9 +61,9 @@ Three things will mislead you if you do not know them.
 ### 2.1 Some tests assert behaviour that is WRONG, on purpose
 
 `packages/netgrep/src/lib/Netgrep.integration.spec.ts` ends with a block titled
-**`documented defects (asserting current, incorrect behaviour)`**. Those assertions pin known bugs — a NUL byte
-discarding a block of lines, a match longer than the 64 KB tail ceiling still spanning a chunk boundary, and so
-on. `packages/search/tests/search.rs` has a `documented_defects` module doing the same for the ones that live in
+**`documented defects (asserting current, incorrect behaviour)`**. Those assertions pin known bugs — a match
+longer than the 64 KB tail ceiling still spanning a chunk boundary, `$` missing on CRLF input, and so on.
+`packages/search/tests/search.rs` has a `documented_defects` module doing the same for the ones that live in
 the engine, where a failure names `lib.rs` without a browser and a stream in the way.
 
 They are not mistakes and they are not out of date. Their job is to detect *unintended* change during
@@ -561,13 +561,12 @@ manifests cannot drift, and **deletes the `.gitignore` wasm-pack writes into `pk
 ## 7. Known correctness caveats
 
 Real, present in the published package, and **documented rather than fixed**. Each is pinned by a test that
-asserts the wrong behaviour — in `Netgrep.integration.spec.ts`, and for the two that live in the engine also
+asserts the wrong behaviour — in `Netgrep.integration.spec.ts`, and for the one that lives in the engine also
 in `packages/search/tests/search.rs`. Read §2.1 before touching any of them.
 
 | | Where | Effect |
 |---|---|---|
 | Anchors and long matches inside a >64 KB line | `Netgrep.ts`, `MAX_TAIL_BYTES` | What remains of the chunk-boundary defect (**3g**). The retained tail is the incomplete trailing *line*, which is exact; past a 64 KB ceiling it degrades to a byte window. Inside such a line a match longer than 64 KB is lost, **and** `^` can match at the window's first byte. Needs a line over 64 KB — unreachable in prose. |
-| One NUL discards the searched block | `lib.rs`, `BinaryDetection::quit` | A match is dropped even when it precedes the NUL. |
 | `$` misses on CRLF input | `lib.rs`, no `.crlf(true)` | The line terminator is `\n`, so `\r` sits between the text and `$`. A `$`-anchored pattern silently misses on Windows-authored files. |
 
 The last was found while broadening the test suite on 2026-07-29 and is backlog item 17.
@@ -588,8 +587,11 @@ hand over and two concurrent searches of one url each download it. That is now a
 than a defect — pinned by an ordinary assertion, and published under *By design* rather than in the README's
 defect list.
 
-Decision 0018 also narrowed the row that remains: what the engine is handed is now a block of complete lines
-rather than a network chunk, which changed the shape of the NUL defect's blast radius. See
+**A fourth left on 2026-08-05: the NUL row.** `BinaryDetection::quit(b'\x00')` did not stop *at* the NUL — it
+abandoned the whole block it was handed, so a match was dropped even when it preceded the NUL. `lib.rs` now
+builds its searcher with `BinaryDetection::none()`, which searches every byte as text instead. Nothing now
+declines to search binary input, so a pattern occurring inside a `.png` is reported like any other match — a
+real trade, published under *By design* as `no-binary-detection` rather than dropped silently. See
 [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md#known-limitations--correctness-caveats) and
 [decision 0002](docs/decisions/0002-search-while-downloading.md).
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ unnoticed, and each is explained in full in the
 
 <!-- BEGIN GENERATED CAVEATS -->
 - **[Inside a line longer than 64 KB, results are approximate](https://netgrep.diegopasquali.com/docs/#long-lines)** — Past a 64 KB line with no terminator, a longer match is lost and `^` can match at a window edge.
-- **[A file containing a NUL byte reports no match](https://netgrep.diegopasquali.com/docs/#nul-byte)** — A NUL byte discards the block of lines containing it, even when the match came earlier.
 - **[`$` does not match on CRLF files](https://netgrep.diegopasquali.com/docs/#crlf-dollar)** — On Windows-authored text the `\r` sits between your text and the anchor, so `needle$` misses what `needle` finds.
 <!-- END GENERATED CAVEATS -->
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -124,7 +124,7 @@ Per call it:
    case-sensitively. netgrep calls this once per network chunk with the same pattern every time, so the cache
    hits on every chunk after the first; compilation was 97–99% of the cost before it existed. Failed compiles
    are cached alongside successful ones. See [decision 0016](decisions/0016-compiled-matcher-memo.md).
-2. Builds a `Searcher` with `BinaryDetection::quit(b'\x00')` and `line_number(false)`.
+2. Builds a `Searcher` with `BinaryDetection::none()` and `line_number(false)`.
 3. Runs `search_slice` into `MemSink`, a minimal `Sink` implementation that does nothing but record that a
    match happened and stop — chosen because ripgrep's real sinks write to stdout, which does not exist in
    WASM.
@@ -239,6 +239,8 @@ overtaken entirely on 2026-08-01 by [decision 0024](decisions/0024-remove-the-in
 deleted the cache both of them described; their headings are kept because the numbering is referenced from
 this file's own text and from [decision 0002](decisions/0002-search-while-downloading.md), which cites both by
 number. Caveat 7 stopped being a defect on the same day, for the same reason, and is now a design consequence.
+Caveat 5 was fixed on 2026-08-05, and what replaced it is described below rather than removed, because the
+trade it made is a caveat worth publishing rather than a closed matter.
 
 ### 1. Chunk-boundary false negatives — FIXED, with a residual
 
@@ -294,21 +296,23 @@ cache's, and netgrep now retains nothing between searches, so there is no growth
 It returns `void` and starts every search eagerly with no concurrency limit. Callers cannot await it, cannot
 detect completion, and a batch of N URLs opens N simultaneous connections.
 
-### 5. One NUL byte discards the whole searched block — `lib.rs`, `BinaryDetection::quit`
+### 5. One NUL byte discarded the whole searched block — FIXED
 
-`BinaryDetection::quit(b'\x00')` does not stop *at* the NUL — it abandons everything it was handed. A match is
-dropped even when it occurs before the NUL, and even on an earlier line. Any remote file containing a stray
-NUL therefore reports "no match" for content that is demonstrably present.
+`BinaryDetection::quit(b'\x00')` did not stop *at* the NUL — it abandoned everything it was handed, so a match
+was dropped even when it occurred before the NUL, and even on an earlier line. `build_searcher` now uses
+`BinaryDetection::none()`, which searches every byte as text instead.
 
-Quitting on binary input is a reasonable ripgrep default; the surprise is that the API cannot distinguish
-"binary, not searched" from "no match" — `capture` does not help, since a discarded block reports no match and
-therefore no line.
+Quitting on binary input was a reasonable ripgrep default; the defect was that a boolean API could not
+distinguish "binary, not searched" from "no match" — `capture` did not help, since a discarded block reported
+no match and therefore no line.
 
-Decision 0018 changed the *shape* of this without fixing it. What the engine is handed is no longer the network
-chunk but the block of complete lines within it, so how far a NUL reaches now depends on where the last `\n`
-falls rather than on where the network split the response — and a match on an earlier line survives *if* the
-NUL happens to land in the held-back partial line. Both behaviours are pinned, so that accident is not mistaken
-for a fix.
+The trade is real and is published rather than hidden: nothing now declines to search binary input, so a
+pattern occurring inside a `.png` is reported like any other match, and a captured line is whatever those bytes
+decode to. Listed in [`guide/caveats.data.json`](guide/caveats.data.json) as `no-binary-detection`,
+`kind: "by-design"`. Decision 0018's incidental narrowing — a NUL landing in the held-back partial line let an
+earlier match survive by accident, rather than by design — stopped being incidental: every match now survives,
+for the ordinary reason, and that case is still pinned so the two are not told apart by chance. Closed as
+BACKLOG 3f; see the `# Done` table in [`BACKLOG.md`](BACKLOG.md).
 
 ### 6. `$` does not match on CRLF input — `lib.rs`, no `.crlf(true)` on the matcher
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -104,26 +104,6 @@ do.
 Not obviously worth fixing. Raising the ceiling trades memory for a case nobody has hit; removing it means
 buffering without bound. Left recorded rather than planned.
 
-### 3f. A single NUL byte discards the whole searched block — `packages/search/src/lib.rs`
-
-`BinaryDetection::quit(b'\x00')` does not merely stop at the NUL; it abandons the entire chunk. A match is
-dropped even when it occurs *before* the NUL, and even on an earlier line.
-
-```
-"needle here"              ~  "needle"  ->  true
-"needle here\0tail"        ~  "needle"  ->  false   # match precedes the NUL
-"needle here\n\0tail"      ~  "needle"  ->  false   # and is on an earlier line
-```
-
-Quitting on binary input is a reasonable ripgrep default; the surprise is that a boolean API cannot
-distinguish "binary, not searched" from "no match". Options: `BinaryDetection::none()`, or surfacing the
-distinction — which is an API change and therefore out of scope today.
-
-Decision 0018 changed its blast radius without fixing it. The engine is handed the block of complete lines in a
-chunk rather than the chunk, so how far a NUL reaches now depends on where the last `\n` falls, and a match on
-an earlier line survives *if* the NUL lands in the held-back partial line. Incidental, and pinned in both
-directions so it is not mistaken for a fix. **Fix it in `lib.rs` or not at all.**
-
 ### 17. `$` never matches on CRLF input — `packages/search/src/lib.rs`
 
 The matcher is built without `.crlf(true)`, and the searcher's line terminator is `\n`, so on a
@@ -243,6 +223,7 @@ analysis was wrong.
 
 | # | Item | Outcome |
 |---|---|---|
+| 3f | A single NUL byte discards the whole searched block | **Fixed, 2026-08-05.** `BinaryDetection::quit(b'\x00')` never stopped *at* the NUL — it abandoned the entire block the searcher was handed, so a match was dropped even when it preceded the NUL and even when it sat on an earlier line, and a boolean cannot tell "binary, not searched" from "no match". `BinaryDetection::none()`. The entry's own analysis offered two options and this took the first; the second — surfacing the distinction — remains an API change and stays out of scope. The incidental narrowing [0018](decisions/0018-line-oriented-tail-buffer.md) introduced, where a NUL landing in the held-back partial line let the match survive, is no longer load-bearing but its assertion is kept: it now passes for the ordinary reason rather than the accidental one, and the two must not be told apart by chance. **The trade is real and is published as a caveat:** nothing now declines to search binary input, so a pattern occurring inside a `.png` is reported like any other match. Pinned in both `search.rs` and `Netgrep.integration.spec.ts` under decision [0011](decisions/0011-tests-that-assert-known-bugs.md)'s rule — inverted and renamed, not deleted. |
 | 24 | The demo could not demonstrate what the project claims | **Shipped, 2026-08-02** — see [0026](decisions/0026-demo-as-log-dashboard.md). Never an Open item: it was recorded in [0025](decisions/0025-streaming-grep-over-http.md)'s *Consequences* as a gap that record could not close itself, and it is here so the closure is on the list rather than only in a decision. The demo searched 56 files averaging 46 KB under a hero reading *on files your tab could never hold*, so the demo's own files were a standing counterexample to the claim above it, and an answer-before-the-last-byte on a file that arrives in two chunks is invisible. Four generated logs — 8.3, 40.0, 120.1 and 240.2 MB, 408.6 MB together — tiled from four committed ~512 KB CC BY 4.0 loghub-2.0 seeds into a gitignored `public/logs/`, served as `.txt` so Pages compresses them. Measured in a browser: an early match answers at ~16 ms while the 240 MB source still streams, all four settle at ~1.8 s, and a marker a quarter of the way into that source answers at ~467 ms against ~1.8 s for a full read of it. **Half the gap only.** Constant memory is still not demonstrated on the page and is not scheduled to be: no browser API gives an honest per-stream memory figure, so a number there would be a fabrication. — **Extended, 2026-08-03.** The clause that read *the page reports elapsed time and nothing else, because nothing else is honestly measurable from inside a tab* was wrong in its second half and is retracted. The page now also reports **bytes read per source and in total**, counted by wrapping the demo's own `window.fetch` and piping each log response through a counting `TransformStream` — a measurement at the page's own boundary, needing nothing from the library. Measured against the built site: a match near the head of Apache answers after **8.9%** of that file while the other three read 100%, `NETGREP-MARKER-25` lands at 25.0–32.3% across the four, `-75` at 75.0–78.1%, and a miss reads 100% of all of them. ⚠️ The figure is **decompressed file content, not wire bytes** — the logs are served gzipped at ~16× — so it is labelled *Scanned* and the stats bar says which it is; do not let that sentence be shortened away. Resource Timing was probed and cannot do this: an aborted fetch reports `encodedBodySize: 0` in Chromium, which is exactly the case worth showing. Two costs accepted: `pnpm dev` and `pnpm build:example` now depend on a ~0.8 s generation step, and the generated logs are repetitive by construction, so the four `NETGREP-MARKER-*` lines are their only deep needles. Made item **23** visible — see above. |
 | 19 | The cache has no eviction, size cap or TTL | **Closed by deleting the cache**, not by adding eviction — see [0024](decisions/0024-remove-the-in-memory-cache.md). This was what remained of item **11** after [0018](decisions/0018-line-oriented-tail-buffer.md) fixed its O(n²) half. The eviction it asked for is the browser HTTP cache's, and always was: netgrep now retains nothing between searches, so there is no growth to bound. ⚠️ **This is the second item numbered 19** — see the note under *Item numbers are stable*, above. |
 | 21 | Early resolution did not cancel the request | **Fixed.** `resolve()` on a match stopped issuing reads but left the request open, so the remaining bytes still arrived and were still paid for — the saving was latency only. `reader.cancel()` at the match site ends the transfer. Never an Open item on this list: it was recorded in [0002](decisions/0002-search-while-downloading.md)'s *Consequences* and nowhere else, which is why it went unclosed for years. Pinned by "cancels the response stream on a match, ending the transfer" in `Netgrep.integration.spec.ts`, with the stream-ends-normally control beside it. |

--- a/docs/guide/07-limitations.md
+++ b/docs/guide/07-limitations.md
@@ -13,12 +13,6 @@ Each defect is pinned by a test, so it cannot change unnoticed.
 
 netgrep holds back the incomplete last *line* of each chunk and prepends it to the next. That is exact, since a match can never cross a newline, so ordinary text is unaffected no matter how the network splits the response. The exception is a line with no terminator in 64 KB, such as minified JavaScript or a one-line data dump. Past that ceiling the retained bytes become a plain 64 KB window, so a match longer than the window is lost, `^` can match at a window edge where no line actually begins, and a line captured with `capture` is a mid-line fragment rather than a line. That fragment need not contain the match, so `ranges` can come back empty even though `result` is still correct. Newline-free input is also answered more slowly, because nothing can be searched until the ceiling fills or the download ends.
 
-<a id="nul-byte"></a>
-
-### A file containing a NUL byte reports no match
-
-The block of lines containing the NUL reports no match, even when the match came earlier. ripgrep's binary detection abandons what it is given rather than stopping at the NUL, and a boolean cannot distinguish “binary, not searched” from “no match”. Plain text, the intended use, is unaffected.
-
 <a id="crlf-dollar"></a>
 
 ### `$` does not match on CRLF files
@@ -28,6 +22,12 @@ The line terminator is `\n`, so on Windows-authored text the `\r` sits between y
 ## By design
 
 These are not bugs and will not be fixed.
+
+<a id="no-binary-detection"></a>
+
+### netgrep does not detect binary files
+
+netgrep searches every byte it is given as text. It does not sniff for binary content and does not decline to search it, so pointing it at an image, an archive or an executable produces matches wherever the pattern's bytes occur, and a captured line is whatever the surrounding bytes decode to — lossily, so anything that is not valid UTF-8 becomes `U+FFFD`. This is deliberate: the alternative ripgrep offers is to abandon the whole block of lines on the first NUL byte, which discarded matches that came *before* it and made a file's answer depend on a byte the caller never looked for. Deciding what a url points at is the caller's job, and it is the one thing the caller can actually do.
 
 <a id="concurrent-dedup"></a>
 

--- a/docs/guide/caveats.data.json
+++ b/docs/guide/caveats.data.json
@@ -8,12 +8,12 @@
     "backlog": "3g"
   },
   {
-    "id": "nul-byte",
-    "title": "A file containing a NUL byte reports no match",
-    "short": "A NUL byte discards the block of lines containing it, even when the match came earlier.",
-    "body": "The block of lines containing the NUL reports no match, even when the match came earlier. ripgrep's binary detection abandons what it is given rather than stopping at the NUL, and a boolean cannot distinguish “binary, not searched” from “no match”. Plain text, the intended use, is unaffected.",
-    "kind": "defect",
-    "backlog": "3f"
+    "id": "no-binary-detection",
+    "title": "netgrep does not detect binary files",
+    "short": "A pattern that occurs inside a `.png` is reported like any other match.",
+    "body": "netgrep searches every byte it is given as text. It does not sniff for binary content and does not decline to search it, so pointing it at an image, an archive or an executable produces matches wherever the pattern's bytes occur, and a captured line is whatever the surrounding bytes decode to — lossily, so anything that is not valid UTF-8 becomes `U+FFFD`. This is deliberate: the alternative ripgrep offers is to abandon the whole block of lines on the first NUL byte, which discarded matches that came *before* it and made a file's answer depend on a byte the caller never looked for. Deciding what a url points at is the caller's job, and it is the one thing the caller can actually do.",
+    "kind": "by-design",
+    "backlog": null
   },
   {
     "id": "crlf-dollar",

--- a/packages/netgrep/src/lib/Netgrep.integration.spec.ts
+++ b/packages/netgrep/src/lib/Netgrep.integration.spec.ts
@@ -1079,14 +1079,15 @@ describe('Netgrep integration (real WASM)', () => {
       });
     });
 
-    it('BACKLOG 3f: one NUL byte discards the whole searched block, match included', async () => {
-      // `BinaryDetection::quit(b'\x00')` abandons what it was given on the first
-      // NUL, so the match is dropped even when it precedes the NUL.
+    it('BACKLOG 3f (FIXED): a NUL byte no longer discards the searched block', async () => {
+      // `BinaryDetection::quit(b'\x00')` abandoned the block on the first NUL,
+      // so the match was dropped even when it preceded the NUL. With
+      // `BinaryDetection::none()` the bytes are searched as text.
       //
-      // STILL OPEN, but the blast radius changed shape: the engine now gets a
-      // chunk's block of COMPLETE LINES, so a NUL's reach depends on where the
-      // last `\n` falls. Case (c) needed a terminator added, or the NUL lands in
-      // the held-back partial line and never shares a block with the match.
+      // Case (d) used to be the incidental narrowing — the NUL landing in the
+      // held-back partial line so it never shared a block with the match. It is
+      // kept because it now passes for the ordinary reason rather than the
+      // accidental one, and the two must not be told apart by chance.
       const NG = new Netgrep();
 
       serve([bytes('needle here')]);
@@ -1096,19 +1097,14 @@ describe('Netgrep integration (real WASM)', () => {
 
       serve([bytes('needle here', 0x00, 'tail')]);
       await expect(NG.search('b', 'needle')).resolves.toMatchObject({
-        result: false,
+        result: true,
       });
 
       serve([bytes('needle here\n', 0x00, 'tail\n')]);
       await expect(NG.search('c', 'needle')).resolves.toMatchObject({
-        result: false,
+        result: true,
       });
 
-      // The incidental narrowing, pinned so it is not mistaken for the fix: case
-      // (c) minus the final terminator, so the NUL sits in the trailing partial
-      // line and gets its own block. The match survives — because of where the
-      // newline is, which nobody should rely on. 3f is fixed in `lib.rs` or not
-      // at all.
       serve([bytes('needle here\n', 0x00, 'tail')]);
       await expect(NG.search('d', 'needle')).resolves.toMatchObject({
         result: true,

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -27,5 +27,5 @@ Each is a separate entry point so a caller pays only for what it asks for, and a
 matcher and one searcher, so their matching semantics cannot differ.
 
 On its own this package is a **~1.17 MB WebAssembly binary** (~500 KB gzipped) and nothing else. Its
-[known limitations](https://github.com/dgopsq/netgrep#known-limitations) are worth reading first — a
-single NUL byte discards the block of lines being searched, and `$` does not match on CRLF input.
+[known limitations](https://github.com/dgopsq/netgrep#known-limitations) are worth reading first — netgrep
+does not detect binary files, and `$` does not match on CRLF input.

--- a/packages/search/src/lib.rs
+++ b/packages/search/src/lib.rs
@@ -194,17 +194,23 @@ fn build_matcher(pattern: &str) -> Result<RegexMatcher, String> {
         .map_err(|error| error.to_string())
 }
 
-/// Build a searcher with netgrep's fixed reading semantics: quit on a NUL, and
-/// do not count lines.
+/// Build a searcher with netgrep's fixed reading semantics: search every byte
+/// as text, and do not count lines.
 ///
 /// Shared by all three entry points rather than spelled out in each. They must
 /// agree — a caller who adds `capture: 'line-ranges'` to an existing search is
 /// entitled to the same answer — and binary detection in particular decides
 /// whether a whole block is abandoned, so a divergence here would be a
 /// difference in `result`, not merely in what is returned alongside it.
+///
+/// `BinaryDetection::none()` rather than `quit(b'\x00')`, which abandoned the
+/// entire block on the first NUL and so dropped matches that preceded it. The
+/// trade is that netgrep no longer declines to search binary input at all: a
+/// pattern occurring inside a `.png` is reported like any other match, and the
+/// line handed back is whatever those bytes decode to.
 fn build_searcher() -> Searcher {
     SearcherBuilder::new()
-        .binary_detection(BinaryDetection::quit(b'\x00'))
+        .binary_detection(BinaryDetection::none())
         .line_number(false)
         .build()
 }

--- a/packages/search/tests/search.rs
+++ b/packages/search/tests/search.rs
@@ -509,16 +509,23 @@ mod matching_line {
     #[test]
     fn test_the_three_entry_points_share_one_searcher_configuration() {
         // All three go through `build_searcher`, so binary detection cannot
-        // differ between them. That matters more than it looks: a NUL abandons
-        // the whole block, so a divergence would change `result` — adding
-        // `capture: 'line-ranges'` to a working search would change its
-        // ANSWER, not just what came back alongside it.
+        // differ between them. That matters more than it looks: a divergence
+        // would change `result` — adding `capture: 'line-ranges'` to a working
+        // search would change its ANSWER, not just what came back alongside it.
         //
         // Asserted through the observable behaviour rather than the builder,
-        // because the builder is not comparable.
-        assert!(!matches(b"needle here\x00tail", "needle"));
-        assert_eq!(first_line(b"needle here\x00tail", "needle", NO_CAP), None);
-        assert_eq!(line_ranges(b"needle here\x00tail", "needle", NO_CAP), None);
+        // because the builder is not comparable. The input still carries a NUL
+        // because that is the setting most able to diverge — it used to abandon
+        // the whole block and now searches it as text.
+        assert!(matches(b"needle here\x00tail", "needle"));
+        assert_eq!(
+            first_line(b"needle here\x00tail", "needle", NO_CAP).as_deref(),
+            Some("needle here\u{0}tail")
+        );
+        assert_eq!(
+            line_ranges(b"needle here\x00tail", "needle", NO_CAP),
+            Some(("needle here\u{0}tail".to_string(), vec![0, 6]))
+        );
 
         // The control, so this is pinning the shared config rather than an
         // input that never matched.
@@ -755,15 +762,22 @@ mod documented_defects {
     }
 
     #[test]
-    fn backlog_3f_one_nul_byte_discards_the_whole_chunk() {
-        // `BinaryDetection::quit(b'\x00')` does not stop AT the NUL; it
-        // abandons everything it was given. The match is dropped even when it
-        // precedes the NUL, and even when it is on an earlier line.
+    fn backlog_3f_fixed_a_nul_byte_no_longer_discards_the_block() {
+        // `BinaryDetection::quit(b'\x00')` abandoned everything it was given on
+        // the first NUL, so a match was dropped even when it preceded the NUL
+        // and even when it sat on an earlier line. `BinaryDetection::none()`
+        // searches the bytes as text and reports what is there.
         assert!(matches(b"needle here", "needle"));
 
-        assert!(!matches(b"needle here\x00tail", "needle"));
-        assert!(!matches(b"needle here\n\x00tail", "needle"));
-        assert!(!matches(b"\x00needle here", "needle"));
+        assert!(matches(b"needle here\x00tail", "needle"));
+        assert!(matches(b"needle here\n\x00tail", "needle"));
+        assert!(matches(b"\x00needle here", "needle"));
+
+        // The cost of the fix, pinned so it is not mistaken for an oversight:
+        // nothing now declines to search binary input, so a pattern that occurs
+        // inside a `.png` is reported like any other match. The caller decides
+        // what it is pointing at.
+        assert!(matches(b"\x89PNG\r\n\x1a\nIHDRneedle", "needle"));
     }
 
     #[test]


### PR DESCRIPTION
Closes BACKLOG **3f**, an open P1 correctness defect. Independent of the API rewrite — worth shipping on its own terms.

## The defect

`BinaryDetection::quit(b'\x00')` does not stop *at* the NUL. It abandons everything the searcher was handed, so a match was dropped even when it **preceded** the NUL and even when it sat on an earlier line:

```
"needle here"           ~ "needle" -> true
"needle here\0tail"     ~ "needle" -> false   # match precedes the NUL
"needle here\n\0tail"   ~ "needle" -> false   # and is on an earlier line
```

A boolean API cannot distinguish "binary, not searched" from "no match", which is what made this silent.

## The fix

`BinaryDetection::none()` — one line.

## The trade, published rather than hidden

netgrep now declines nothing: a pattern occurring inside a `.png` is reported like any other match, and the captured line is whatever those bytes decode to. That replaces the old caveat rather than quietly removing it, as `no-binary-detection` (`kind: by-design`).

## Notes for review

- **A second test asserted this defect from outside `documented_defects`.** `test_the_three_entry_points_share_one_searcher_configuration` pinned the three exports' shared config *through* the NUL behaviour. The invariant it guards is unchanged; only the observable inverted.
- Both defect tests are **inverted and renamed, not deleted**, per [0011](https://github.com/dgopsq/netgrep/blob/main/docs/decisions/0011-tests-that-assert-known-bugs.md).
- The third commit stops `ARCHITECTURE.md` and `AGENTS.md` describing the defect as live — `AGENTS.md` is what `CLAUDE.md` points every agent at as canonical, so a stale row there actively misleads.

## Verification

`pnpm test:rust` 58/58 · `pnpm test` 180/180 · `pnpm lint` clean · `pnpm docs:sync --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)