### PR TITLE
feat(search): return every matching line in a block

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,7 +219,7 @@ pnpm build:wasm        # REQUIRED FIRST — see §2.2
 | Test TS | `pnpm test` | Vitest — **180 tests**: 60 unit in Node, 49 integration in headless Chromium, 71 tooling in Node |
 | — one suite | `pnpm test:unit` / `pnpm test:browser` / `pnpm test:tools` | The three Vitest projects separately. Only `test:browser` needs WASM or a browser |
 | Test the tooling | `pnpm test:tools` | **71 tests** over the docs generator, the guide renderer and the example's pure modules. Touches neither the library nor `pkg/` |
-| Test Rust | `pnpm test:rust` | `cargo test`, native, no browser — **58 tests** |
+| Test Rust | `pnpm test:rust` | `cargo test`, native, no browser — **73 tests** |
 | Regenerate the caveat surfaces | `pnpm docs:sync` | Renders `docs/guide/caveats.data.json` onto the guide and the README. `--check` writes nothing and exits 1 when they disagree — §2.3 |
 | Verify packaging | `pnpm verify:pack` | Packs both packages and inspects the tarballs. **Needs `pnpm build` first** |
 | Run the demo | `pnpm dev` | Vite, at <http://localhost:5173/>. **Needs `pnpm build` first** — see below |
@@ -365,15 +365,22 @@ Three packages, ~530 lines of first-party source. pnpm workspaces link them; the
 ```
 packages/
   search/            Rust → WASM core. The actual search engine.
-    src/lib.rs         ~430 lines, mostly comment. Exports three functions,
+    src/lib.rs         ~670 lines, mostly comment. Exports four functions,
                        sharing one compiled-matcher memo (decision 0016) and one
-                       searcher, so a caller pays only for the mode it names:
+                       searcher, so a caller pays only for the mode it names.
+                       Binary detection is fixed for all four; line-number
+                       counting is the one thing that varies by caller:
                          search_bytes(&[u8], &str) -> Result<bool, JsError>
                          search_bytes_line(&[u8], &str, usize)
                              -> Result<Option<String>, JsError>   see decision 0020
                          search_bytes_line_ranges(&[u8], &str, usize)
                              -> Result<Option<LineWithRanges>, JsError>
                                                                   see decision 0022
+                         search_block(&[u8], &str, usize)
+                             -> Result<BlockHits, JsError>        every match in
+                                                                  the block, not
+                                                                  just the first;
+                                                                  no TS caller yet
     tests/search.rs    plain native `cargo test` — no browser, no WebDriver.
                        Ends with a `documented_defects` module; read §2.1 first
     scripts/post_build.js   fixes up the generated pkg/ (see below)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -87,7 +87,7 @@ never compiled. See [decision 0001](decisions/0001-fork-ripgrep-for-wasm.md).
 
 ## The Rust core — `packages/search`
 
-`src/lib.rs` is ~430 lines, most of them comment, and exposes three `#[wasm_bindgen]` functions:
+`src/lib.rs` is ~670 lines, most of them comment, and exposes four `#[wasm_bindgen]` functions:
 
 ```rust
 pub fn search_bytes(chunk: &[u8], pattern: &str) -> Result<bool, JsError>
@@ -95,26 +95,55 @@ pub fn search_bytes_line(chunk: &[u8], pattern: &str, max_line_bytes: usize)
     -> Result<Option<String>, JsError>
 pub fn search_bytes_line_ranges(chunk: &[u8], pattern: &str, max_line_bytes: usize)
     -> Result<Option<LineWithRanges>, JsError>
+pub fn search_block(chunk: &[u8], pattern: &str, max_line_bytes: usize)
+    -> Result<BlockHits, JsError>
 ```
 
 wasm-bindgen unwraps those `Result`s, so the TypeScript a consumer sees is
 `search_bytes(chunk: Uint8Array, pattern: string): boolean`,
-`search_bytes_line(chunk: Uint8Array, pattern: string, max_line_bytes: number): string | undefined`, and a
+`search_bytes_line(chunk: Uint8Array, pattern: string, max_line_bytes: number): string | undefined`, a
 third returning a `LineWithRanges | undefined` carrying the same `line` plus a flat
-`Uint32Array` of `[start, end, …]` — all three simply **throw** on a pattern the regex engine will not accept,
-rather than trapping the instance as they did until 2026.
+`Uint32Array` of `[start, end, …]`, and a fourth, `search_block(chunk: Uint8Array, pattern: string,
+max_line_bytes: number): BlockHits`, described below — all four simply **throw** on a pattern the regex engine
+will not accept, rather than trapping the instance as they did until 2026.
 
-The extra entry points exist so the first stays free. `Netgrep.ts` calls one of the three depending on
-`capture`, so a caller who wants only membership allocates nothing, decodes nothing and copies no string out
-of WebAssembly — the same call it has always made, and the line path pays for no ranges it did not ask for.
-`undefined` is the only no-match signal any of them returns: a pattern matching an empty line yields `""`,
-which is falsy. All three share one compiled-matcher memo and one searcher, so their matching semantics and
-binary detection cannot drift apart.
+The first three exist so the cheapest one stays free. `Netgrep.ts` calls one of them depending on `capture`, so
+a caller who wants only membership allocates nothing, decodes nothing and copies no string out of WebAssembly —
+the same call it has always made, and the line path pays for no ranges it did not ask for. `undefined` is the
+only no-match signal any of the three returns: a pattern matching an empty line yields `""`, which is falsy.
+
+All four share one compiled-matcher memo and one searcher-building function, `build_searcher`. Its **binary
+detection is fixed for every caller**, deliberately: `BinaryDetection::none()` decides whether a block is
+abandoned before a byte of it is searched, so letting that vary by caller would change `result` itself, not
+merely what accompanies it (caveat 5, below). Its **line-number counting is not fixed** —
+`build_searcher(line_numbers: bool)` takes that as a parameter, because counting terminators changes only cost,
+never the answer: `search_bytes`, `search_bytes_line` and `search_bytes_line_ranges` all pass `false`, since
+none of them reports a line number, and `search_block` passes `true`, because the streaming loop that will
+consume it needs one per hit.
 
 The ranges are computed only after the search has ended, by running the same compiled matcher over the kept
-line — bounded by the line, off the hot path. Conversion to UTF-16 code units happens against the decoded,
-truncated string, since a byte offset into the input would be wrong wherever lossy decoding substituted
-`U+FFFD`. See [decision 0022](decisions/0022-capture-ranges.md).
+line — bounded by the line, off the hot path. `search_block` reuses the same routine per hit rather than once
+per call. Conversion to UTF-16 code units happens against the decoded, truncated string, since a byte offset
+into the input would be wrong wherever lossy decoding substituted `U+FFFD`. See
+[decision 0022](decisions/0022-capture-ranges.md).
+
+`search_block` is the streaming counterpart to `search_bytes_line_ranges`: where `MemSink` and `LineSink` both
+return `Ok(false)` from `matched` to stop at the first hit, `search_block`'s `BlockSink` returns `Ok(true)` and
+keeps going, collecting every matching line in the block rather than just the first. Each hit carries a
+**1-based, block-relative** line number — turning that into a file-absolute one is the streaming loop's job, in
+a later PR — plus the same ranges `search_bytes_line_ranges` computes.
+
+The result crosses the WASM boundary as `BlockHits { text: String, table: Vec<u32> }` rather than a vector of
+per-hit structs. `serde-wasm-bindgen` would build every JavaScript object eagerly at marshalling time, and a
+common token in a 240 MB log produces hundreds of thousands of hits live at once — exactly the allocation
+pressure the constant-memory claim ([decision 0025](decisions/0025-streaming-grep-over-http.md)) cannot afford.
+Instead exactly two values cross the boundary per block, whatever the hit count: `text` is every matching line,
+terminator-stripped, joined by `\n` in hit order — unambiguous by construction, since a match can never span a
+`\n` — and `table` is `[hitCount, linesInBlock]` followed by one record per hit, `[lineNumber, nRanges, start,
+end, …]`. `nRanges` counts **pairs**, so a hit's record is `2 + nRanges * 2` words long.
+
+**Nothing in TypeScript calls `search_block` yet.** The streaming loop that will — reading blocks, tracking a
+running file-absolute line base, and turning each `BlockHits` back into per-match results — is a later PR.
 
 Per call it:
 
@@ -126,7 +155,8 @@ Per call it:
    pattern every time, so the cache hits on every chunk after the first; compilation was 97–99% of the cost
    before it existed. Failed compiles are cached alongside successful ones. See
    [decision 0016](decisions/0016-compiled-matcher-memo.md).
-2. Builds a `Searcher` with `BinaryDetection::none()` and `line_number(false)`.
+2. Builds a `Searcher` with `BinaryDetection::none()` and `line_number(false)` — `search_block` is the one
+   caller that passes `true`, since it needs a line number per hit; see above.
 3. Runs `search_slice` into `MemSink`, a minimal `Sink` implementation that does nothing but record that a
    match happened and stop — chosen because ripgrep's real sinks write to stdout, which does not exist in
    WASM.
@@ -484,7 +514,7 @@ components straight out of `rust-toolchain.toml`.
 | `splitAtLastLine.spec.ts` | Vitest in **Node**, 12 tests | The chunk-boundary tail arithmetic in isolation, with `cap = 8` so the over-the-ceiling cases fit on one line. A pure function, so no mocks at all. |
 | `Netgrep.spec.ts` | Vitest in **Node**, 48 tests | Orchestration only — `fetch` **and** `@netgrep/search` are mocked. Result shape, metadata, abort plumbing, error capture and serialisation, and all three public methods including `searchBatchWithCallback`. |
 | `Netgrep.integration.spec.ts` | Vitest in **headless Chromium** (Playwright), 49 tests | **The real engine through the real streaming loop, in a real browser.** Only `fetch` is faked, and only to remove the network: bytes still travel through a real `ReadableStream`, still arrive chunked, still get matched by the compiled `search_bytes`. |
-| `packages/search/tests/search.rs` | `cargo test`, native, 58 tests | The three `try_*` entry points as pure Rust — bytes in, bool/line/ranges out. Regex features, smart case, line semantics, encoding and BOM handling, binary detection, the compiled-matcher cache, and the UTF-16 offset conversion including its lossy-decoding and truncation edges. No browser involved. |
+| `packages/search/tests/search.rs` | `cargo test`, native, 73 tests | The four `try_*` entry points as pure Rust — bytes in, bool/line/ranges/block-hits out. Regex features, smart case, line semantics, encoding and BOM handling, binary detection, the compiled-matcher cache, block-hit collection and line numbering, and the UTF-16 offset conversion including its lossy-decoding and truncation edges. No browser involved. |
 | `scripts/verify-pack.mjs` | Node, in CI | The published tarballs: required files present, no `workspace:` range survived packing, no version drift. |
 
 The split between the Rust and TypeScript suites is deliberate: anything that depends only on the bytes is cheapest to pin

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -211,6 +211,31 @@ Fusing also has a real cost beyond the code: `try_search_block` returning a plai
 lets the sink and the encoding be reviewed and tested separately, and eight tests assert against that
 shape. Weigh that against whatever the measurement shows.
 
+### 27. The streaming loop never overlaps the network with the search — `packages/netgrep/src/lib/Netgrep.ts`
+
+`handleReader` awaits `reader.read()`, searches what came back, then recurses (`Netgrep.ts:295-354`). The two
+never run at the same time: the network sits idle while WebAssembly works, and WebAssembly sits idle while
+the next chunk arrives. Issuing the next `read()` *before* searching the current block would overlap them.
+
+Today the cost is small, because a search stops at the first match and most searches end early. It grows
+once every block is searched to completion rather than short-circuited, which is the direction
+[decision 0027](decisions/0027-streaming-matching-lines.md) takes the API.
+
+**Do not do this without measuring.** The saving is bounded by however long the search actually takes
+against however long a read takes, and nobody has measured either. If the network dominates — likely on the
+files netgrep is aimed at — overlapping buys nothing. [Decision 0016](decisions/0016-compiled-matcher-memo.md)
+is the precedent: it profiled this engine and found the cost was somewhere nobody expected.
+
+**A property to preserve, and a reason this must stay bounded.** An async generator suspends at `yield` and
+does not resume until the consumer asks for the next value, so a consumer that stops consuming stops the
+reads, the response body's queue fills, and the browser stops draining the socket — backpressure reaches the
+wire without any pause logic being written. That is a property of the shape rather than of any code here, and
+it is worth not breaking: a lookahead of one block costs exactly one block of slack, while an unbounded
+read-ahead queue would discard the property entirely and let a slow consumer buffer the file.
+
+Backpressure has one thing it cannot do — hold a pause long enough that the connection times out. That wants
+resuming by `Range` request instead, which is a feature and belongs in an issue rather than here.
+
 ---
 
 ## P3 — Papercuts

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -174,6 +174,43 @@ features are deprecated no-ops, so `default-features = false` drops nothing. net
 Removing it means patching `grep-searcher`, i.e. reintroducing the fork that was deleted in
 [decision 0001](decisions/0001-fork-ripgrep-for-wasm.md). Not worth it. Recorded so it is not rediscovered.
 
+### 26. The block path copies each matching line three times — `packages/search/src/lib.rs`
+
+`search_block` copies every matching line's bytes three times before they cross the boundary:
+
+```
+lib.rs:518   mat.bytes().to_vec()                      # BlockSink, per hit
+lib.rs:472   String::from_utf8_lossy(capped).into_owned()   # decode_line_with_ranges
+lib.rs:152   text.push_str(&hit.line)                  # encode_block, into the joined buffer
+```
+
+**The first is forced and cannot be removed on its own.** `SinkMatch` does not outlive the callback — the
+searcher reuses its internal buffer — so anything that defers processing has to copy. `LineSink` carries
+the same constraint and the same comment.
+
+**The copies are not the interesting cost; the intermediate is.** `BlockOutcome.hits` holds one `String`
+and one `Vec<u32>` per hit, all alive at once, for the whole block before `encode_block` runs. That is a
+smaller version of the eager materialisation that the flat `text`+`table` encoding exists to avoid, so
+the design argument against `serde-wasm-bindgen` applies in miniature to netgrep's own intermediate.
+
+The candidate fix is to **fuse the sink with the encoder**: give `BlockSink` the `&RegexMatcher`,
+`max_line_bytes`, and the output `text`/`table` buffers, and encode inside `matched()` where
+`mat.bytes()` is still valid. That removes the first and third copies and the intermediate entirely —
+one copy per line, and peak memory O(output) rather than O(2 × output + 2N allocations). A smaller
+variant removes only the second: `from_utf8_lossy` returns a `Cow` that is `Borrowed` for valid UTF-8,
+which is nearly always, and `.into_owned()` allocates anyway; a consumer that pushed the `Cow` straight
+into a buffer would not.
+
+**Do not do either without measuring first.** [Decision 0016](decisions/0016-compiled-matcher-memo.md)
+profiled this engine and found matcher *compilation* was 97–99% of the cost — the copies were not where
+the time went. Nothing has profiled the block path, and `wee_alloc` is no longer in this crate, so
+[decision 0008](decisions/0008-wee-alloc.md)'s assumptions about allocation cost no longer hold either.
+The measurement wants a realistic workload, which means waiting until the streaming loop can drive it.
+
+Fusing also has a real cost beyond the code: `try_search_block` returning a plain `BlockOutcome` is what
+lets the sink and the encoding be reviewed and tested separately, and eight tests assert against that
+shape. Weigh that against whatever the measurement shows.
+
 ---
 
 ## P3 — Papercuts

--- a/packages/search/src/lib.rs
+++ b/packages/search/src/lib.rs
@@ -244,7 +244,7 @@ pub fn try_search_block(
 /// Run `use_matcher` against the compiled form of `pattern`, compiling it only
 /// if the memo is not already holding it.
 ///
-/// Generic over the return type so all three entry points share one memo: the
+/// Generic over the return type so all four entry points share one memo: the
 /// slot caches the *matcher*, which is the expensive part, and is indifferent
 /// to what the caller then does with it.
 fn with_matcher<T>(

--- a/packages/search/src/lib.rs
+++ b/packages/search/src/lib.rs
@@ -226,29 +226,27 @@ fn build_matcher(pattern: &str) -> Result<RegexMatcher, String> {
 }
 
 /// Build a searcher with netgrep's fixed reading semantics: search every byte
-/// as text, and do not count lines.
+/// as text, and count lines only when the caller needs them.
 ///
-/// Shared by all three entry points rather than spelled out in each. They must
-/// agree — a caller who adds `capture: 'line-ranges'` to an existing search is
-/// entitled to the same answer — and binary detection in particular decides
-/// whether a whole block is abandoned, so a divergence here would be a
-/// difference in `result`, not merely in what is returned alongside it.
+/// Shared by every entry point rather than spelled out in each. They must agree
+/// on binary detection in particular, because it decides whether a block is
+/// abandoned — a divergence there would be a difference in `result`, not merely
+/// in what is returned alongside it. `BinaryDetection::none()` is therefore
+/// fixed here for all callers and is not a parameter.
 ///
-/// `BinaryDetection::none()` rather than `quit(b'\x00')`, which abandoned the
-/// entire block on the first NUL and so dropped matches that preceded it. The
-/// trade is that netgrep no longer declines to search binary input at all: a
-/// pattern occurring inside a `.png` is reported like any other match, and the
-/// line handed back is whatever those bytes decode to.
-fn build_searcher() -> Searcher {
+/// `line_numbers` is a parameter because it is the one setting that changes
+/// cost without changing answers: counting terminators is work the membership
+/// path has no use for, and `search_bytes` exists to allocate nothing.
+fn build_searcher(line_numbers: bool) -> Searcher {
     SearcherBuilder::new()
         .binary_detection(BinaryDetection::none())
-        .line_number(false)
+        .line_number(line_numbers)
         .build()
 }
 
 /// Run a compiled matcher over one chunk of bytes.
 fn search_with(matcher: &RegexMatcher, chunk: &[u8]) -> bool {
-    let mut searcher = build_searcher();
+    let mut searcher = build_searcher(false);
 
     let mut sink = MemSink { found: false };
 
@@ -286,7 +284,7 @@ impl Sink for MemSink {
 /// Run a compiled matcher over one block of bytes, keeping the first matching
 /// line.
 fn search_line_with(matcher: &RegexMatcher, chunk: &[u8], max_line_bytes: usize) -> Option<String> {
-    let mut searcher = build_searcher();
+    let mut searcher = build_searcher(false);
 
     let mut sink = LineSink { first: None };
 
@@ -338,7 +336,7 @@ fn search_line_ranges_with(
     chunk: &[u8],
     max_line_bytes: usize,
 ) -> Option<(String, Vec<u32>)> {
-    let mut searcher = build_searcher();
+    let mut searcher = build_searcher(false);
     let mut sink = LineSink { first: None };
 
     let _ = searcher.search_slice(matcher, chunk, &mut sink);

--- a/packages/search/src/lib.rs
+++ b/packages/search/src/lib.rs
@@ -151,6 +151,21 @@ pub fn try_search_bytes_line_ranges(
     })
 }
 
+/// Search a block for every matching line.
+///
+/// The native half of `search_block`, for the reason `try_search_bytes` gives:
+/// `JsError` cannot be constructed on a native target, so the Rust suite calls
+/// this.
+pub fn try_search_block(
+    chunk: &[u8],
+    pattern: &str,
+    max_line_bytes: usize,
+) -> Result<BlockOutcome, String> {
+    with_matcher(pattern, |matcher| {
+        search_block_with(matcher, chunk, max_line_bytes)
+    })
+}
+
 /// Run `use_matcher` against the compiled form of `pattern`, compiling it only
 /// if the memo is not already holding it.
 ///
@@ -326,11 +341,6 @@ impl Sink for LineSink {
 /// The ranges pass runs AFTER the search, over one line's bytes — it does not
 /// touch the early exit, and a `capture: 'line'` or boolean caller never pays
 /// for it.
-///
-/// `find_iter` runs over the full stripped line, not the truncated slice:
-/// truncating first would let `$` match at the cut, reporting a match the
-/// real line does not contain. Ranges past the cut are then dropped, and one
-/// straddling it is clamped — the string cannot show what it does not hold.
 fn search_line_ranges_with(
     matcher: &RegexMatcher,
     chunk: &[u8],
@@ -341,35 +351,146 @@ fn search_line_ranges_with(
 
     let _ = searcher.search_slice(matcher, chunk, &mut sink);
 
-    sink.first.map(|line| {
-        let content = strip_terminator(&line);
-        let cap = floor_char_boundary(content, max_line_bytes);
+    sink.first
+        .map(|line| decode_line_with_ranges(matcher, &line, max_line_bytes))
+}
 
-        let mut byte_offsets: Vec<usize> = Vec::new();
-        let _ = matcher.find_iter(content, |m| {
-            byte_offsets.push(m.start());
-            byte_offsets.push(m.end());
-            true
-        });
+/// Decode one matched line and locate the pattern's matches within it.
+///
+/// `find_iter` runs over the FULL stripped line, not the truncated slice:
+/// truncating first would let `$` match at the cut, reporting a match the real
+/// line does not contain. Ranges starting at or past the cut are then dropped
+/// and one straddling it is clamped — the string cannot show what it does not
+/// hold. `start == 0 && cap == 0` is kept deliberately, so the empty match on
+/// an empty line still has a range, which is the one case a caller cannot
+/// re-derive.
+///
+/// Shared by `search_line_ranges_with` and the block path so the two cannot
+/// drift; every subtlety above was paid for once already.
+fn decode_line_with_ranges(
+    matcher: &RegexMatcher,
+    line: &[u8],
+    max_line_bytes: usize,
+) -> (String, Vec<u32>) {
+    let content = strip_terminator(line);
+    let cap = floor_char_boundary(content, max_line_bytes);
 
-        // Drop pairs starting at or past the cut; clamp ends to it. `start ==
-        // cap` survives only for the empty match on an empty line, where
-        // dropping it would break "a match always has a range" in the one case
-        // a caller cannot re-derive.
-        let mut kept: Vec<usize> = Vec::with_capacity(byte_offsets.len());
-        for pair in byte_offsets.chunks_exact(2) {
-            let (start, end) = (pair[0], pair[1]);
-            if start < cap || (start == 0 && cap == 0) {
-                kept.push(start);
-                kept.push(end.min(cap));
-            }
+    let mut byte_offsets: Vec<usize> = Vec::new();
+    let _ = matcher.find_iter(content, |m| {
+        byte_offsets.push(m.start());
+        byte_offsets.push(m.end());
+        true
+    });
+
+    let mut kept: Vec<usize> = Vec::with_capacity(byte_offsets.len());
+    for pair in byte_offsets.chunks_exact(2) {
+        let (start, end) = (pair[0], pair[1]);
+        if start < cap || (start == 0 && cap == 0) {
+            kept.push(start);
+            kept.push(end.min(cap));
         }
+    }
 
-        let capped = &content[..cap];
-        let ranges = byte_offsets_to_utf16(capped, &kept);
+    let capped = &content[..cap];
+    let ranges = byte_offsets_to_utf16(capped, &kept);
 
-        (String::from_utf8_lossy(capped).into_owned(), ranges)
-    })
+    (String::from_utf8_lossy(capped).into_owned(), ranges)
+}
+
+/// One matching line, as the block API reports it.
+pub struct BlockHit {
+    /// 1-based, **relative to the block searched**, not to the file. The
+    /// running file-absolute base is the streaming loop's job.
+    pub line_number: u32,
+    /// Terminator stripped, truncated to `max_line_bytes`, lossily decoded.
+    pub line: String,
+    /// Flat `[start, end, …]` pairs, UTF-16 code units into `line`.
+    pub ranges: Vec<u32>,
+}
+
+/// What one block produced.
+pub struct BlockOutcome {
+    /// How many lines the block contained, matching or not. The streaming loop
+    /// advances its running line base by this, so it must count the final line
+    /// of a terminator-less block.
+    pub lines_in_block: u32,
+    pub hits: Vec<BlockHit>,
+}
+
+/// A `Sink` that keeps every matching line rather than the first.
+///
+/// The counterpart to `LineSink`, and the difference is the return value:
+/// `Ok(true)` continues the search. The bytes are copied because `SinkMatch`
+/// does not outlive the callback, and copied undecoded so the expensive half
+/// happens once, after the search.
+struct BlockSink {
+    hits: Vec<(u32, Vec<u8>)>,
+}
+
+impl Sink for BlockSink {
+    type Error = std::io::Error;
+
+    fn matched(
+        &mut self,
+        _searcher: &Searcher,
+        mat: &SinkMatch<'_>,
+    ) -> Result<bool, std::io::Error> {
+        // `line_number` is `Some` because the searcher is built with
+        // `line_number(true)`; 0 is unreachable and would be a wrong answer
+        // rather than a crash, so it is not worth an unwrap that could trap
+        // the WASM instance.
+        self.hits
+            .push((mat.line_number().unwrap_or(0) as u32, mat.bytes().to_vec()));
+
+        Ok(true)
+    }
+}
+
+/// Count the lines in a block.
+///
+/// Terminators, plus one for a final line that has none — the last block of a
+/// file not ending in a newline. Getting this wrong drifts the streaming loop's
+/// running base for every line after it.
+fn count_lines(chunk: &[u8]) -> u32 {
+    if chunk.is_empty() {
+        return 0;
+    }
+
+    let terminators = bytecount_newlines(chunk);
+
+    if chunk.last() == Some(&b'\n') {
+        terminators
+    } else {
+        terminators + 1
+    }
+}
+
+/// Terminators in a block. Split out so `count_lines` reads as its own rule.
+fn bytecount_newlines(chunk: &[u8]) -> u32 {
+    chunk.iter().filter(|&&byte| byte == b'\n').count() as u32
+}
+
+fn search_block_with(
+    matcher: &RegexMatcher,
+    chunk: &[u8],
+    max_line_bytes: usize,
+) -> BlockOutcome {
+    let mut searcher = build_searcher(true);
+    let mut sink = BlockSink { hits: Vec::new() };
+
+    let _ = searcher.search_slice(matcher, chunk, &mut sink);
+
+    let hits = sink
+        .hits
+        .into_iter()
+        .map(|(line_number, bytes)| {
+            let (line, ranges) = decode_line_with_ranges(matcher, &bytes, max_line_bytes);
+
+            BlockHit { line_number, line, ranges }
+        })
+        .collect();
+
+    BlockOutcome { lines_in_block: count_lines(chunk), hits }
 }
 
 /// Map ascending byte offsets in `bytes` to UTF-16 code-unit offsets in

--- a/packages/search/src/lib.rs
+++ b/packages/search/src/lib.rs
@@ -111,6 +111,81 @@ pub fn search_bytes_line_ranges(
         .map_err(|error| JsError::new(&error))
 }
 
+/// The value `search_block` hands to JavaScript.
+///
+/// Two fields rather than a vector of structs, and the choice is load-bearing.
+/// A `serde-wasm-bindgen` `Vec<BlockHit>` builds every JavaScript object
+/// eagerly at marshalling time; searching a common token across a 240 MB log
+/// produces hundreds of thousands of them, live at once, which is exactly the
+/// allocation pressure the project's constant-memory claim cannot afford. Here
+/// the crossing is one string and one integer array per block whatever the hit
+/// count, and the consumer builds each object at the moment it yields it.
+///
+/// `getter_with_clone` for the same reason `LineWithRanges` uses it: both
+/// fields are heap types, so the getters return copies and the caller frees the
+/// carrier after reading them.
+#[wasm_bindgen(getter_with_clone)]
+pub struct BlockHits {
+    /// The matching lines in hit order, joined by `\n`.
+    ///
+    /// Unambiguous by construction: lines are terminator-stripped, and a match
+    /// can never span a `\n`, so no segment can contain the separator.
+    pub text: String,
+    /// `[hitCount, linesInBlock]`, then per hit
+    /// `[lineNumber, nRanges, start, end, …]`, where `nRanges` counts **pairs**
+    /// — so a hit's record is `2 + nRanges * 2` words long.
+    pub table: Vec<u32>,
+}
+
+/// Flatten a `BlockOutcome` into the wire format.
+fn encode_block(outcome: BlockOutcome) -> BlockHits {
+    let mut table = Vec::with_capacity(2 + outcome.hits.len() * 4);
+    table.push(outcome.hits.len() as u32);
+    table.push(outcome.lines_in_block);
+
+    let mut text = String::new();
+
+    for (index, hit) in outcome.hits.iter().enumerate() {
+        if index > 0 {
+            text.push('\n');
+        }
+        text.push_str(&hit.line);
+
+        table.push(hit.line_number);
+        table.push((hit.ranges.len() / 2) as u32);
+        table.extend_from_slice(&hit.ranges);
+    }
+
+    BlockHits { text, table }
+}
+
+/// The native half of `search_block`, for the Rust suite.
+pub fn try_encode_block(
+    chunk: &[u8],
+    pattern: &str,
+    max_line_bytes: usize,
+) -> Result<BlockHits, String> {
+    try_search_block(chunk, pattern, max_line_bytes).map(encode_block)
+}
+
+/// Search a block and return every matching line, flattened.
+///
+/// The streaming counterpart to `search_bytes_line_ranges`, which returns only
+/// the first match and stops there. Two values cross the boundary per block
+/// however many lines matched; see `BlockHits` for the layout and why it is not
+/// a vector of structs.
+///
+/// Throws a JavaScript `Error` when the pattern will not compile, exactly as
+/// the other exports do.
+#[wasm_bindgen]
+pub fn search_block(
+    chunk: &[u8],
+    pattern: &str,
+    max_line_bytes: usize,
+) -> Result<BlockHits, JsError> {
+    try_encode_block(chunk, pattern, max_line_bytes).map_err(|error| JsError::new(&error))
+}
+
 /// The engine, as plain Rust.
 ///
 /// `search_bytes` above is a two-line wrapper around this, and the split is

--- a/packages/search/tests/search.rs
+++ b/packages/search/tests/search.rs
@@ -787,6 +787,118 @@ mod block {
     }
 }
 
+#[cfg(test)]
+mod encoding {
+    /// Decode the flat form back into `(line_number, line, ranges)` triples.
+    ///
+    /// This is the Rust mirror of the walker PR 5 writes in TypeScript. Having
+    /// it here means the encoding is pinned by a decoder that was written
+    /// against the format's description rather than against the encoder's
+    /// implementation.
+    fn decode(hits: &::search::BlockHits) -> (u32, Vec<(u32, String, Vec<u32>)>) {
+        let table = &hits.table;
+        let hit_count = table[0];
+        let lines_in_block = table[1];
+
+        let mut out = Vec::new();
+        let mut cursor = 2;
+        let mut lines = hits.text.split('\n');
+
+        for _ in 0..hit_count {
+            let line_number = table[cursor];
+            let n_ranges = table[cursor + 1] as usize;
+            let ranges = table[cursor + 2..cursor + 2 + n_ranges * 2].to_vec();
+
+            cursor += 2 + n_ranges * 2;
+
+            out.push((
+                line_number,
+                lines.next().expect("one text segment per hit").to_string(),
+                ranges,
+            ));
+        }
+
+        (lines_in_block, out)
+    }
+
+    #[test]
+    fn the_flat_form_round_trips_to_the_same_hits() {
+        let encoded = ::search::try_encode_block(
+            b"needle one\nmiss\nneedle two and needle\n",
+            "needle",
+            4096,
+        )
+        .expect("the pattern should compile");
+
+        let (lines_in_block, decoded) = decode(&encoded);
+
+        assert_eq!(lines_in_block, 3);
+        assert_eq!(decoded.len(), 2);
+        assert_eq!(decoded[0], (1, "needle one".to_string(), vec![0, 6]));
+        assert_eq!(
+            decoded[1],
+            (3, "needle two and needle".to_string(), vec![0, 6, 15, 21])
+        );
+    }
+
+    #[test]
+    fn a_block_with_no_hits_encodes_an_empty_text_and_a_two_word_table() {
+        let encoded = ::search::try_encode_block(b"alpha\nbeta\n", "needle", 4096)
+            .expect("the pattern should compile");
+
+        assert_eq!(encoded.table, vec![0, 2]);
+        assert_eq!(encoded.text, "");
+    }
+
+    #[test]
+    fn an_empty_matching_line_survives_the_join() {
+        // The join is by '\n' and an empty line contributes an empty segment.
+        // If the walker ever loses one, hits and text desynchronise for every
+        // hit after it — so this pins the case that would cause that.
+        let encoded = ::search::try_encode_block(b"a\n\n\nb\n", "^$", 4096)
+            .expect("the pattern should compile");
+
+        let (lines_in_block, decoded) = decode(&encoded);
+
+        assert_eq!(lines_in_block, 4);
+        assert_eq!(decoded.len(), 2);
+        assert_eq!(decoded[0], (2, "".to_string(), vec![0, 0]));
+        assert_eq!(decoded[1], (3, "".to_string(), vec![0, 0]));
+    }
+
+    #[test]
+    fn no_matched_line_can_contain_the_join_byte() {
+        // The format's whole safety argument: lines are terminator-stripped and
+        // a match can never span a '\n', so '\n' is an unambiguous separator.
+        // If this ever fails, the encoding is unsound, not merely wrong.
+        let encoded =
+            ::search::try_encode_block(b"one\ntwo\nthree\n", ".", 4096)
+                .expect("the pattern should compile");
+
+        let (_, decoded) = decode(&encoded);
+
+        for (_, line, _) in &decoded {
+            assert!(!line.contains('\n'), "a matched line contained the separator: {line:?}");
+        }
+    }
+
+    #[test]
+    fn a_line_past_the_cap_is_truncated_and_its_ranges_drop_or_clamp() {
+        // block()'s test helper (above) hardcodes max_line_bytes = 4096, so no
+        // block-path test exercises truncation — the drop/clamp branches were
+        // pinned only through `search_bytes_line_ranges`. This threads a small
+        // cap through the encoder instead, so a match fully past the cap is
+        // dropped and the survivor is clamped to the cut.
+        let encoded = ::search::try_encode_block(b"needle and needle\n", "needle", 8)
+            .expect("the pattern should compile");
+
+        let (_, decoded) = decode(&encoded);
+
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0], (1, "needle a".to_string(), vec![0, 6]));
+    }
+}
+
 /// ---------------------------------------------------------------------
 /// DOCUMENTED DEFECTS — these assertions pin behaviour that is WRONG.
 /// ---------------------------------------------------------------------

--- a/packages/search/tests/search.rs
+++ b/packages/search/tests/search.rs
@@ -700,6 +700,93 @@ mod line_ranges_tests {
     }
 }
 
+/// Assert-friendly wrapper for the block API, matching `matches` above.
+#[cfg(test)]
+fn block(haystack: &[u8], pattern: &str) -> ::search::BlockOutcome {
+    ::search::try_search_block(haystack, pattern, 4096).expect("the pattern should compile")
+}
+
+#[cfg(test)]
+mod block {
+    use super::block;
+
+    #[test]
+    fn every_matching_line_is_returned_not_just_the_first() {
+        // The whole point of the export: `LineSink` stops at the first match,
+        // this one does not.
+        let out = block(b"needle one\nmiss\nneedle two\nneedle three\n", "needle");
+
+        assert_eq!(out.hits.len(), 3);
+        assert_eq!(out.hits[0].line, "needle one");
+        assert_eq!(out.hits[1].line, "needle two");
+        assert_eq!(out.hits[2].line, "needle three");
+    }
+
+    #[test]
+    fn line_numbers_are_one_based_and_relative_to_the_block() {
+        let out = block(b"a\nb\nneedle\nc\nneedle\n", "needle");
+
+        assert_eq!(out.hits.len(), 2);
+        assert_eq!(out.hits[0].line_number, 3);
+        assert_eq!(out.hits[1].line_number, 5);
+    }
+
+    #[test]
+    fn lines_in_block_counts_the_final_line_without_a_terminator() {
+        // The streaming loop hands over whole lines, but the LAST block of a
+        // file that does not end in a newline has no trailing terminator. The
+        // count has to include that line or the running base in TypeScript
+        // drifts by one for the rest of the file.
+        assert_eq!(block(b"a\nb\nc\n", "zzz").lines_in_block, 3);
+        assert_eq!(block(b"a\nb\nc", "zzz").lines_in_block, 3);
+        assert_eq!(block(b"", "zzz").lines_in_block, 0);
+    }
+
+    #[test]
+    fn ranges_are_utf16_offsets_into_the_returned_line() {
+        // Same contract as `search_bytes_line_ranges`: offsets index the
+        // decoded string, not the bytes.
+        let out = block("café needle\n".as_bytes(), "needle");
+
+        assert_eq!(out.hits.len(), 1);
+        assert_eq!(out.hits[0].line, "café needle");
+        assert_eq!(out.hits[0].ranges, vec![5, 11]);
+    }
+
+    #[test]
+    fn several_matches_on_one_line_each_get_a_range() {
+        let out = block(b"needle and needle\n", "needle");
+
+        assert_eq!(out.hits.len(), 1);
+        assert_eq!(out.hits[0].ranges, vec![0, 6, 11, 17]);
+    }
+
+    #[test]
+    fn a_block_with_no_match_returns_no_hits_but_still_counts_lines() {
+        let out = block(b"alpha\nbeta\n", "needle");
+
+        assert!(out.hits.is_empty());
+        assert_eq!(out.lines_in_block, 2);
+    }
+
+    #[test]
+    fn a_match_on_an_empty_line_is_an_empty_string_with_a_range() {
+        // The trap `search_bytes_line` documents: an empty string is falsy, so
+        // a consumer must count hits rather than test the line for truthiness.
+        let out = block(b"a\n\nb\n", "^$");
+
+        assert_eq!(out.hits.len(), 1);
+        assert_eq!(out.hits[0].line, "");
+        assert_eq!(out.hits[0].line_number, 2);
+        assert_eq!(out.hits[0].ranges, vec![0, 0]);
+    }
+
+    #[test]
+    fn an_invalid_pattern_is_an_error_not_a_panic() {
+        assert!(::search::try_search_block(b"anything", "(", 4096).is_err());
+    }
+}
+
 /// ---------------------------------------------------------------------
 /// DOCUMENTED DEFECTS — these assertions pin behaviour that is WRONG.
 /// ---------------------------------------------------------------------

--- a/packages/search/tests/search.rs
+++ b/packages/search/tests/search.rs
@@ -818,6 +818,12 @@ mod encoding {
             ));
         }
 
+        // Prove the encoding is exactly consumed, not merely a prefix of it: a
+        // stray trailing table word or an extra joined segment would otherwise
+        // pass every assertion above unnoticed.
+        assert_eq!(cursor, table.len(), "the table has unconsumed words");
+        assert!(lines.next().is_none(), "the text has unconsumed segments");
+
         (lines_in_block, out)
     }
 
@@ -885,17 +891,55 @@ mod encoding {
     #[test]
     fn a_line_past_the_cap_is_truncated_and_its_ranges_drop_or_clamp() {
         // block()'s test helper (above) hardcodes max_line_bytes = 4096, so no
-        // block-path test exercises truncation — the drop/clamp branches were
-        // pinned only through `search_bytes_line_ranges`. This threads a small
-        // cap through the encoder instead, so a match fully past the cap is
-        // dropped and the survivor is clamped to the cut.
-        let encoded = ::search::try_encode_block(b"needle and needle\n", "needle", 8)
+        // block-path test exercised truncation before this — the drop/clamp
+        // branches were pinned only through `search_bytes_line_ranges`. This
+        // threads a small cap through the encoder instead: the first match
+        // straddles the cut and is clamped, the second sits entirely past it
+        // and is dropped.
+        let encoded = ::search::try_encode_block(b"needle and needle\n", "needle", 4)
             .expect("the pattern should compile");
 
         let (_, decoded) = decode(&encoded);
 
         assert_eq!(decoded.len(), 1);
-        assert_eq!(decoded[0], (1, "needle a".to_string(), vec![0, 6]));
+        assert_eq!(decoded[0], (1, "need".to_string(), vec![0, 4]));
+    }
+
+    #[test]
+    fn a_hit_whose_match_is_entirely_past_the_cap_is_a_two_word_record() {
+        // The first hit's only match starts past the cap and is dropped, so
+        // its record collapses to its two fixed words — `nRanges` is
+        // legitimately 0 without the hit itself being absent. The second hit
+        // is included alongside it, unmodified, as the control: its match
+        // starts before the cap and is clamped instead, so a walker reading
+        // this table has to size each record from its own `nRanges` rather
+        // than assume a fixed stride.
+        let encoded = ::search::try_encode_block(b"aaaa needle\nzz needle\n", "needle", 4)
+            .expect("the pattern should compile");
+
+        assert_eq!(encoded.table, vec![2, 2, 1, 0, 2, 1, 3, 4]);
+        assert_eq!(encoded.text, "aaaa\nzz n");
+
+        let (_, decoded) = decode(&encoded);
+        assert_eq!(decoded.len(), 2);
+        assert_eq!(decoded[0], (1, "aaaa".to_string(), vec![]));
+        assert_eq!(decoded[1], (2, "zz n".to_string(), vec![3, 4]));
+    }
+
+    #[test]
+    fn a_single_empty_matching_hit_still_reports_hit_count_one() {
+        // The trap for a walker written against this format: `text == ""` is
+        // also what a ZERO-hit block encodes, so a guard like `if (!text)
+        // return` would silently drop this real hit rather than decode it.
+        // `hitCount` is what distinguishes the two, not `text`'s truthiness.
+        let encoded = ::search::try_encode_block(b"a\n\nb\n", "^$", 4096)
+            .expect("the pattern should compile");
+
+        assert_eq!(encoded.text, "");
+
+        let (_, decoded) = decode(&encoded);
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0], (2, "".to_string(), vec![0, 0]));
     }
 }
 

--- a/packages/search/tests/search.rs
+++ b/packages/search/tests/search.rs
@@ -332,13 +332,13 @@ fn first_line(haystack: &[u8], pattern: &str, max_line_bytes: usize) -> Option<S
 ///
 /// Everything here is about what `search_bytes_line` returns *given* a match;
 /// whether something matches at all is `mod search` above, and is deliberately
-/// not re-asserted. All three entry points share one compiled matcher and one
+/// not re-asserted. All four entry points share one compiled matcher and one
 /// searcher configuration, so matching semantics cannot diverge between them —
-/// `test_the_three_entry_points_share_one_matcher` is the assertion that keeps
+/// `test_the_four_entry_points_share_one_matcher` is the assertion that keeps
 /// that true.
 #[cfg(test)]
 mod matching_line {
-    use super::{first_line, line_ranges, matches};
+    use super::{block, first_line, line_ranges, matches};
     use ::search::try_search_bytes_line;
 
     /// Comfortably above every line used here, so a test only exercises the cap
@@ -514,8 +514,8 @@ mod matching_line {
     // ---------------------------------------------------------------
 
     #[test]
-    fn test_the_three_entry_points_share_one_searcher_configuration() {
-        // All three go through `build_searcher`, so binary detection cannot
+    fn test_the_four_entry_points_share_one_searcher_configuration() {
+        // All four go through `build_searcher`, so binary detection cannot
         // differ between them. That matters more than it looks: a divergence
         // would change `result` — adding `capture: 'line-ranges'` to a working
         // search would change its ANSWER, not just what came back alongside it.
@@ -533,6 +533,9 @@ mod matching_line {
             line_ranges(b"needle here\x00tail", "needle", NO_CAP),
             Some(("needle here\u{0}tail".to_string(), vec![0, 6]))
         );
+        let block_hit = block(b"needle here\x00tail", "needle");
+        assert_eq!(block_hit.hits[0].line, "needle here\u{0}tail");
+        assert_eq!(block_hit.hits[0].ranges, vec![0, 6]);
 
         // The control, so this is pinning the shared config rather than an
         // input that never matched.
@@ -545,11 +548,14 @@ mod matching_line {
             line_ranges(b"needle here", "needle", NO_CAP),
             Some(("needle here".to_string(), vec![0, 6]))
         );
+        let block_hit = block(b"needle here", "needle");
+        assert_eq!(block_hit.hits[0].line, "needle here");
+        assert_eq!(block_hit.hits[0].ranges, vec![0, 6]);
     }
 
     #[test]
-    fn test_the_three_entry_points_share_one_matcher() {
-        // All three go through `with_matcher`, so a pattern compiled by one is
+    fn test_the_four_entry_points_share_one_matcher() {
+        // All four go through `with_matcher`, so a pattern compiled by one is
         // reused by the others. That is the point — but it also means a stale
         // slot would let one entry point answer with another's matcher, which
         // is the same silent-wrong-answer failure `mod search` guards for
@@ -563,11 +569,16 @@ mod matching_line {
             line_ranges(b"one wiseman", "wiseman", NO_CAP),
             Some(("one wiseman".to_string(), vec![4, 11]))
         );
+        assert_eq!(
+            block(b"one wiseman", "wiseman").hits[0].line,
+            "one wiseman"
+        );
 
         // Smart case is decided at compile time, so these need different
         // matchers despite differing by one bit.
         assert_eq!(first_line(b"one wiseman", "Wiseman", NO_CAP), None);
         assert_eq!(line_ranges(b"one wiseman", "Wiseman", NO_CAP), None);
+        assert!(block(b"one wiseman", "Wiseman").hits.is_empty());
         assert!(matches(b"one wiseman", "wiseman"));
     }
 
@@ -800,6 +811,15 @@ mod encoding {
         let hit_count = table[0];
         let lines_in_block = table[1];
 
+        if hit_count == 0 {
+            // `"".split('\n')` yields ONE empty segment, not zero — splitting
+            // unconditionally would misread a zero-hit block as one empty hit.
+            // A walker that skips this guard has the same bug.
+            assert_eq!(table.len(), 2, "a zero-hit table carries only its header");
+            assert_eq!(hits.text, "", "a zero-hit block has no text to join");
+            return (lines_in_block, Vec::new());
+        }
+
         let mut out = Vec::new();
         let mut cursor = 2;
         let mut lines = hits.text.split('\n');
@@ -854,6 +874,13 @@ mod encoding {
 
         assert_eq!(encoded.table, vec![0, 2]);
         assert_eq!(encoded.text, "");
+
+        // Exercise `decode` itself on the zero-hit case, not just the raw
+        // fields: its own doc calls it the walker's Rust mirror, so its
+        // zero-hit path needs to be run at least once.
+        let (lines_in_block, decoded) = decode(&encoded);
+        assert_eq!(lines_in_block, 2);
+        assert!(decoded.is_empty());
     }
 
     #[test]
@@ -877,8 +904,13 @@ mod encoding {
         // The format's whole safety argument: lines are terminator-stripped and
         // a match can never span a '\n', so '\n' is an unambiguous separator.
         // If this ever fails, the encoding is unsound, not merely wrong.
+        //
+        // `(?s).*` is deliberate, not `.`: dot-matches-newline is what would
+        // actually drive a cross-line match through the line reader if
+        // anything here were unsound. A plain `.` can never span a line under
+        // ANY implementation, so it would pass even if this were broken.
         let encoded =
-            ::search::try_encode_block(b"one\ntwo\nthree\n", ".", 4096)
+            ::search::try_encode_block(b"one\ntwo\nthree\n", "(?s).*", 4096)
                 .expect("the pattern should compile");
 
         let (_, decoded) = decode(&encoded);


### PR DESCRIPTION
**PR 4 of 7** in the streaming API rewrite argued in [decision 0027](https://github.com/dgopsq/netgrep/blob/main/docs/decisions/0027-streaming-matching-lines.md). Rust only — nothing in TypeScript calls the new export yet, so `main` stays shippable and no user-facing behaviour changes.

## What it adds

Every existing export stops at the **first** match: `MemSink` and `LineSink` both return `Ok(false)` from `matched()`. `BlockSink` returns `Ok(true)` and accumulates, so a block yields every matching line, each with a **1-based, block-relative** line number and its match ranges. Converting that to a file-absolute number is the streaming loop's job, in PR 5.

`build_searcher` gains a `line_numbers: bool` parameter. Binary detection stays hardcoded for every caller, deliberately: it decides whether a block is abandoned, so it changes *answers*, whereas line counting changes only cost.

## The wire format

```
text  : the matching lines, joined by '\n', in hit order
table : [hitCount, linesInBlock] then per hit [lineNumber, nRanges, start, end, …]
```

`nRanges` counts **pairs**, so a hit's record is `2 + nRanges * 2` words. Two values cross the WASM boundary per block whatever the hit count.

**Why not `serde-wasm-bindgen` and a `Vec<BlockHit>`:** it builds every JavaScript object eagerly at marshalling time. Searching a common token across the demo's 240 MB log produces hundreds of thousands of them live at once — exactly the allocation pressure the constant-memory claim cannot afford. With the flat form the consumer builds each object at the moment it yields it. It would also add serde to a `.wasm` that BACKLOG **14** already calls too big.

The join is unambiguous by construction: lines are terminator-stripped and a match can never span a `\n`. A test pins that rather than leaving it as an argument.

## Review notes

- **The decode-and-ranges logic is extracted, not copied.** `search_line_ranges_with` carried [0022](https://github.com/dgopsq/netgrep/blob/main/docs/decisions/0022-capture-ranges.md)'s drop/clamp rules — `find_iter` over the full stripped line so `$` cannot match at the truncation cut, and the empty-line range kept deliberately. Both paths now call one shared `decode_line_with_ranges`, verified faithful statement-for-statement.
- **`lines_in_block` counts a final line with no terminator.** The last block of a file not ending in a newline has one, and PR 5's running base would otherwise drift for every line after it.
- **A test-side reference decoder** mirrors the format from its *written description* rather than the encoder, so the two cannot agree on a shared mistake. It asserts the encoding is exactly consumed — a trailing `'\n'` or a stray table word fails it.
- **⚠️ For whoever writes the walker:** `"".split('\n')` yields one empty segment in both Rust and JavaScript, so the zero-hit case needs an explicit guard. The Rust decoder has one; the TypeScript walker will need the same.

## Verification

`pnpm test:rust` 73/73 · `pnpm test` 180/180 · `pnpm lint` clean · `pnpm docs:sync --check` clean. `search_block` and `BlockHits` confirmed present in the generated `index.d.ts`.

`.wasm` grew **13,050 bytes (+1.12%)** — proportionate, no new dependency. A cheap reduction if BACKLOG 14 is ever pressed: the `pub` fields on `BlockHits` and `LineWithRanges` generate setters nothing uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)