### PR TITLE
feat(netgrep): stream every matching line with grep()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -390,7 +390,7 @@ packages/
     → published as @netgrep/search
 
   netgrep/           TypeScript wrapper. Streaming + batching + a streaming grep.
-    src/lib/Netgrep.ts               the class API (~470 lines); no longer the
+    src/lib/Netgrep.ts               the class API (~390 lines); no longer the
                                      whole public API — see grep.ts below
     src/lib/grep.ts                  async generator: every matching line, with a
                                      file-absolute line number, as it is found
@@ -586,8 +586,9 @@ manifests cannot drift, and **deletes the `.gitignore` wasm-pack writes into `pk
 ## 7. Known correctness caveats
 
 Real, present in the published package, and **documented rather than fixed**. Each is pinned by a test that
-asserts the wrong behaviour — in `Netgrep.integration.spec.ts`, and for the ones that live in the engine also
-in `packages/search/tests/search.rs`. Read §2.1 before touching any of them.
+asserts the wrong behaviour — in `Netgrep.integration.spec.ts` and, for what **3g** does to `grep`, in
+`grep.integration.spec.ts`; for the ones that live in the engine also in `packages/search/tests/search.rs`.
+Read §2.1 before touching any of them.
 
 | | Where | Effect |
 |---|---|---|

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -380,7 +380,8 @@ packages/
                              -> Result<BlockHits, JsError>        every match in
                                                                   the block, not
                                                                   just the first;
-                                                                  no TS caller yet
+                                                                  the only caller
+                                                                  is grep()
     tests/search.rs    plain native `cargo test` — no browser, no WebDriver.
                        Ends with a `documented_defects` module; read §2.1 first
     scripts/post_build.js   fixes up the generated pkg/ (see below)
@@ -388,15 +389,32 @@ packages/
     pkg/               BUILD OUTPUT, gitignored
     → published as @netgrep/search
 
-  netgrep/           TypeScript wrapper. Streaming + batching.
-    src/lib/Netgrep.ts               the whole public API (~470 lines)
+  netgrep/           TypeScript wrapper. Streaming + batching + a streaming grep.
+    src/lib/Netgrep.ts               the class API (~470 lines); no longer the
+                                     whole public API — see grep.ts below
+    src/lib/grep.ts                  async generator: every matching line, with a
+                                     file-absolute line number, as it is found
+    src/lib/streamBlocks.ts          fetch → reader → blocks of whole lines,
+                                     onProgress, cancel-in-finally. Shared plumbing,
+                                     NOT re-exported by index.ts
+    src/lib/decodeBlock.ts           lazy text+table walker for one block, plus
+                                     linesInBlock(table). NOT re-exported
+    src/lib/wasmReady.ts             the shared init() promise, awaited by both
+                                     Netgrep and grep. NOT re-exported
     src/lib/splitAtLastLine.ts       the chunk-boundary tail arithmetic, pure and
-                                     unit-tested on its own. NOT re-exported by
+                                     unit-tested on its own; also exports
+                                     MAX_TAIL_BYTES. NOT re-exported by
                                      index.ts — see decision 0018
-    src/lib/data/*.ts                6 type definitions, one per file
+    src/lib/concatBytes.ts           joins tail + chunk. NOT re-exported
+    src/lib/resolveMaxLineBytes.ts   applies GrepOptions' default cap. NOT re-exported
+    src/lib/data/*.ts                8 type definitions, one per file
     src/lib/Netgrep.spec.ts          unit suite; mocks fetch and the engine
     src/lib/Netgrep.integration.spec.ts   real WASM through the real streaming loop,
                                           in headless Chromium (§4.2)
+    src/lib/decodeBlock.spec.ts      unit suite for the block walker
+    src/lib/streamBlocks.spec.ts     unit suite; mocks fetch
+    src/lib/grep.spec.ts             unit suite; mocks @netgrep/search
+    src/lib/grep.integration.spec.ts real WASM through grep, in headless Chromium
     dist/              BUILD OUTPUT, gitignored
     → published as @netgrep/netgrep
 
@@ -482,8 +500,8 @@ manifests cannot drift, and **deletes the `.gitignore` wasm-pack writes into `pk
 |---|---|
 | Matching semantics (regex flags, case sensitivity, binary handling) | `packages/search/src/lib.rs` |
 | What a result contains | `packages/search/src/lib.rs` **and** `packages/netgrep/src/lib/data/NetgrepResult.ts`. Read [decision 0020](docs/decisions/0020-the-matching-line.md) and [0022](docs/decisions/0022-capture-ranges.md) first — 0022's table is the current list of what has been refused |
-| Streaming, batching, abort behaviour | `packages/netgrep/src/lib/Netgrep.ts` |
-| A config option | `packages/netgrep/src/lib/data/NetgrepSearchConfig.ts` — per-call, and the only configuration there is |
+| Streaming, batching, abort behaviour | `Netgrep.search`'s recursive reader lives in `packages/netgrep/src/lib/Netgrep.ts`; `grep`'s loop and its shared plumbing (`streamBlocks.ts`, `decodeBlock.ts`) live in `packages/netgrep/src/lib/grep.ts` and beside it |
+| A config option | `packages/netgrep/src/lib/data/NetgrepSearchConfig.ts` for `Netgrep`, `packages/netgrep/src/lib/data/GrepOptions.ts` for `grep` — both per-call, and the only configuration either has |
 | Build or release steps | root `package.json` scripts, `packages/*/package.json` scripts, `.github/workflows/` |
 | Binary size / release profile | root `Cargo.toml` — **not** `packages/search/Cargo.toml` |
 
@@ -573,7 +591,7 @@ in `packages/search/tests/search.rs`. Read §2.1 before touching any of them.
 
 | | Where | Effect |
 |---|---|---|
-| Anchors and long matches inside a >64 KB line | `Netgrep.ts`, `MAX_TAIL_BYTES` | What remains of the chunk-boundary defect (**3g**). The retained tail is the incomplete trailing *line*, which is exact; past a 64 KB ceiling it degrades to a byte window. Inside such a line a match longer than 64 KB is lost, **and** `^` can match at the window's first byte. Needs a line over 64 KB — unreachable in prose. |
+| Anchors and long matches inside a >64 KB line | `Netgrep.ts`, `grep.ts`, `MAX_TAIL_BYTES` | What remains of the chunk-boundary defect (**3g**). The retained tail is the incomplete trailing *line*, which is exact; past a 64 KB ceiling it degrades to a byte window. Inside such a line a match longer than 64 KB is lost, **and** `^` can match at the window's first byte; in `grep`, a hit inside such a line is also yielded more than once, and the running line number drifts by one per window slide. Needs a line over 64 KB — unreachable in prose. |
 | `^`/`$` also anchor to a bare `\r` | `lib.rs`, `crlf(true)` | The CRLF-aware anchors that fixed item 17 treat a lone `\r` as a line boundary too, not only a `\r\n` pair, so `foo$` and `^bar` both match `"foo\rbar\n"` on either side of the bare `\r`. The line splitter disagrees: it still only ever breaks on `\n`, so `capture` can return a line that describes a different boundary than the anchor just matched against. |
 
 The last was found during code review on 2026-08-05, riding along with item 17's fix, and is backlog item 25.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -142,8 +142,9 @@ terminator-stripped, joined by `\n` in hit order — unambiguous by construction
 `\n` — and `table` is `[hitCount, linesInBlock]` followed by one record per hit, `[lineNumber, nRanges, start,
 end, …]`. `nRanges` counts **pairs**, so a hit's record is `2 + nRanges * 2` words long.
 
-**Nothing in TypeScript calls `search_block` yet.** The streaming loop that will — reading blocks, tracking a
-running file-absolute line base, and turning each `BlockHits` back into per-match results — is a later PR.
+**`grep` in `packages/netgrep` is the only caller.** It advances a running file-absolute line base by
+each block's `linesInBlock` rather than counting terminators itself — that count would mean walking
+every byte of the file again, in the slowest language on the path.
 
 Per call it:
 
@@ -182,7 +183,7 @@ third is `regex-automata`'s DFA and Unicode tables.
 
 ## The TypeScript wrapper — `packages/netgrep`
 
-`src/lib/Netgrep.ts` is the entire public surface. `src/lib/data/` holds six types, one per file.
+The public surface is `Netgrep` and `grep`. `src/lib/data/` holds eight types, one per file.
 
 `src/lib/splitAtLastLine.ts` sits beside it and is **not** re-exported by `index.ts` — `index.ts` is
 `export * from './lib/Netgrep.js'`, so anything exported from that file would become public API. It is a
@@ -196,6 +197,7 @@ tiny cap, instead of only through a >64 KB fixture in a browser.
 | `search(url, pattern, metadata?, config?)` | `Promise<NetgrepResult<T>>` | One URL. |
 | `searchBatch(inputs, pattern, config?)` | `Promise<BatchNetgrepResult<T>[]>` | `Promise.all` — resolves only when **all** searches settle. Per-item errors are captured into `error`, never rejected. |
 | `searchBatchWithCallback(inputs, pattern, cb, config?)` | `void` | Fires `cb` per completed search. **No completion signal** — the caller cannot know when the batch is done. |
+| `grep(url, pattern, options?)` | `AsyncIterable<NetgrepHit>` | Every matching line, as it is found, with a file-absolute line number. |
 
 The constructor takes no arguments — the library retains nothing between searches, so there is nothing to
 configure ([0024](decisions/0024-remove-the-in-memory-cache.md)).
@@ -205,6 +207,10 @@ boolean ([0020](decisions/0020-the-matching-line.md), [0022](decisions/0022-capt
 
 `metadata` is an opaque generic `T` carried through untouched and returned on the result — the mechanism by
 which a caller correlates results back to domain objects (a blog post, a document record).
+
+`Netgrep` and `grep` coexist — neither replaces the other. `grep` takes `GrepOptions { maxLineBytes,
+onProgress }` and carries no `signal`: leaving the `for await` loop cancels the transfer, so there is
+nothing an `AbortSignal` would do that breaking out of the loop does not already do.
 
 ### The search loop
 
@@ -250,6 +256,42 @@ Errors are normalised to strings by `serializeError` — `Error.message`, or `JS
 non-`Error` throws. The recursive `handleReader` call carries a `.catch(reject)`: the promise it returns is not
 chained to the one the executor was handed, so without it a rejection from any chunk after the first would be
 an unhandled rejection and the search would never settle.
+
+### The streaming loop
+
+```
+grep(url, pattern)
+  │
+  ├─ await wasmReady            ← init() started once at module load
+  ├─ search_bytes([], pattern)  ← compiles the pattern before the connection
+  │
+  └─ for await (block of streamBlocks(url))
+       ├─ fetch(url) → res.body.getReader()
+       ├─ read() → { value, done }
+       ├─ splitAtLastLine(tail ++ value, 64 KB) → whole lines, tail held back
+       ├─ done → yield the held-back tail, if it has not gone out already
+       │
+       └─ search_block(block, pattern, maxLineBytes)
+            ├─ { text, table } ── two crossings per block, whatever the hit count
+            ├─ free the carrier
+            ├─ decodeBlock walks it with a cursor → yield one hit at a time
+            └─ linesBefore += table[1]
+  │
+  └─ finally → reader.cancel()   ← break, throw and return all land here
+```
+
+Three things about that shape are load-bearing, matching the search loop's own:
+
+- **The running line base comes from the engine, not from counting `\n` in JavaScript.** `search_block`
+  already counts terminators to answer with a line number per hit; walking the block again in TypeScript
+  to arrive at the same number would double the cost for no more correctness.
+- **The walk is lazy.** `decodeBlock` is a generator over `table`, so a block with half a million hits does
+  not materialise half a million `NetgrepHit` objects before the caller sees the first one — the same
+  allocation pressure `BlockHits` crossing the WASM boundary as two flat values, rather than one per hit,
+  is built to avoid.
+- **The generator suspends at `yield`.** A consumer that is slow to resume `grep`'s `for await` leaves the
+  loop parked there, which leaves `streamBlocks`' `read()` uncalled — backpressure on the socket with no
+  pause logic anywhere in this code.
 
 ---
 
@@ -304,6 +346,15 @@ a seam.
 > are unreachable in hand-written text, and in the demo's log files too: 408.6 MB of real log lines whose
 > longest, across all four sources, is 387 bytes. Size is not what reaches this — line length is.
 > Pinned by the three `BACKLOG 3g` tests in `Netgrep.integration.spec.ts`, each alongside its control case.
+>
+> **`grep` inherits the same window and adds two consequences of its own**, pinned as `documented defects`
+> in `grep.integration.spec.ts` rather than fixed. A hit inside such a line is **yielded more than once** —
+> the windowed tail is searched as the whole of one block and again as the head of the next, and each pass
+> reports it. And the running line base **gains a line at every window slide**, drifting every line number
+> reported after the over-long line, not only its own. Both are deliberate: suppressing the repeat would
+> mean not yielding it at all if the stream happened to end inside the window, and a lost hit is worse for
+> a grep than a repeated one; and the windowed tail, once it has been searched, is never re-searched at
+> EOF, so there is no later pass that could correct the count.
 
 Newline-free input is answered more slowly than before, since nothing is searched until the ceiling fills or
 the stream ends. Correct either way — the end-of-stream flush catches a file smaller than the ceiling.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -185,8 +185,9 @@ third is `regex-automata`'s DFA and Unicode tables.
 
 The public surface is `Netgrep` and `grep`. `src/lib/data/` holds eight types, one per file.
 
-`src/lib/splitAtLastLine.ts` sits beside it and is **not** re-exported by `index.ts` — `index.ts` is
-`export * from './lib/Netgrep.js'`, so anything exported from that file would become public API. It is a
+`src/lib/splitAtLastLine.ts` sits beside it and is **not** re-exported by `index.ts` — `index.ts` star-exports
+`./lib/grep.js` and `./lib/Netgrep.js` and nothing else, so anything exported from either file would become
+public API, and the two entry points share enough plumbing for that to matter more than it used to. It is a
 separate module rather than a private function so that its edge cases can be unit-tested directly, with a
 tiny cap, instead of only through a >64 KB fixture in a browser.
 
@@ -209,8 +210,11 @@ boolean ([0020](decisions/0020-the-matching-line.md), [0022](decisions/0022-capt
 which a caller correlates results back to domain objects (a blog post, a document record).
 
 `Netgrep` and `grep` coexist — neither replaces the other. `grep` takes `GrepOptions { maxLineBytes,
-onProgress }` and carries no `signal`: leaving the `for await` loop cancels the transfer, so there is
-nothing an `AbortSignal` would do that breaking out of the loop does not already do.
+onProgress }` and carries no `signal`. Breaking out of the `for await` loop cancels the transfer, which
+covers cancelling **from a hit** — but `grep` yields only on a hit, so over a stretch of file that matches
+nothing the loop body never runs and there is no `break` to take. A stream that yields nothing therefore
+runs to completion and cannot be stopped: [backlog item 29](BACKLOG.md), which per-call `fetch` options
+([item 22](BACKLOG.md)) close, and those are not plumbed through yet.
 
 ### The search loop
 
@@ -266,18 +270,20 @@ grep(url, pattern)
   ├─ search_bytes([], pattern)  ← compiles the pattern before the connection
   │
   └─ for await (block of streamBlocks(url))
-       ├─ fetch(url) → res.body.getReader()
-       ├─ read() → { value, done }
-       ├─ splitAtLastLine(tail ++ value, 64 KB) → whole lines, tail held back
-       ├─ done → yield the held-back tail, if it has not gone out already
+       │
+       ├─ streamBlocks: fetch(url) → res.body.getReader()
+       │    ├─ read() → { value, done }
+       │    ├─ done → yield the held-back tail, if it has not gone out already
+       │    ├─ splitAtLastLine(tail ++ value, 64 KB) → whole lines, tail held back
+       │    └─ finally → reader.cancel()   ← break, throw and return all land
+       │                                     here — but a break only exists to
+       │                                     take once a hit has been yielded
        │
        └─ search_block(block, pattern, maxLineBytes)
             ├─ { text, table } ── two crossings per block, whatever the hit count
             ├─ free the carrier
             ├─ decodeBlock walks it with a cursor → yield one hit at a time
             └─ linesBefore += table[1]
-  │
-  └─ finally → reader.cancel()   ← break, throw and return all land here
 ```
 
 Three things about that shape are load-bearing, matching the search loop's own:
@@ -298,8 +304,8 @@ Three things about that shape are load-bearing, matching the search loop's own:
 ## Known limitations & correctness caveats
 
 All verified against the source in this repository, and every one still open is **pinned by a test** — in
-`Netgrep.integration.spec.ts`, and for the ones that live in the engine also in the `documented_defects` module
-of `packages/search/tests/search.rs`. Those tests assert the current, wrong behaviour; the ones marked
+`Netgrep.integration.spec.ts` and, for what item 3g does to `grep`, in `grep.integration.spec.ts`; for the ones
+that live in the engine also in the `documented_defects` module of `packages/search/tests/search.rs`. Those tests assert the current, wrong behaviour; the ones marked
 `(FIXED)` there were inverted in place when the defect was closed. Two left the block on 2026-08-01 rather
 than being inverted in it, because the code they described was deleted rather than corrected — the rule is in
 [`../AGENTS.md` §2.1](../AGENTS.md#21-some-tests-assert-behaviour-that-is-wrong-on-purpose), which is worth

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -96,6 +96,19 @@ not regress — a match arriving complete in **one** chunk is found, because the
 the window is taken; `^` does not match when the window is never flushed on its own; and a line captured from a
 single chunk starts where the line starts.
 
+**`grep` hits the same window and adds two more consequences**, confirmed against the real engine. A hit
+inside an over-long line is **yielded more than once** — the windowed tail is searched as the whole of one
+block and again as the head of the next, so each pass reports the hit again. And the running file-absolute
+line base **gains a line at every window slide**: on the tested fixture the true line number was 2 and `grep`
+reported 3, and the drift carries forward into every line number after the over-long line, not only its own.
+Both are pinned rather than fixed, and deliberately: suppressing the repeat would drop the hit outright if the
+stream ended inside the window, and a lost hit is worse for a grep than a repeated one; the windowed tail,
+once searched, is never re-searched at EOF, so there is no later pass that could correct the count. Pinned by
+`BACKLOG 3g: a hit inside an over-long line is yielded three times` and
+`BACKLOG 3g: the line number drifts after an over-long line` in `grep.integration.spec.ts`. Not yet in
+[`guide/caveats.data.json`](guide/caveats.data.json) below — the published list still describes only
+`Netgrep`, deliberately, until `grep`'s own consumer documentation lands.
+
 **Published anyway**, in [`guide/caveats.data.json`](guide/caveats.data.json) and so in the guide and the
 README, alongside item 25 below. The demo used to filter its own list down to what its own files could reach;
 it no longer carries one, and a reader running netgrep over minified JavaScript reaches this whether or not
@@ -287,6 +300,18 @@ browser on 2026-08-02. **But the demo has stopped being evidence against it.** I
 the matcher between paints over roughly 1.8 seconds, where the old 2.6 MB of stories was matched faster than a
 frame — so this is a thing a visitor could plausibly notice rather than a note kept against rediscovery.
 Still not planned: a worker is a widening and needs its own issue and record.
+
+### 28. An expression-bodied `beforeEach` silently registers a teardown — `packages/netgrep/src/lib/*.spec.ts`
+
+`beforeEach(() => mockFetch.mockReset())` returns the mock, and Vitest treats a function returned from a hook
+as that hook's own teardown — so it *calls* the mock after every test, not just resets it before one. Invisible
+until the mock's implementation has a side effect: in `grep.integration.spec.ts` the teardown invoked an
+implementation that returned a rejected promise, producing an unhandled rejection that failed an unrelated test
+with a bare `Error: offline`. Fixed there with a block body.
+
+`Netgrep.spec.ts:745` still has the shape — `beforeEach(() => mockSearchLine.mockReturnValue('x'));` — and is
+harmless today only because calling that mock has no side effect. The rule: hook bodies in this repository use
+braces.
 
 ---
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -41,8 +41,10 @@ Verified against the repository on **2026-07-30** (macOS arm64, Node 24.18.0, Ru
 Full analysis in [`ARCHITECTURE.md`](ARCHITECTURE.md#known-limitations--correctness-caveats).
 
 Every item below is **pinned by a test that asserts the current, wrong behaviour** — in
-`Netgrep.integration.spec.ts`, and for the ones that live in the engine also in the `documented_defects`
-module of `packages/search/tests/search.rs`. Read
+`Netgrep.integration.spec.ts` and, for what 3g does to `grep`, in `grep.integration.spec.ts`; for the ones
+that live in the engine also in the `documented_defects` module of `packages/search/tests/search.rs`. Item
+**29** is the exception and has no test: a transfer that cannot be stopped produces no wrong answer to pin.
+Read
 [`../AGENTS.md` §2.1](../AGENTS.md#21-some-tests-assert-behaviour-that-is-wrong-on-purpose)
 and [decision 0011](decisions/0011-tests-that-assert-known-bugs.md) before touching any of them: **fixing one
 means inverting its assertion in the same PR.**
@@ -53,8 +55,9 @@ means inverting its assertion in the same PR.**
 > every one of them lives once in [`guide/caveats.data.json`](guide/caveats.data.json). Delete the entry and
 > run `pnpm docs:sync`, or the site goes on warning the world about a bug you just fixed.
 >
-> **The two lists are not mirrors of each other.** Every P1 item still open here has an entry there today,
-> but that file also carries two `by-design` entries that nothing *open* here corresponds to: *no ranking*,
+> **The two lists are not mirrors of each other.** Every P1 item still open here has an entry there today
+> except **29**, which is `grep`-only and waits on `grep`'s own consumer documentation like the `grep` half of
+> 3g; and that file also carries two `by-design` entries that nothing *open* here corresponds to: *no ranking*,
 > which has never been a backlog item at all, and *concurrent downloads of one url*, which is item **18** —
 > in *Done*, and staying there. An entry earns its place there by affecting a visitor, which is a judgement
 > call rather than a lookup. `pnpm docs:sync --check` keeps the two rendered surfaces honest
@@ -99,8 +102,9 @@ single chunk starts where the line starts.
 **`grep` hits the same window and adds two more consequences**, confirmed against the real engine. A hit
 inside an over-long line is **yielded more than once** — the windowed tail is searched as the whole of one
 block and again as the head of the next, so each pass reports the hit again. And the running file-absolute
-line base **gains a line at every window slide**: on the tested fixture the true line number was 2 and `grep`
-reported 3, and the drift carries forward into every line number after the over-long line, not only its own.
+line base **gains a line at every window slide**: on the tested fixture the two lines following the over-long
+one are truly 2 and 3, and `grep` reports 3 and 4 — the drift carries forward into every line number after it
+rather than being spent on the first of them, which is why the fixture has two lines and not one.
 Both are pinned rather than fixed, and deliberately: suppressing the repeat would drop the hit outright if the
 stream ended inside the window, and a lost hit is worse for a grep than a repeated one; the windowed tail,
 once searched, is never re-searched at EOF, so there is no later pass that could correct the count. Pinned by
@@ -147,6 +151,26 @@ well-defined either. Not obviously worth fixing. Pinned in the `documented_defec
 [`guide/caveats.data.json`](guide/caveats.data.json) as `bare-cr-anchors`.
 
 Found on 2026-08-05 during review of item 17's fix.
+
+### 29. `grep` cannot be cancelled while it is finding nothing — `packages/netgrep/src/lib/grep.ts`
+
+`grep` yields only on a hit, so across a stretch of file that matches nothing the consumer's loop body never
+runs — and a `break` only exists to take once a hit has been yielded. Calling `.return()` on the iterator does
+not help either: an async generator suspended inside an `await` queues the return request and honours it only
+when the body next reaches a `yield`, which for a hitless stream is never. A file with no match therefore
+downloads in full, and nothing the caller can write stops it.
+
+Not a workaround away, which is why this is P1 rather than a nicety: the caller does not own the request.
+The workload that reaches it is the demo's own — a debounced search box over 408.6 MB, issuing a fresh
+`grep` every 300 ms of typing, each abandoned one still reading to the end of its file.
+
+`GrepOptions` deliberately carries no `signal`: a top-level one would need a documented precedence rule
+against the `signal` inside per-call `fetch` options, and those are **item 22** above, unsettled and deferred.
+Item 22 is what closes this — an `AbortSignal` reaching `fetch` cancels a transfer no `break` can reach.
+Not in [`guide/caveats.data.json`](guide/caveats.data.json), like the `grep` half of 3g: the published list
+describes `Netgrep` only, until `grep`'s own consumer documentation lands.
+
+Found on 2026-08-06 during review of the `grep` branch.
 
 ---
 
@@ -309,9 +333,15 @@ until the mock's implementation has a side effect: in `grep.integration.spec.ts`
 implementation that returned a rejected promise, producing an unhandled rejection that failed an unrelated test
 with a bare `Error: offline`. Fixed there with a block body.
 
-`Netgrep.spec.ts:745` still has the shape — `beforeEach(() => mockSearchLine.mockReturnValue('x'));` — and is
+**This entry shipped with an inventory that was already false.** It named `Netgrep.spec.ts:745` as the one
+remaining instance, while `streamBlocks.spec.ts:88` carried the exact `mockFetch.mockReset()` shape — in a file
+added two commits before the entry was written, and harmless there only because that suite never leaves a
+rejecting implementation in place for the teardown to invoke. Fixed with a block body on 2026-08-06.
+
+`Netgrep.spec.ts:745` — `beforeEach(() => mockSearchLine.mockReturnValue('x'));` — is now the last, and is
 harmless today only because calling that mock has no side effect. The rule: hook bodies in this repository use
-braces.
+braces. A count of instances in an entry like this one goes stale the moment a spec file is added, so the rule
+is the durable half and the list is not.
 
 ---
 

--- a/packages/netgrep/src/index.ts
+++ b/packages/netgrep/src/index.ts
@@ -1,7 +1,10 @@
 export type * from './lib/data/BatchNetgrepResult.js';
+export type * from './lib/data/GrepOptions.js';
 export type * from './lib/data/NetgrepCapture.js';
+export type * from './lib/data/NetgrepHit.js';
 export type * from './lib/data/NetgrepInput.js';
 export type * from './lib/data/NetgrepMatchRange.js';
 export type * from './lib/data/NetgrepResult.js';
 export type * from './lib/data/NetgrepSearchConfig.js';
+export * from './lib/grep.js';
 export * from './lib/Netgrep.js';

--- a/packages/netgrep/src/lib/Netgrep.ts
+++ b/packages/netgrep/src/lib/Netgrep.ts
@@ -1,33 +1,18 @@
-import init, {
+import {
   search_bytes,
   search_bytes_line,
   search_bytes_line_ranges,
 } from '@netgrep/search';
+import { concatBytes } from './concatBytes.js';
 import type { BatchNetgrepResult } from './data/BatchNetgrepResult.js';
 import type { NetgrepCapture } from './data/NetgrepCapture.js';
 import type { NetgrepInput } from './data/NetgrepInput.js';
 import type { NetgrepMatchRange } from './data/NetgrepMatchRange.js';
 import type { NetgrepResult } from './data/NetgrepResult.js';
 import type { NetgrepSearchConfig } from './data/NetgrepSearchConfig.js';
-import { splitAtLastLine } from './splitAtLastLine.js';
-
-/**
- * Ceiling on the bytes retained between two `fetch` chunks.
- *
- * Only terminator-free input reaches it — the tail is normally the incomplete
- * trailing line, 387 bytes at worst in the demo's log files. Past it the
- * guarantee weakens to "a boundary never hides a match shorter than 64 KB".
- *
- * A safety valve for input netgrep is not aimed at, so not configurable.
- */
-const MAX_TAIL_BYTES = 64 * 1024;
-
-/**
- * Ceiling on the returned line when `capture` is set and the caller names no
- * other. Far past any line of prose, and small enough that a minified bundle
- * costs a snippet rather than a copy of itself.
- */
-const DEFAULT_MAX_LINE_BYTES = 4096;
+import { resolveMaxLineBytes } from './resolveMaxLineBytes.js';
+import { MAX_TAIL_BYTES, splitAtLastLine } from './splitAtLastLine.js';
+import { wasmReady } from './wasmReady.js';
 
 /**
  * What one call into the engine produced.
@@ -94,37 +79,6 @@ function runEngine(
 }
 
 /**
- * The largest cap a Rust `usize` receives intact on wasm32.
- */
-const MAX_LINE_BYTES_CEILING = 0xffffffff;
-
-/**
- * Clamp a caller-supplied `maxLineBytes` into something the engine can hold.
- *
- * Clamped rather than validated: throwing would be a new failure mode for a
- * cosmetic setting, and wasm-bindgen checks nothing.
- *
- * ⚠️ THE UPPER BOUND MATTERS AS MUCH AS THE LOWER ONE. The number crosses the
- * boundary through ToUint32, which WRAPS rather than saturates, so `Infinity`,
- * `NaN` and 2³² all arrive as **0** — and a cap of 0 returns an empty string
- * for every match, which is exactly how a match on an empty line is reported.
- * Unbounded, the obvious way to ask for no cap silently produced the one result
- * this API cannot afford to be ambiguous about.
- */
-function resolveMaxLineBytes(requested: number | undefined): number {
-  // Not a request for anything.
-  if (requested === undefined || Number.isNaN(requested)) {
-    return DEFAULT_MAX_LINE_BYTES;
-  }
-
-  // `Infinity` is how a caller spells "no cap", so it becomes the largest cap
-  // rather than falling back to the default and quietly ignoring them.
-  if (requested >= MAX_LINE_BYTES_CEILING) return MAX_LINE_BYTES_CEILING;
-
-  return Math.max(1, Math.floor(requested));
-}
-
-/**
  * Assemble a resolved result.
  *
  * The `line` and `ranges` keys are OMITTED, not set to `null`, when nothing
@@ -179,35 +133,6 @@ function withError<T extends object, C extends NetgrepCapture>(
 ): BatchNetgrepResult<T, C> {
   return { ...result, error } as BatchNetgrepResult<T, C>;
 }
-
-/**
- * Join a list of byte chunks into one buffer.
- */
-function concatBytes(chunks: Array<Uint8Array>): Uint8Array {
-  const total = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
-  const joined = new Uint8Array(total);
-
-  let offset = 0;
-
-  for (const chunk of chunks) {
-    joined.set(chunk, offset);
-    offset += chunk.length;
-  }
-
-  return joined;
-}
-
-/**
- * The WASM module has to be instantiated before `search_bytes` can be called.
- *
- * Started once at module load and shared by every `Netgrep` instance: the
- * download begins as soon as the library is imported rather than on the first
- * search, and awaiting an already-settled promise costs nothing.
- *
- * Kept module-private on purpose — callers should not have to know the engine
- * needs booting.
- */
-const wasmReady = init();
 
 /**
  * The `netgrep` library allows to search remote files

--- a/packages/netgrep/src/lib/concatBytes.ts
+++ b/packages/netgrep/src/lib/concatBytes.ts
@@ -1,0 +1,16 @@
+/**
+ * Join a list of byte chunks into one buffer.
+ */
+export function concatBytes(chunks: Array<Uint8Array>): Uint8Array {
+  const total = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const joined = new Uint8Array(total);
+
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    joined.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  return joined;
+}

--- a/packages/netgrep/src/lib/data/GrepOptions.ts
+++ b/packages/netgrep/src/lib/data/GrepOptions.ts
@@ -1,0 +1,27 @@
+/**
+ * The optional configuration for a `grep` call.
+ */
+export type GrepOptions = {
+  /**
+   * Ceiling on the bytes of each yielded line. Defaults to 4096.
+   *
+   * Truncation happens inside WebAssembly, before the copy, so a minified
+   * bundle or a one-line data dump cannot move megabytes per file into
+   * JavaScript. The cut is taken on a UTF-8 character boundary, and applies to
+   * the line's content — the terminator is stripped first.
+   *
+   * Values below 1, and fractions, are clamped rather than rejected: the
+   * number becomes a Rust `usize`, and wasm-bindgen does not validate it.
+   */
+  maxLineBytes?: number;
+
+  /**
+   * Called after each network chunk with the cumulative bytes read.
+   *
+   * These are DECOMPRESSED bytes delivered to the page, not bytes on the wire:
+   * a gzipped response moves far fewer. No total is offered to compare them
+   * against, because `Content-Length` on a compressed response is the
+   * compressed size and would drive a bar that finishes at a few per cent.
+   */
+  onProgress?: (bytesRead: number) => void;
+};

--- a/packages/netgrep/src/lib/data/NetgrepHit.ts
+++ b/packages/netgrep/src/lib/data/NetgrepHit.ts
@@ -11,8 +11,9 @@ export type NetgrepHit = {
   line: string;
 
   /**
-   * Every match's position within `line`, in order. Never null and never
-   * absent — a streamed hit with no match in it would not be a hit.
+   * Every match's position within `line`, in order. Always present, never
+   * null — but empty when every match sits past the `maxLineBytes` cut, since
+   * `line` cannot show a range it does not hold.
    */
   ranges: Array<NetgrepMatchRange>;
 

--- a/packages/netgrep/src/lib/data/NetgrepHit.ts
+++ b/packages/netgrep/src/lib/data/NetgrepHit.ts
@@ -1,0 +1,27 @@
+import type { NetgrepMatchRange } from './NetgrepMatchRange.js';
+
+/**
+ * One matching line, as `grep` yields it.
+ */
+export type NetgrepHit = {
+  /**
+   * The matching line with its terminator stripped, truncated to
+   * `maxLineBytes` and lossily decoded.
+   */
+  line: string;
+
+  /**
+   * Every match's position within `line`, in order. Never null and never
+   * absent — a streamed hit with no match in it would not be a hit.
+   */
+  ranges: Array<NetgrepMatchRange>;
+
+  /**
+   * The line's 1-based position in the FILE, not in the network chunk it
+   * arrived in.
+   *
+   * Exact until a single line outgrows the 64 KB retained-tail ceiling, past
+   * which the count gains a line each time the window slides.
+   */
+  lineNumber: number;
+};

--- a/packages/netgrep/src/lib/decodeBlock.spec.ts
+++ b/packages/netgrep/src/lib/decodeBlock.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { decodeBlock, linesInBlock } from './decodeBlock.js';
+
+/** Build a table from its parts, so a test reads as the layout it asserts. */
+function table(
+  lines: number,
+  ...hits: Array<[lineNumber: number, ...ranges: Array<number>]>
+): Uint32Array {
+  const words: Array<number> = [hits.length, lines];
+
+  for (const [lineNumber, ...ranges] of hits) {
+    words.push(lineNumber, ranges.length / 2, ...ranges);
+  }
+
+  return new Uint32Array(words);
+}
+
+describe('decodeBlock', () => {
+  it('yields nothing for a block with no hits', () => {
+    expect([...decodeBlock('', table(12), 0)]).toEqual([]);
+  });
+
+  it('yields one hit with its line and ranges', () => {
+    const hits = [...decodeBlock('alpha beta', table(3, [2, 0, 5]), 0)];
+
+    expect(hits).toEqual([
+      { line: 'alpha beta', ranges: [{ start: 0, end: 5 }], lineNumber: 2 },
+    ]);
+  });
+
+  it('splits the joined text back into one line per hit', () => {
+    const hits = [
+      ...decodeBlock(
+        'first\nsecond\nthird',
+        table(9, [1, 0, 5], [4, 0, 6], [7, 0, 5]),
+        0,
+      ),
+    ];
+
+    expect(hits.map((hit) => hit.line)).toEqual(['first', 'second', 'third']);
+    expect(hits.map((hit) => hit.lineNumber)).toEqual([1, 4, 7]);
+  });
+
+  it('unflattens several ranges within one line', () => {
+    const hits = [...decodeBlock('a b a', table(1, [1, 0, 1, 4, 5]), 0)];
+
+    expect(hits[0].ranges).toEqual([
+      { start: 0, end: 1 },
+      { start: 4, end: 5 },
+    ]);
+  });
+
+  it('makes the line number file-absolute by adding the running base', () => {
+    const hits = [...decodeBlock('x\ny', table(4, [2, 0, 1], [3, 0, 1]), 1000)];
+
+    expect(hits.map((hit) => hit.lineNumber)).toEqual([1002, 1003]);
+  });
+
+  it('treats an EMPTY matching line as a line, not as absent text', () => {
+    // A pattern matching an empty line yields an empty segment, and the
+    // separator that follows it still belongs to the next hit. Reading this
+    // wrong shifts every later line by one.
+    const hits = [...decodeBlock('\nnext', table(5, [2, 0, 0], [3, 0, 4]), 0)];
+
+    expect(hits.map((hit) => hit.line)).toEqual(['', 'next']);
+    expect(hits[0].ranges).toEqual([{ start: 0, end: 0 }]);
+  });
+
+  it('yields a hit with no ranges at all without consuming a range pair', () => {
+    // Guards the cursor arithmetic: a zero-pair record is 2 words, and
+    // over-advancing here would read the next hit's line number as a range.
+    const hits = [...decodeBlock('one\ntwo', table(2, [1], [2, 0, 3]), 0)];
+
+    expect(hits.map((hit) => hit.lineNumber)).toEqual([1, 2]);
+    expect(hits[0].ranges).toEqual([]);
+    expect(hits[1].ranges).toEqual([{ start: 0, end: 3 }]);
+  });
+
+  it('reads the line count out of the table', () => {
+    expect(linesInBlock(table(4096, [1, 0, 1]))).toBe(4096);
+  });
+});

--- a/packages/netgrep/src/lib/decodeBlock.ts
+++ b/packages/netgrep/src/lib/decodeBlock.ts
@@ -1,0 +1,69 @@
+import type { NetgrepHit } from './data/NetgrepHit.js';
+import type { NetgrepMatchRange } from './data/NetgrepMatchRange.js';
+
+/** Where the per-hit records start: past `hitCount` and `linesInBlock`. */
+const FIRST_RECORD = 2;
+
+/**
+ * How many lines the block contained, matching or not.
+ *
+ * The streaming loop advances its running file-absolute base by this, so it
+ * counts a final line with no terminator too.
+ */
+export function linesInBlock(table: Uint32Array): number {
+  return table[1];
+}
+
+/**
+ * Walk one block's flat `text` and `table` back into hits.
+ *
+ * A generator, and lazily so: the caller renders and discards one hit at a
+ * time, and a common token in a large log produces hundreds of thousands per
+ * block. `indexOf` rather than `text.split('\n')` is what keeps that true —
+ * splitting would allocate every line before the consumer read the first, which
+ * is the eager materialisation the flat encoding exists to avoid.
+ *
+ * @param text
+ * The matching lines, terminator-stripped, joined by `\n`. Unambiguous by
+ * construction: a match can never span a `\n`, so no line can contain one.
+ * @param table
+ * `[hitCount, linesInBlock]`, then per hit `[lineNumber, nRanges, start, end,
+ * …]`, where `nRanges` counts pairs.
+ * @param linesBefore
+ * How many lines of the file preceded this block. Block-relative line numbers
+ * are 1-based, so this is a count and not an index.
+ */
+export function* decodeBlock(
+  text: string,
+  table: Uint32Array,
+  linesBefore: number,
+): Generator<NetgrepHit> {
+  const hitCount = table[0];
+
+  let cursor = FIRST_RECORD;
+  let lineStart = 0;
+
+  for (let hit = 0; hit < hitCount; hit += 1) {
+    const lineNumber = table[cursor];
+    const rangeCount = table[cursor + 1];
+
+    cursor += 2;
+
+    // The last line has no separator after it, so a missing one is the end of
+    // the text rather than an error.
+    const separator = text.indexOf('\n', lineStart);
+    const lineEnd = separator === -1 ? text.length : separator;
+    const line = text.slice(lineStart, lineEnd);
+
+    lineStart = lineEnd + 1;
+
+    const ranges: Array<NetgrepMatchRange> = [];
+
+    for (let range = 0; range < rangeCount; range += 1) {
+      ranges.push({ start: table[cursor], end: table[cursor + 1] });
+      cursor += 2;
+    }
+
+    yield { line, ranges, lineNumber: linesBefore + lineNumber };
+  }
+}

--- a/packages/netgrep/src/lib/grep.integration.spec.ts
+++ b/packages/netgrep/src/lib/grep.integration.spec.ts
@@ -1,0 +1,496 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GrepOptions } from './data/GrepOptions.js';
+import type { NetgrepHit } from './data/NetgrepHit.js';
+import { grep } from './grep.js';
+
+/**
+ * Integration tests: the REAL WASM engine driven through the REAL streaming
+ * loop behind `grep`.
+ *
+ * The counterpart to `grep.spec.ts`, which mocks `@netgrep/search` and so
+ * executes no Rust at all — it can prove the generator's bookkeeping but not
+ * that a line number, a UTF-16 range or a truncated line is right. Only
+ * `fetch` is faked here, and only to remove the network: the bytes still
+ * travel through a real `ReadableStream`, are still chunked, and are still
+ * matched by the compiled `search_block`.
+ *
+ * It runs in a real headless Chromium, so `pkg/` is instantiated by its own
+ * fetch-based `init()` — the same module, binary and loader a consumer gets.
+ *
+ * These assertions describe what `grep` ACTUALLY DOES TODAY, which is not
+ * always what it should do. The `documented defects` block at the bottom pins
+ * known-wrong behaviour on purpose; read the comment there before "fixing" it.
+ *
+ * Build the engine with: pnpm build:wasm
+ */
+vi.mock('@netgrep/search', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@netgrep/search')>();
+
+  // Instantiate through the REAL, fetch-based `init()` — the point of running
+  // in a browser. It happens at mock-factory time, which is before this file's
+  // body replaces `globalThis.fetch` with a spy; any later and the engine's own
+  // `.wasm` request would go into the spy.
+  await mod.default();
+
+  // Already instantiated, so the library's own `init()` must be a no-op rather
+  // than a second instantiation.
+  return { ...mod, default: () => Promise.resolve() };
+});
+
+const encoder = new TextEncoder();
+
+/**
+ * Wrap a stream in a response body that counts the consumer's reads and
+ * cancels.
+ *
+ * Counted here rather than on the stream's own `cancel` callback: once a
+ * stream is closed the Streams spec makes `cancel()` a no-op that never
+ * reaches the source, so a source-side counter cannot distinguish a call that
+ * happened from one that did not.
+ */
+function countingBody(
+  stream: ReadableStream<Uint8Array>,
+  state: { reads: number; cancelCalls: number },
+) {
+  return {
+    getReader() {
+      const reader = stream.getReader();
+
+      return {
+        read() {
+          state.reads += 1;
+          return reader.read();
+        },
+        cancel() {
+          state.cancelCalls += 1;
+          return reader.cancel();
+        },
+      };
+    },
+  };
+}
+
+const mockFetch = vi.fn();
+globalThis.fetch = mockFetch;
+
+/** Split a string into fixed-size byte chunks — deterministically. */
+function chunked(str: string, size: number): Array<Uint8Array> {
+  const bytes = encoder.encode(str);
+  const out: Array<Uint8Array> = [];
+
+  for (let i = 0; i < bytes.length; i += size) {
+    out.push(bytes.slice(i, i + size));
+  }
+
+  return out;
+}
+
+/**
+ * The underlying source, so a cancel that actually reaches it is observable
+ * separately from one the consumer merely called.
+ */
+function streamSource(
+  chunks: Array<Uint8Array>,
+  state: { sourceCancels: number },
+) {
+  let index = 0;
+
+  return {
+    pull(controller: ReadableStreamDefaultController<Uint8Array>) {
+      if (index >= chunks.length) {
+        controller.close();
+        return;
+      }
+
+      controller.enqueue(chunks[index]);
+      index += 1;
+    },
+    cancel() {
+      state.sourceCancels += 1;
+    },
+  };
+}
+
+function serve(chunks: Array<Uint8Array>) {
+  const state = { reads: 0, cancelCalls: 0, sourceCancels: 0 };
+
+  // A fresh stream per call — a `ReadableStream` can only be consumed once,
+  // and reusing one throws "ReadableStream is locked". The counters are shared.
+  mockFetch.mockImplementation(() =>
+    Promise.resolve({
+      body: countingBody(
+        new ReadableStream(streamSource(chunks, state)),
+        state,
+      ),
+    }),
+  );
+
+  return state;
+}
+
+async function collect(url: string, pattern: string, options?: GrepOptions) {
+  const out: Array<NetgrepHit> = [];
+
+  for await (const hit of grep(url, pattern, options)) {
+    out.push(hit);
+  }
+
+  return out;
+}
+
+const POEM =
+  'One Wiseman came to Jhaampe-town.\n' +
+  'He set aside both Queen and Crown\n' +
+  'Did his task and fell asleep\n' +
+  'Gave his bones to the stones to keep.\n';
+
+describe('grep integration (real WASM)', () => {
+  // A block body, not a concise one: `mockReset` returns the mock, which is a
+  // function, and a hook that returns a function has returned a teardown —
+  // Vitest would call `mockFetch()` after every test.
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  describe('chunk-size invariance', () => {
+    // The property that makes the design defensible: netgrep's answer is a
+    // function of the file, not of where the network happened to split it.
+    // One test covers the tail split, the running line base and the encoding
+    // walk at once, because every bug this design can introduce is a bug that
+    // makes output depend on chunking.
+    const sizes = [1, 7, 64, 1024, 65536];
+
+    it('yields identical hits at every chunk size', async () => {
+      const runs = [];
+
+      for (const size of sizes) {
+        serve(chunked(POEM, size));
+        runs.push(await collect('/f', 'his'));
+      }
+
+      for (const run of runs) {
+        expect(run).toEqual(runs[0]);
+      }
+
+      // A guard against the whole suite passing on an empty result.
+      expect(runs[0].length).toBeGreaterThan(0);
+    });
+
+    it('is invariant for a pattern matching every line, too', async () => {
+      const runs = [];
+
+      for (const size of sizes) {
+        serve(chunked(POEM, size));
+        runs.push(await collect('/f', 'e'));
+      }
+
+      for (const run of runs) {
+        expect(run).toEqual(runs[0]);
+      }
+
+      expect(runs[0]).toHaveLength(4);
+    });
+
+    it('is invariant for a file that does not end in a newline', async () => {
+      const unterminated = 'alpha\nbeta\ngamma';
+      const runs = [];
+
+      for (const size of sizes) {
+        serve(chunked(unterminated, size));
+        runs.push(await collect('/f', 'a'));
+      }
+
+      for (const run of runs) {
+        expect(run).toEqual(runs[0]);
+      }
+
+      expect(runs[0].map((hit) => hit.lineNumber)).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe('line numbers', () => {
+    it('numbers lines from 1, against the file', async () => {
+      serve(chunked(POEM, 4096));
+
+      const hits = await collect('/f', 'his');
+
+      expect(hits.map((hit) => hit.lineNumber)).toEqual([3, 4]);
+    });
+
+    it('keeps numbering across a chunk boundary', async () => {
+      serve(chunked(POEM, 20));
+
+      const hits = await collect('/f', 'his');
+
+      expect(hits.map((hit) => hit.lineNumber)).toEqual([3, 4]);
+    });
+
+    it('numbers a final line that nothing terminates', async () => {
+      serve([encoder.encode('one\ntwo\nthree')]);
+
+      const hits = await collect('/f', 'three');
+
+      expect(hits.map((hit) => hit.lineNumber)).toEqual([3]);
+    });
+
+    it('counts non-matching lines too', async () => {
+      serve([encoder.encode('a\nb\nc\nd\nTARGET\n')]);
+
+      const hits = await collect('/f', 'TARGET');
+
+      expect(hits[0].lineNumber).toBe(5);
+    });
+  });
+
+  describe('lines and ranges', () => {
+    it('yields the whole line, not the matched fragment', async () => {
+      serve(chunked(POEM, 4096));
+
+      const hits = await collect('/f', 'Wiseman');
+
+      expect(hits[0].line).toBe('One Wiseman came to Jhaampe-town.');
+    });
+
+    it('yields ranges that slice the line back to the match', async () => {
+      serve(chunked(POEM, 4096));
+
+      const hits = await collect('/f', 'Wiseman');
+      const { line, ranges } = hits[0];
+
+      expect(ranges).toHaveLength(1);
+      expect(line.slice(ranges[0].start, ranges[0].end)).toBe('Wiseman');
+    });
+
+    it('yields every match within one line', async () => {
+      serve([encoder.encode('to the to the to\n')]);
+
+      const hits = await collect('/f', 'to');
+
+      expect(hits).toHaveLength(1);
+      expect(hits[0].ranges).toHaveLength(3);
+      expect(
+        hits[0].ranges.map((range) =>
+          hits[0].line.slice(range.start, range.end),
+        ),
+      ).toEqual(['to', 'to', 'to']);
+    });
+
+    it('treats an EMPTY matching line as a hit, not as a miss', async () => {
+      // A pattern matching an empty line yields an empty string, which is
+      // falsy — the trap the old boolean-plus-line API documented at length.
+      serve([encoder.encode('a\n\nb\n')]);
+
+      const hits = await collect('/f', '^$');
+
+      expect(hits).toHaveLength(1);
+      expect(hits[0].line).toBe('');
+      expect(hits[0].lineNumber).toBe(2);
+    });
+
+    it('carries a multi-byte character across a chunk boundary intact', async () => {
+      serve(chunked('før\nnaïve café\n', 3));
+
+      const hits = await collect('/f', 'café');
+
+      expect(hits[0].line).toBe('naïve café');
+    });
+
+    it('gives UTF-16 offsets, not byte offsets', async () => {
+      serve([encoder.encode('naïve café\n')]);
+
+      const hits = await collect('/f', 'café');
+      const { line, ranges } = hits[0];
+
+      expect(line.slice(ranges[0].start, ranges[0].end)).toBe('café');
+    });
+
+    it('applies smart case: a lowercase pattern is case-insensitive', async () => {
+      serve([encoder.encode('Wiseman\nwiseman\n')]);
+
+      expect(await collect('/f', 'wiseman')).toHaveLength(2);
+    });
+
+    it('applies smart case: an uppercased pattern is case-sensitive', async () => {
+      serve([encoder.encode('Wiseman\nwiseman\n')]);
+
+      const hits = await collect('/f', 'Wiseman');
+
+      expect(hits).toHaveLength(1);
+      expect(hits[0].lineNumber).toBe(1);
+    });
+
+    it('supports regex syntax, not just literals', async () => {
+      serve(chunked(POEM, 4096));
+
+      const hits = await collect('/f', '^Did.*asleep$');
+
+      expect(hits.map((hit) => hit.lineNumber)).toEqual([3]);
+    });
+  });
+
+  describe('the cap', () => {
+    it('truncates the line on a character boundary', async () => {
+      serve([encoder.encode('ααααααααα match\n')]);
+
+      const hits = await collect('/f', 'match', { maxLineBytes: 7 });
+
+      // Three two-byte characters fit in seven bytes; the fourth does not.
+      expect(hits[0].line).toBe('ααα');
+    });
+
+    it('keeps the hit when the match itself is past the cut', async () => {
+      serve([encoder.encode('abcdefghij match\n')]);
+
+      const hits = await collect('/f', 'match', { maxLineBytes: 4 });
+
+      expect(hits).toHaveLength(1);
+      expect(hits[0].line).toBe('abcd');
+    });
+  });
+
+  describe('errors and stream shapes', () => {
+    it('throws on an invalid pattern before any request is made', async () => {
+      await expect(collect('/f', '[')).rejects.toThrow();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('throws when the response carries no body', async () => {
+      mockFetch.mockImplementation(() => Promise.resolve({ body: null }));
+
+      await expect(collect('/f', 'a')).rejects.toThrow(
+        "doesn't contain a body",
+      );
+    });
+
+    it('rejects from the iteration when the fetch itself fails', async () => {
+      mockFetch.mockImplementation(() => Promise.reject(new Error('offline')));
+
+      await expect(collect('/f', 'a')).rejects.toThrow('offline');
+    });
+
+    it('yields nothing for a body that closes without emitting', async () => {
+      serve([]);
+
+      expect(await collect('/f', 'a')).toEqual([]);
+    });
+
+    it('keeps reading past a zero-length chunk', async () => {
+      serve([new Uint8Array(0), encoder.encode('found\n')]);
+
+      expect(await collect('/f', 'found')).toHaveLength(1);
+    });
+
+    it('does not let a chunk boundary fake a line boundary for ^', async () => {
+      // `^` must not match at the start of a chunk that begins mid-line.
+      serve(chunked('xxxTARGET\n', 3));
+
+      expect(await collect('/f', '^TARGET')).toEqual([]);
+    });
+
+    it('finds a match straddling a chunk boundary', async () => {
+      serve(chunked('xxTARGETxx\n', 4));
+
+      const hits = await collect('/f', 'TARGET');
+
+      expect(hits).toHaveLength(1);
+      expect(hits[0].line).toBe('xxTARGETxx');
+    });
+  });
+
+  describe('progress', () => {
+    it('reports cumulative decompressed bytes after each chunk', async () => {
+      serve([encoder.encode('abc\n'), encoder.encode('de\n')]);
+
+      const seen: Array<number> = [];
+
+      await collect('/f', 'zzz', { onProgress: (bytes) => seen.push(bytes) });
+
+      expect(seen).toEqual([4, 7]);
+    });
+  });
+
+  describe('cancellation', () => {
+    it('cancels the transfer when the consumer breaks out early', async () => {
+      const state = serve(chunked('hit\nhit\nhit\nhit\nhit\n', 4));
+
+      for await (const _hit of grep('/f', 'hit')) {
+        break;
+      }
+
+      expect(state.cancelCalls).toBe(1);
+      expect(state.sourceCancels).toBe(1);
+    });
+
+    it('cancels the transfer when the consumer throws', async () => {
+      const state = serve(chunked('hit\nhit\nhit\n', 4));
+
+      await expect(
+        (async () => {
+          for await (const _hit of grep('/f', 'hit')) {
+            throw new Error('boom');
+          }
+        })(),
+      ).rejects.toThrow('boom');
+
+      expect(state.sourceCancels).toBe(1);
+    });
+
+    it('stops reading the file once the consumer stops', async () => {
+      const state = serve(chunked('hit\n'.repeat(20), 4));
+
+      for await (const _hit of grep('/f', 'hit')) {
+        break;
+      }
+
+      expect(state.reads).toBe(1);
+    });
+
+    it('cancelling a stream that already ended reaches no source', async () => {
+      // The generator's `finally` runs on a natural end too, and this is why
+      // that is safe: the Streams spec makes `cancel()` on a closed stream a
+      // no-op that never touches the underlying source.
+      const state = serve([encoder.encode('nothing here\n')]);
+
+      await collect('/f', 'zzz');
+
+      expect(state.cancelCalls).toBe(1);
+      expect(state.sourceCancels).toBe(0);
+    });
+  });
+
+  describe('documented defects (asserting current, incorrect behaviour)', () => {
+    // BACKLOG 3g: past the 64 KB retained-tail ceiling the tail becomes a byte
+    // window that is searched with its own block AND again as the head of the
+    // next one. Two wrong answers follow, and both are pinned here rather than
+    // fixed: suppressing them would lose a hit outright when the stream ends
+    // inside such a line, and losing a hit is the worse failure for a grep.
+
+    it('BACKLOG 3g: a hit inside an over-long line is yielded three times', async () => {
+      // The match sits far enough in that three consecutive windows still
+      // contain it, and each one searches it again. One line of one file, and
+      // the line number climbs with every repeat.
+      const overLong = `${'x'.repeat(100 * 1024)}TARGET${'y'.repeat(100 * 1024)}\n`;
+      serve(chunked(overLong, 32 * 1024));
+
+      const hits = await collect('/f', 'TARGET');
+
+      expect(hits.map((hit) => hit.lineNumber)).toEqual([2, 3, 4]);
+    });
+
+    it('BACKLOG 3g: the line number drifts after an over-long line', async () => {
+      // 100 KB in 32 KB chunks is the smallest fixture that actually windows:
+      // the split only falls back to a byte window once a read leaves MORE
+      // than 64 KB with no terminator in it, which takes a fourth chunk.
+      const overLong = `${'x'.repeat(100 * 1024)}\nTARGET\n`;
+      serve(chunked(overLong, 32 * 1024));
+
+      const hits = await collect('/f', '^TARGET$');
+
+      // The true answer is 2. The windowed block counts its incomplete final
+      // line, and the next block counts the same line again — one window
+      // slide, one line of drift.
+      expect(hits).toHaveLength(1);
+      expect(hits[0].lineNumber).toBe(3);
+    });
+  });
+});

--- a/packages/netgrep/src/lib/grep.integration.spec.ts
+++ b/packages/netgrep/src/lib/grep.integration.spec.ts
@@ -345,6 +345,10 @@ describe('grep integration (real WASM)', () => {
 
       expect(hits).toHaveLength(1);
       expect(hits[0].line).toBe('abcd');
+
+      // Dropped, not clamped to the cut: a range the truncated string cannot
+      // show is not reported at all.
+      expect(hits[0].ranges).toEqual([]);
     });
   });
 
@@ -395,6 +399,17 @@ describe('grep integration (real WASM)', () => {
       expect(hits).toHaveLength(1);
       expect(hits[0].line).toBe('xxTARGETxx');
     });
+
+    it('does not search a windowed tail twice when the file ends inside it', async () => {
+      // Over 64 KB with no terminator anywhere, so the last read leaves a tail
+      // that is a byte window its own block already searched. Yielding it
+      // again at EOF would report the same hit a second time — this is the one
+      // windowed path that is right today, and the guard that keeps it right.
+      const overLong = `${'x'.repeat(100 * 1024)}TARGET`;
+      serve(chunked(overLong, 32 * 1024));
+
+      expect(await collect('/f', 'TARGET')).toHaveLength(1);
+    });
   });
 
   describe('progress', () => {
@@ -432,6 +447,7 @@ describe('grep integration (real WASM)', () => {
         })(),
       ).rejects.toThrow('boom');
 
+      expect(state.cancelCalls).toBe(1);
       expect(state.sourceCancels).toBe(1);
     });
 
@@ -481,16 +497,16 @@ describe('grep integration (real WASM)', () => {
       // 100 KB in 32 KB chunks is the smallest fixture that actually windows:
       // the split only falls back to a byte window once a read leaves MORE
       // than 64 KB with no terminator in it, which takes a fourth chunk.
-      const overLong = `${'x'.repeat(100 * 1024)}\nTARGET\n`;
+      const overLong = `${'x'.repeat(100 * 1024)}\nTARGET\nAFTER\n`;
       serve(chunked(overLong, 32 * 1024));
 
-      const hits = await collect('/f', '^TARGET$');
+      const hits = await collect('/f', '^(TARGET|AFTER)$');
 
-      // The true answer is 2. The windowed block counts its incomplete final
-      // line, and the next block counts the same line again — one window
-      // slide, one line of drift.
-      expect(hits).toHaveLength(1);
-      expect(hits[0].lineNumber).toBe(3);
+      // The true answers are 2 and 3. The windowed block counts its incomplete
+      // final line, and the next block counts the same line again — one window
+      // slide, one line of drift, carried by EVERY line after the over-long
+      // one rather than spent on the first of them.
+      expect(hits.map((hit) => hit.lineNumber)).toEqual([3, 4]);
     });
   });
 });

--- a/packages/netgrep/src/lib/grep.spec.ts
+++ b/packages/netgrep/src/lib/grep.spec.ts
@@ -159,12 +159,17 @@ describe('grep', () => {
 
   it('stops searching when the consumer breaks out', async () => {
     serve(['a\n', 'a\n', 'a\n']);
-    mockSearchBlock.mockReturnValue(blockHits('a', [1, 1, 1, 1, 0, 1]));
+    const hits = blockHits('a', [1, 1, 1, 1, 0, 1]);
+    mockSearchBlock.mockReturnValue(hits);
 
     for await (const _hit of grep('/f', 'a')) {
       break;
     }
 
     expect(mockSearchBlock).toHaveBeenCalledTimes(1);
+
+    // Freed BEFORE the walk, so a consumer that leaves mid-block does not
+    // strand the carrier's WASM memory.
+    expect(hits.free).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/netgrep/src/lib/grep.spec.ts
+++ b/packages/netgrep/src/lib/grep.spec.ts
@@ -1,0 +1,170 @@
+import { ReadableStream } from 'node:stream/web';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GrepOptions } from './data/GrepOptions.js';
+import type { NetgrepHit } from './data/NetgrepHit.js';
+import { grep } from './grep.js';
+
+const encoder = new TextEncoder();
+
+// `vi.hoisted` is required, not stylistic: `vi.mock` is lifted above the module
+// body, and its factory runs while `./grep.js` is being imported.
+const { mockSearchBlock, mockSearchBytes } = vi.hoisted(() => ({
+  mockSearchBlock: vi.fn(),
+  mockSearchBytes: vi.fn(),
+}));
+
+vi.mock('@netgrep/search', () => ({
+  default: () => Promise.resolve(),
+  search_block: (...args: Array<unknown>) => mockSearchBlock(...args),
+  search_bytes: (...args: Array<unknown>) => mockSearchBytes(...args),
+}));
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+/** What the real `search_block` hands back: a carrier owning WASM memory. */
+function blockHits(text: string, table: Array<number>) {
+  return { text, table: new Uint32Array(table), free: vi.fn() };
+}
+
+function serve(chunks: Array<string>) {
+  let index = 0;
+
+  mockFetch.mockImplementation(() =>
+    Promise.resolve({
+      body: new ReadableStream({
+        pull(controller) {
+          if (index >= chunks.length) {
+            controller.close();
+            return;
+          }
+
+          controller.enqueue(encoder.encode(chunks[index]));
+          index += 1;
+        },
+      }),
+    }),
+  );
+}
+
+async function collect(url: string, pattern: string, options?: GrepOptions) {
+  const out: Array<NetgrepHit> = [];
+
+  for await (const hit of grep(url, pattern, options)) {
+    out.push(hit);
+  }
+
+  return out;
+}
+
+describe('grep', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockSearchBlock.mockReset();
+    mockSearchBytes.mockReset();
+  });
+
+  it('yields the hits of a single block', async () => {
+    serve(['a\nb\n']);
+    mockSearchBlock.mockReturnValue(blockHits('a', [1, 2, 1, 1, 0, 1]));
+
+    expect(await collect('/f', 'a')).toEqual([
+      { line: 'a', ranges: [{ start: 0, end: 1 }], lineNumber: 1 },
+    ]);
+  });
+
+  it('makes line numbers file-absolute by carrying a base across blocks', async () => {
+    serve(['one\ntwo\n', 'three\nfour\n']);
+    mockSearchBlock
+      .mockReturnValueOnce(blockHits('two', [1, 2, 2, 1, 0, 3]))
+      .mockReturnValueOnce(blockHits('four', [1, 2, 2, 1, 0, 4]));
+
+    const hits = await collect('/f', 'o');
+
+    expect(hits.map((hit) => hit.lineNumber)).toEqual([2, 4]);
+  });
+
+  it('advances the base by the lines a block held, not by its hits', async () => {
+    // A block of a thousand lines with one hit still moves the base by a
+    // thousand. Counting hits instead is the bug this pins.
+    serve(['x\n', 'y\n']);
+    mockSearchBlock
+      .mockReturnValueOnce(blockHits('', [0, 1000]))
+      .mockReturnValueOnce(blockHits('y', [1, 1, 1, 1, 0, 1]));
+
+    const hits = await collect('/f', 'y');
+
+    expect(hits.map((hit) => hit.lineNumber)).toEqual([1001]);
+  });
+
+  it('frees the carrier for every block, hit or no hit', async () => {
+    serve(['a\n', 'b\n']);
+    const first = blockHits('', [0, 1]);
+    const second = blockHits('b', [1, 1, 1, 1, 0, 1]);
+    mockSearchBlock.mockReturnValueOnce(first).mockReturnValueOnce(second);
+
+    await collect('/f', 'b');
+
+    expect(first.free).toHaveBeenCalledTimes(1);
+    expect(second.free).toHaveBeenCalledTimes(1);
+  });
+
+  it('compiles the pattern BEFORE opening the connection', async () => {
+    mockSearchBytes.mockImplementation(() => {
+      throw new Error('regex parse error');
+    });
+
+    await expect(collect('/f', '[')).rejects.toThrow('regex parse error');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not run at all until the first next()', async () => {
+    // An async generator's body is deferred, so a bad pattern surfaces from
+    // the iteration rather than from the call.
+    mockSearchBytes.mockImplementation(() => {
+      throw new Error('regex parse error');
+    });
+
+    const hits = grep('/f', '[');
+
+    expect(mockSearchBytes).not.toHaveBeenCalled();
+    await expect(hits.next()).rejects.toThrow('regex parse error');
+  });
+
+  it('caps lines at 4096 bytes by default', async () => {
+    serve(['a\n']);
+    mockSearchBlock.mockReturnValue(blockHits('', [0, 1]));
+
+    await collect('/f', 'a');
+
+    expect(mockSearchBlock).toHaveBeenCalledWith(expect.anything(), 'a', 4096);
+  });
+
+  it('passes a caller-supplied cap to the engine', async () => {
+    serve(['a\n']);
+    mockSearchBlock.mockReturnValue(blockHits('', [0, 1]));
+
+    await collect('/f', 'a', { maxLineBytes: 12 });
+
+    expect(mockSearchBlock).toHaveBeenCalledWith(expect.anything(), 'a', 12);
+  });
+
+  it('yields nothing for a file with no match, having read all of it', async () => {
+    serve(['a\n', 'b\n']);
+    mockSearchBlock.mockReturnValue(blockHits('', [0, 1]));
+
+    expect(await collect('/f', 'zzz')).toEqual([]);
+    expect(mockSearchBlock).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops searching when the consumer breaks out', async () => {
+    serve(['a\n', 'a\n', 'a\n']);
+    mockSearchBlock.mockReturnValue(blockHits('a', [1, 1, 1, 1, 0, 1]));
+
+    for await (const _hit of grep('/f', 'a')) {
+      break;
+    }
+
+    expect(mockSearchBlock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/netgrep/src/lib/grep.ts
+++ b/packages/netgrep/src/lib/grep.ts
@@ -1,0 +1,70 @@
+import { search_block, search_bytes } from '@netgrep/search';
+import type { GrepOptions } from './data/GrepOptions.js';
+import type { NetgrepHit } from './data/NetgrepHit.js';
+import { decodeBlock, linesInBlock } from './decodeBlock.js';
+import { resolveMaxLineBytes } from './resolveMaxLineBytes.js';
+import { streamBlocks } from './streamBlocks.js';
+import { wasmReady } from './wasmReady.js';
+
+/**
+ * Search a remote file and yield every matching line as it is found.
+ *
+ * Hits arrive while the file is still downloading, and memory stays flat
+ * however large it is: one network chunk and the incomplete line at its end
+ * are all that is ever held, and each hit is built at the moment it is yielded.
+ *
+ * Iteration drives everything. Nothing is fetched until the first `next()`, so
+ * a pattern that will not compile throws from the loop rather than from this
+ * call; and leaving the loop with `break`, `return` or a `throw` terminates the
+ * transfer instead of leaving the rest of the file to arrive unread.
+ *
+ * An error can arrive AFTER hits have already been yielded — a connection that
+ * drops at 180 MB gives every hit up to that point and then throws. Those hits
+ * are correct and complete for the bytes that were read.
+ *
+ * @param url
+ * The url to the remote file.
+ * @param pattern
+ * The pattern to search for. Anything `ripgrep` can understand, matched with
+ * smart case: lowercase is case-insensitive, any uppercase character makes it
+ * case-sensitive.
+ * @param options
+ * Optional `GrepOptions` — the per-line byte cap and a progress callback.
+ * @returns
+ * An async iterable of `NetgrepHit`, in file order.
+ */
+export async function* grep(
+  url: string,
+  pattern: string,
+  options?: GrepOptions,
+): AsyncGenerator<NetgrepHit> {
+  await wasmReady;
+
+  // Compile before the connection opens. Reaching the engine with the first
+  // chunk instead spends a request on a 240 MB file to discover an unclosed
+  // `[`; the engine memoises the compiled matcher, so the real search reuses
+  // this one and the check costs nothing.
+  search_bytes(new Uint8Array(0), pattern);
+
+  const maxLineBytes = resolveMaxLineBytes(options?.maxLineBytes);
+
+  // Lines of the file that came before the current block. Advanced by what the
+  // engine counted, because counting terminators in JavaScript would mean
+  // walking every byte of the file in the slowest language on the path.
+  let linesBefore = 0;
+
+  for await (const block of streamBlocks(url, options)) {
+    const hits = search_block(block, pattern, maxLineBytes);
+
+    // Read out, then free: the carrier owns WASM memory, and waiting for GC
+    // would leak it for the page's lifetime under engines without weak-ref
+    // finalization.
+    const text = hits.text;
+    const table = hits.table;
+    hits.free();
+
+    yield* decodeBlock(text, table, linesBefore);
+
+    linesBefore += linesInBlock(table);
+  }
+}

--- a/packages/netgrep/src/lib/resolveMaxLineBytes.ts
+++ b/packages/netgrep/src/lib/resolveMaxLineBytes.ts
@@ -1,0 +1,37 @@
+/**
+ * Ceiling on the returned line when `capture` is set and the caller names no
+ * other. Far past any line of prose, and small enough that a minified bundle
+ * costs a snippet rather than a copy of itself.
+ */
+const DEFAULT_MAX_LINE_BYTES = 4096;
+
+/**
+ * The largest cap a Rust `usize` receives intact on wasm32.
+ */
+const MAX_LINE_BYTES_CEILING = 0xffffffff;
+
+/**
+ * Clamp a caller-supplied `maxLineBytes` into something the engine can hold.
+ *
+ * Clamped rather than validated: throwing would be a new failure mode for a
+ * cosmetic setting, and wasm-bindgen checks nothing.
+ *
+ * ⚠️ THE UPPER BOUND MATTERS AS MUCH AS THE LOWER ONE. The number crosses the
+ * boundary through ToUint32, which WRAPS rather than saturates, so `Infinity`,
+ * `NaN` and 2³² all arrive as **0** — and a cap of 0 returns an empty string
+ * for every match, which is exactly how a match on an empty line is reported.
+ * Unbounded, the obvious way to ask for no cap silently produced the one result
+ * this API cannot afford to be ambiguous about.
+ */
+export function resolveMaxLineBytes(requested: number | undefined): number {
+  // Not a request for anything.
+  if (requested === undefined || Number.isNaN(requested)) {
+    return DEFAULT_MAX_LINE_BYTES;
+  }
+
+  // `Infinity` is how a caller spells "no cap", so it becomes the largest cap
+  // rather than falling back to the default and quietly ignoring them.
+  if (requested >= MAX_LINE_BYTES_CEILING) return MAX_LINE_BYTES_CEILING;
+
+  return Math.max(1, Math.floor(requested));
+}

--- a/packages/netgrep/src/lib/splitAtLastLine.ts
+++ b/packages/netgrep/src/lib/splitAtLastLine.ts
@@ -1,4 +1,15 @@
 /**
+ * Ceiling on the bytes retained between two `fetch` chunks.
+ *
+ * Only terminator-free input reaches it — the tail is normally the incomplete
+ * trailing line, 387 bytes at worst in the demo's log files. Past it the
+ * guarantee weakens to "a boundary never hides a match shorter than 64 KB".
+ *
+ * A safety valve for input netgrep is not aimed at, so not configurable.
+ */
+export const MAX_TAIL_BYTES = 64 * 1024;
+
+/**
  * The only byte that ends a line here: `packages/search` builds its matcher with
  * `line_terminator(Some(b'\n'))` and no multi-line mode.
  */

--- a/packages/netgrep/src/lib/streamBlocks.spec.ts
+++ b/packages/netgrep/src/lib/streamBlocks.spec.ts
@@ -1,0 +1,189 @@
+import { ReadableStream } from 'node:stream/web';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { streamBlocks } from './streamBlocks.js';
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+/** Split a string into fixed-size byte chunks, the way a response arrives. */
+function chunked(str: string, size: number): Array<Uint8Array> {
+  const bytes = encoder.encode(str);
+  const out: Array<Uint8Array> = [];
+
+  for (let i = 0; i < bytes.length; i += size) {
+    out.push(bytes.slice(i, i + size));
+  }
+
+  return out;
+}
+
+function streamOfChunks(chunks: Array<Uint8Array>) {
+  let index = 0;
+
+  return new ReadableStream({
+    pull(controller) {
+      if (index >= chunks.length) {
+        controller.close();
+        return;
+      }
+
+      controller.enqueue(chunks[index]);
+      index += 1;
+    },
+  });
+}
+
+/**
+ * Serve the given chunks, counting reads and the consumer's `cancel()` calls.
+ *
+ * Counted at the consumer boundary rather than on the stream's own `cancel`
+ * callback: a stream that has already closed swallows `cancel()` without
+ * telling its source, so a source-side assertion cannot see a call that should
+ * not have happened.
+ */
+function serve(chunks: Array<Uint8Array>) {
+  const state = { reads: 0, cancelCalls: 0 };
+
+  mockFetch.mockImplementation(() => {
+    const stream = streamOfChunks(chunks);
+
+    return Promise.resolve({
+      body: {
+        getReader() {
+          const reader = stream.getReader();
+
+          return {
+            read() {
+              state.reads += 1;
+              return reader.read();
+            },
+            cancel() {
+              state.cancelCalls += 1;
+              return reader.cancel();
+            },
+          };
+        },
+      },
+    });
+  });
+
+  return state;
+}
+
+/** Collect every block a stream yields, as text. */
+async function collect(url: string): Promise<Array<string>> {
+  const out: Array<string> = [];
+
+  for await (const block of streamBlocks(url)) {
+    out.push(decoder.decode(block));
+  }
+
+  return out;
+}
+
+describe('streamBlocks', () => {
+  beforeEach(() => mockFetch.mockReset());
+
+  it('yields whole lines and holds the incomplete one back', async () => {
+    serve(chunked('alpha\nbeta\ngam', 32));
+
+    expect(await collect('/f')).toEqual(['alpha\nbeta\n', 'gam']);
+  });
+
+  it('joins a line split across two chunks before yielding it', async () => {
+    serve([encoder.encode('al'), encoder.encode('pha\n')]);
+
+    expect(await collect('/f')).toEqual(['alpha\n']);
+  });
+
+  it('yields the final line even when nothing terminates it', async () => {
+    serve([encoder.encode('one\ntwo')]);
+
+    expect(await collect('/f')).toEqual(['one\n', 'two']);
+  });
+
+  it('yields nothing at all for an empty body', async () => {
+    serve([]);
+
+    expect(await collect('/f')).toEqual([]);
+  });
+
+  it('yields no empty block for a chunk that completes no line', async () => {
+    serve([encoder.encode('abc'), encoder.encode('def\n')]);
+
+    expect(await collect('/f')).toEqual(['abcdef\n']);
+  });
+
+  it('keeps reading past a zero-length chunk', async () => {
+    serve([encoder.encode(''), encoder.encode('found\n')]);
+
+    expect(await collect('/f')).toEqual(['found\n']);
+  });
+
+  it('throws when the response carries no body', async () => {
+    mockFetch.mockImplementation(() => Promise.resolve({ body: null }));
+
+    await expect(collect('/f')).rejects.toThrow("doesn't contain a body");
+  });
+
+  it('reports cumulative bytes read after each chunk', async () => {
+    serve([encoder.encode('abc\n'), encoder.encode('de\n')]);
+
+    const seen: Array<number> = [];
+
+    for await (const _block of streamBlocks('/f', {
+      onProgress: (bytes) => seen.push(bytes),
+    })) {
+      // Draining is the point; the blocks themselves are asserted elsewhere.
+    }
+
+    expect(seen).toEqual([4, 7]);
+  });
+
+  it('cancels the reader when the consumer breaks out early', async () => {
+    const state = serve(chunked('a\nb\nc\nd\ne\n', 2));
+
+    for await (const _block of streamBlocks('/f')) {
+      break;
+    }
+
+    expect(state.cancelCalls).toBe(1);
+    expect(state.reads).toBe(1);
+  });
+
+  it('cancels the reader when the consumer throws', async () => {
+    const state = serve(chunked('a\nb\nc\n', 2));
+
+    await expect(
+      (async () => {
+        for await (const _block of streamBlocks('/f')) {
+          throw new Error('boom');
+        }
+      })(),
+    ).rejects.toThrow('boom');
+
+    expect(state.cancelCalls).toBe(1);
+  });
+
+  it('stops reading the moment the consumer stops asking', async () => {
+    // The generator suspends at `yield` and does not resume until the consumer
+    // asks again, which is what pushes backpressure onto the socket. A
+    // read-ahead would break it silently, and this is the assertion that
+    // notices.
+    const state = serve(chunked('a\nb\nc\nd\ne\nf\n', 2));
+
+    const blocks = streamBlocks('/f');
+
+    await blocks.next();
+    const readsAfterFirst = state.reads;
+    await blocks.next();
+
+    expect(readsAfterFirst).toBe(1);
+    expect(state.reads).toBe(2);
+
+    await blocks.return(undefined);
+  });
+});

--- a/packages/netgrep/src/lib/streamBlocks.spec.ts
+++ b/packages/netgrep/src/lib/streamBlocks.spec.ts
@@ -85,7 +85,12 @@ async function collect(url: string): Promise<Array<string>> {
 }
 
 describe('streamBlocks', () => {
-  beforeEach(() => mockFetch.mockReset());
+  // A block body, not a concise one: `mockReset` returns the mock, which is a
+  // function, and a hook that returns a function has returned a teardown —
+  // Vitest would call `mockFetch()` after every test.
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
 
   it('yields whole lines and holds the incomplete one back', async () => {
     serve(chunked('alpha\nbeta\ngam', 32));

--- a/packages/netgrep/src/lib/streamBlocks.ts
+++ b/packages/netgrep/src/lib/streamBlocks.ts
@@ -1,0 +1,90 @@
+import { concatBytes } from './concatBytes.js';
+import { MAX_TAIL_BYTES, splitAtLastLine } from './splitAtLastLine.js';
+
+/**
+ * Fetch a url and yield its bytes as blocks of whole lines.
+ *
+ * The engine only ever sees complete lines: a match cannot span a `\n`, so the
+ * incomplete trailing line is the exact carry-over between network chunks, and
+ * a chunk boundary can neither hide a match nor fake a line start for `^`.
+ *
+ * Nothing accumulates. One chunk plus that trailing line, bounded at 64 KB,
+ * however large the file — which is what makes the memory cost independent of
+ * the response size.
+ *
+ * Shared by every entry point that streams, because this is the part where a
+ * bug is expensive and the part both of them would otherwise duplicate.
+ *
+ * @param url
+ * The url to read.
+ * @param options.onProgress
+ * Called after each chunk with the cumulative decompressed bytes delivered.
+ */
+export async function* streamBlocks(
+  url: string,
+  options?: { onProgress?: (bytesRead: number) => void },
+): AsyncGenerator<Uint8Array> {
+  const response = await fetch(url);
+
+  if (!response.body) {
+    throw new Error("The response doesn't contain a body");
+  }
+
+  const reader = response.body.getReader();
+
+  // The incomplete final line seen so far, held back until the rest of it
+  // arrives. Annotated because `subarray` yields an `ArrayBufferLike` view,
+  // which the inferred type would reject.
+  let tail: Uint8Array = new Uint8Array(0);
+
+  // Whether `tail` still needs yielding when the stream ends. False in the
+  // windowed case, where it went out already as part of the whole buffer.
+  let tailPending = false;
+
+  let bytesRead = 0;
+
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+
+      if (done) {
+        // A genuine final line rather than a fragment, and skipping it would
+        // lose the last line of every file not ending in a newline.
+        //
+        // Only when it has not gone out already. A windowed tail was covered
+        // by the whole-buffer block that produced it, and yielding it alone
+        // would treat its first byte as a line start — letting `^` match a
+        // line that begins earlier.
+        if (tailPending && tail.length > 0) yield tail;
+
+        return;
+      }
+
+      bytesRead += value.length;
+      options?.onProgress?.(bytesRead);
+
+      const {
+        searchable,
+        tail: nextTail,
+        tailSearched,
+      } = splitAtLastLine(
+        tail.length > 0 ? concatBytes([tail, value]) : value,
+        MAX_TAIL_BYTES,
+      );
+
+      tail = nextTail;
+      tailPending = !tailSearched;
+
+      // A chunk that completed no line yields nothing and grows the tail.
+      if (searchable.length > 0) yield searchable;
+    }
+  } finally {
+    // Terminate the transfer rather than abandon it: `break`, `throw` and an
+    // early `return` from the consumer all land here, and an abandoned reader
+    // leaves the request open so the rest of the file keeps arriving and is
+    // paid for. Unconditional because cancelling an already-closed stream is
+    // defined as a no-op, which is cheaper than a branch that has to be right.
+    // Rejections are ignored: a stream that has errored rejects here.
+    await reader.cancel().catch(() => {});
+  }
+}

--- a/packages/netgrep/src/lib/wasmReady.ts
+++ b/packages/netgrep/src/lib/wasmReady.ts
@@ -1,0 +1,17 @@
+import init from '@netgrep/search';
+
+/**
+ * The WASM module has to be instantiated before any engine call.
+ *
+ * Started once at module load and shared by every entry point: the download
+ * begins as soon as the library is imported rather than on the first search,
+ * and awaiting an already-settled promise costs nothing.
+ *
+ * Its own module so the class API and `grep` await the same promise. Two
+ * `init()` calls would be idempotent, but two module-level promises racing to
+ * instantiate on a cold import is not something to rely on being harmless.
+ *
+ * Kept out of `index.ts` on purpose — callers should not have to know the
+ * engine needs booting.
+ */
+export const wasmReady = init();


### PR DESCRIPTION
**PR 5 of 7** of the streaming rewrite ([0027](https://github.com/dgopsq/netgrep/blob/main/docs/decisions/0027-streaming-matching-lines.md)). Adds `grep()`. **Nothing is deleted and nothing breaks** — `Netgrep` and its suites are untouched.

```ts
for await (const hit of grep(url, /* pattern */ 'ERROR')) {
  console.log(hit.lineNumber, hit.line, hit.ranges);
}
```

Hits arrive while the file downloads, memory stays flat however large it is, and each hit is built at the moment it is yielded — a block with half a million matches never materialises half a million objects.

### How it fits together

| Module | Job |
|---|---|
| `streamBlocks.ts` | `fetch` → reader → blocks of whole lines, `onProgress`, cancel in a `finally` |
| `decodeBlock.ts` | walks the engine's flat `text`+`Uint32Array` with a cursor, lazily |
| `grep.ts` | one `search_block` per block, running file-absolute line base |

`wasmReady`, `concatBytes`, `resolveMaxLineBytes` and `MAX_TAIL_BYTES` moved out of `Netgrep.ts` so both APIs share one copy. That first commit is a pure move — `Netgrep`'s logic is not touched.

### Three things worth a reviewer's attention

**The walker must not use `split`.** `text.split('\n')` allocates every line up front, which defeats the reason the flat encoding was chosen over serde. No test can tell the two apart — they produce identical output — so it is a code-shape requirement, not a tested one.

**Chunk-size invariance is the property that matters.** The same file and pattern must yield identical hits at chunk sizes 1, 7, 64, 1024 and 65536. One property covers the tail split, the line-number base and the encoding walk at once, because every bug this design can introduce makes output depend on chunking.

**BACKLOG 3g widened, and the new consequences are pinned rather than fixed.** Past the 64 KB tail ceiling the window slides, and the retained tail is searched with its own block *and* again as the next block's head. So `grep` yields such a hit three times on the tested fixture, and the line number gains one per slide. Both are deliberate: suppressing them would lose the hit outright when a stream ends inside such a line, and for a grep a lost hit is worse than a repeated one.

### Two things this PR does not do

**No `fetch` options, no `signal`** — that is BACKLOG 22, in PR 6. This opens a real gap, now tracked as **BACKLOG 29**: `grep` yields only on a hit, so over a hitless stretch there is no loop body to `break` from, and `.return()` on a generator suspended at an `await` is queued until the next `yield`. A file with no match downloads in full and cannot be stopped. Found by the final review, which caught `ARCHITECTURE.md` claiming the opposite.

**No guide, README or `caveats.data.json` changes.** Consumer prose is welded to the deletion in PR 7: until then both APIs exist, so a guide written now would describe two surfaces and a migration between them, half of which is deleted at PR 7 — and there are no consumers to migrate. `docs/ARCHITECTURE.md`, `AGENTS.md` and `docs/BACKLOG.md` ship here because they describe the loop.

### Verification

242 TypeScript tests across 11 files (32 new in headless Chromium against the real WASM), 73 Rust unchanged. `pnpm lint`, `typecheck`, `build`, `docs:sync --check` and `verify:pack` all green. The two new guard assertions were mutation-checked: `tailPending = true` and moving `free()` below the walk each fail exactly one test and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
