### PR TITLE
test(netgrep): prove bytes are searched before the response ends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,8 @@ Thumbs.db
 # repo, so feature PRs stay reviewable.
 /docs/superpowers
 /.superpowers
+# Written by a FAILING browser test run, never by a passing one — so these
+# appear exactly when someone is already debugging and would commit them by
+# accident while staging the fix.
+.vitest-attachments/
+__screenshots__/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -514,6 +514,7 @@ components straight out of `rust-toolchain.toml`.
 | `splitAtLastLine.spec.ts` | Vitest in **Node**, 12 tests | The chunk-boundary tail arithmetic in isolation, with `cap = 8` so the over-the-ceiling cases fit on one line. A pure function, so no mocks at all. |
 | `Netgrep.spec.ts` | Vitest in **Node**, 48 tests | Orchestration only — `fetch` **and** `@netgrep/search` are mocked. Result shape, metadata, abort plumbing, error capture and serialisation, and all three public methods including `searchBatchWithCallback`. |
 | `Netgrep.integration.spec.ts` | Vitest in **headless Chromium** (Playwright), 49 tests | **The real engine through the real streaming loop, in a real browser.** Only `fetch` is faked, and only to remove the network: bytes still travel through a real `ReadableStream`, still arrive chunked, still get matched by the compiled `search_bytes`. |
+| `streaming-transport.integration.spec.ts` | Vitest in **headless Chromium**, 3 tests | **The one suite that does not fake `fetch`.** It proves bytes are delivered and searched *before* the response ends — see below. |
 | `packages/search/tests/search.rs` | `cargo test`, native, 73 tests | The four `try_*` entry points as pure Rust — bytes in, bool/line/ranges/block-hits out. Regex features, smart case, line semantics, encoding and BOM handling, binary detection, the compiled-matcher cache, block-hit collection and line numbering, and the UTF-16 offset conversion including its lossy-decoding and truncation edges. No browser involved. |
 | `scripts/verify-pack.mjs` | Node, in CI | The published tarballs: required files present, no `workspace:` range survived packing, no version drift. |
 
@@ -530,6 +531,26 @@ is precisely the part that failed silently under Vite in [decision 0005](decisio
 
 Why a browser at all, and why Playwright rather than ChromeDriver:
 [decision 0013](decisions/0013-playwright-for-browser-tests.md).
+
+**Faking `fetch` costs the suite the one thing the project claims, so one suite does not.** Every other
+integration test replaces `fetch` to make chunk boundaries deterministic — which means none of them can say
+anything about the network. They establish that netgrep consumes an already-progressive stream
+progressively, and assume the stream is progressive in the first place. That assumption is the project's
+defining property ([decision 0002](decisions/0002-search-while-downloading.md)) and until now nothing
+enforced it.
+
+`streaming-transport.integration.spec.ts` closes that gap with a server that will not finish.
+`vitest.drip-server.ts` registers a Vite middleware serving 64 KB, then holding the connection open and
+sending nothing more until a release URL is hit. A test reads a match out of those first bytes and only then
+releases the rest, so the read can only have succeeded while the response was unfinished — had the browser
+buffered the body, the bytes completing it would not yet exist. **Nothing is timed.** There is no sleep and
+no threshold to tune: the ordering is enforced by the server refusing to end, which is what makes this a
+proof rather than an observation. The 64 KB head is sized past any plausible socket-buffering threshold, so
+a failure means what it says; the deadline in the test exists only to turn a hang into a sentence.
+
+The three cases hold each other honest, and both directions were confirmed by mutating the server: make it
+withhold the head until release — a buffering transport — and the first two fail with their explanation;
+make it send the whole body at once and the third fails, since it asserts the tail is *not* visible early.
 
 Its last block deliberately asserts **incorrect** behaviour, pinning the caveats above so that an unintended
 change is caught. Read

--- a/packages/netgrep/src/lib/streaming-transport.integration.spec.ts
+++ b/packages/netgrep/src/lib/streaming-transport.integration.spec.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DRIP_HEAD_LINE,
+  DRIP_TAIL_LINE,
+} from '../../../../vitest.drip-server.js';
+import { Netgrep } from './Netgrep.js';
+
+/**
+ * How long to wait before calling it: the bytes are not coming.
+ *
+ * Not a performance budget. The server has already written the head by the
+ * time it holds the connection, so on a working platform every wait here
+ * settles in milliseconds. The only thing this number decides is how long a
+ * BROKEN platform takes to say so.
+ */
+const DEADLINE_MS = 10_000;
+
+/**
+ * Await something that must arrive while the response is still open, and fail
+ * with the reason rather than a bare timeout.
+ */
+function beforeTheResponseEnds<T>(work: Promise<T>, what: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () =>
+        reject(
+          new Error(
+            `${what} never arrived. The response is still open and the rest of ` +
+              'its bytes have not been sent yet, so this can only mean the ' +
+              'browser buffered the body instead of delivering it as it arrived.',
+          ),
+        ),
+      DEADLINE_MS,
+    );
+  });
+
+  return Promise.race([work, deadline]).finally(() => clearTimeout(timer));
+}
+
+/** A fresh id per test, so held responses can never collide. */
+function dripId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+const release = (id: string) => fetch(`/__drip/release?id=${id}`);
+
+describe('the transport delivers bytes while the response is still open', () => {
+  // ⚠️ This file must NOT mock `fetch`. Every other integration test fakes the
+  // network to make chunk boundaries deterministic, which means none of them
+  // can say anything about the network itself — they prove netgrep consumes an
+  // already-progressive stream progressively, which was never the question.
+  //
+  // Here a real Chromium makes a real request to a server that sends the first
+  // 64 KB, then holds the connection open and sends nothing more until asked.
+  // Reading a match out of those first bytes is therefore only possible if they
+  // crossed while the response was unfinished. Nothing is timed; the ordering
+  // is enforced by the server refusing to finish.
+
+  it('hands the first bytes to a reader before the rest is sent', async () => {
+    const id = dripId();
+
+    const response = await beforeTheResponseEnds(
+      fetch(`/__drip?id=${id}`),
+      'the response headers',
+    );
+
+    expect(response.body).not.toBeNull();
+
+    const reader = response.body?.getReader();
+
+    if (!reader) throw new Error('the response carried no body');
+
+    const { value, done } = await beforeTheResponseEnds(
+      reader.read(),
+      'the first chunk',
+    );
+
+    expect(done).toBe(false);
+    expect(value?.byteLength).toBeGreaterThan(0);
+    expect(new TextDecoder().decode(value)).toContain(DRIP_HEAD_LINE);
+
+    await reader.cancel();
+    await release(id);
+  }, 20_000);
+
+  it('answers a search from bytes that arrived before the response ended', async () => {
+    const id = dripId();
+    const netgrep = new Netgrep();
+
+    // Resolving at all is the assertion. The line this matches is in the head;
+    // the rest of the body does not exist yet, so a buffered response could
+    // never produce this answer.
+    const result = await beforeTheResponseEnds(
+      netgrep.search(`/__drip?id=${id}`, DRIP_HEAD_LINE, undefined, {
+        capture: 'line',
+      }),
+      'the search result',
+    );
+
+    expect(result.result).toBe(true);
+    expect(result.line).toBe(DRIP_HEAD_LINE);
+
+    await release(id);
+  }, 20_000);
+
+  it('does not see the held-back tail until it is released', async () => {
+    // The mirror of the test above, and what stops it passing for the wrong
+    // reason: if the whole body were somehow already present, this search
+    // would find the tail's line too.
+    const id = dripId();
+    const netgrep = new Netgrep();
+
+    const search = netgrep.search(`/__drip?id=${id}`, DRIP_TAIL_LINE);
+
+    // Give the head every chance to arrive and be searched. Nothing is being
+    // waited FOR here — the point is that the search is still unresolved after
+    // the head has certainly been delivered and scanned.
+    const settledEarly = await Promise.race([
+      search.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 500)),
+    ]);
+
+    expect(settledEarly).toBe(false);
+
+    await release(id);
+
+    const result = await beforeTheResponseEnds(search, 'the released result');
+
+    expect(result.result).toBe(true);
+  }, 20_000);
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
 import { playwright } from '@vitest/browser-playwright';
 import { defineConfig } from 'vitest/config';
+import { dripServer } from './vitest.drip-server.js';
 
 export default defineConfig({
   test: {
@@ -51,6 +52,9 @@ export default defineConfig({
         optimizeDeps: {
           exclude: ['@netgrep/search'],
         },
+        // Serves the half-sent response that `streaming-transport.integration
+        // .spec.ts` uses to prove bytes are searched before the response ends.
+        plugins: [dripServer()],
       },
       {
         // Build-time tooling and the example's pure modules: the docs

--- a/vitest.drip-server.ts
+++ b/vitest.drip-server.ts
@@ -1,0 +1,125 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+/**
+ * The shape of a Vite plugin this file needs, described rather than imported.
+ *
+ * `vite` is a dependency of the example package, not of the library — and the
+ * integration test imports the marker lines below, which would drag whatever
+ * this file imports into `packages/netgrep`'s typecheck. Structural types cost
+ * nine lines and keep the library's program to `node` types alone.
+ */
+type Middleware = (
+  request: IncomingMessage,
+  response: ServerResponse,
+  next: () => void,
+) => void;
+
+type TestServerPlugin = {
+  name: string;
+  configureServer: (server: {
+    middlewares: { use: (middleware: Middleware) => void };
+  }) => void;
+};
+
+/**
+ * A response that has sent its first bytes and is waiting to be told to send
+ * the rest.
+ */
+type Held = {
+  response: ServerResponse;
+  tail: string;
+};
+
+/** Held responses, keyed by the id the test generated. */
+const held = new Map<string, Held>();
+
+/**
+ * Bytes written before the response is held open.
+ *
+ * Sized so the head cannot sit in a socket buffer waiting for company: a few
+ * hundred bytes might legitimately not surface until more arrives, and a test
+ * that failed for that reason would look like a streaming failure. 64 KB is
+ * past any such threshold.
+ *
+ * Padded with short lines, never one long one — a line over the 64 KB tail
+ * ceiling would put the reader on the windowed path and change what it yields.
+ */
+const PAD_LINE = `${'x'.repeat(63)}\n`;
+const PAD_LINES = 1024;
+
+/** The line the head carries, and the line the tail carries. */
+export const DRIP_HEAD_LINE = 'MARKER-HEAD';
+export const DRIP_TAIL_LINE = 'MARKER-TAIL';
+
+function head(): string {
+  return `${DRIP_HEAD_LINE}\n${PAD_LINE.repeat(PAD_LINES)}`;
+}
+
+function tail(): string {
+  return `${DRIP_TAIL_LINE}\n`;
+}
+
+/**
+ * Serve a response whose second half is sent only when a test asks for it.
+ *
+ * This is what makes progressive delivery provable rather than plausible. A
+ * test reads until it gets the head's match, and only then releases the tail —
+ * so the read can only have succeeded if bytes crossed while the response was
+ * still open. Had the browser buffered the whole body, the tail would not yet
+ * exist to complete it and the read would never resolve.
+ *
+ * Nothing here is timing-based. There is no sleep and no deadline to tune: the
+ * ordering is enforced by the server refusing to finish.
+ */
+export function dripServer(): TestServerPlugin {
+  return {
+    name: 'netgrep-drip-server',
+
+    configureServer(server) {
+      server.middlewares.use((request, response, next) => {
+        const url = new URL(request.url ?? '/', 'http://localhost');
+
+        if (url.pathname !== '/__drip' && url.pathname !== '/__drip/release') {
+          return next();
+        }
+
+        const id = url.searchParams.get('id');
+
+        if (!id) {
+          response.statusCode = 400;
+          response.end('missing id');
+          return;
+        }
+
+        if (url.pathname === '/__drip/release') {
+          const waiting = held.get(id);
+
+          if (waiting) {
+            held.delete(id);
+            waiting.response.end(waiting.tail);
+          }
+
+          response.statusCode = 204;
+          response.end();
+          return;
+        }
+
+        response.statusCode = 200;
+        response.setHeader('Content-Type', 'text/plain; charset=utf-8');
+
+        // No `Content-Length`, so the response is chunked and may legally end
+        // whenever the server says. `no-transform` keeps any proxy from
+        // buffering the body to recompress it, which would defeat the point.
+        response.setHeader('Cache-Control', 'no-store, no-transform');
+
+        response.write(head());
+
+        held.set(id, { response, tail: tail() });
+
+        // Nothing calls `end` here. That is the mechanism, not an oversight —
+        // the release route finishes it.
+        request.on('close', () => held.delete(id));
+      });
+    },
+  };
+}


### PR DESCRIPTION
Independent of #48 — branched off `main` so the two don't stack.

### The gap

Every integration test in this repository fakes `fetch`, deliberately, to make chunk boundaries deterministic. The consequence is that **none of them can say anything about the network.** They prove netgrep consumes an already-progressive stream progressively, and *assume* the stream is progressive in the first place.

That assumption is the project's defining property — [decision 0002](https://github.com/dgopsq/netgrep/blob/main/docs/decisions/0002-search-while-downloading.md) calls a real streaming `fetch` a hard requirement with no fallback path — and nothing enforced it. The only evidence was a measurement in the demo (`BACKLOG` item 24: a match answering after 8.9% of a file streamed). A number in a demo is not something CI defends.

### The proof

`vitest.drip-server.ts` registers a Vite middleware that serves 64 KB and then **holds the connection open**, sending nothing more until a release URL is hit.

A test reads a match out of those first bytes and only then releases the rest. The read can therefore only have succeeded while the response was unfinished — had the browser buffered the body, the bytes that complete it would not yet exist.

**Nothing is timed.** No sleep, no threshold to tune, no flaky stopwatch: the ordering is enforced by the server refusing to end. That is what makes it a proof rather than an observation. The deadline in the test exists only to turn a hang into a sentence:

> the search result never arrived. The response is still open and the rest of its bytes have not been sent yet, so this can only mean the browser buffered the body instead of delivering it as it arrived.

### Both directions were mutation-tested

A green test proves nothing until you have watched it fail, so I ran the server both ways:

| Mutation | Result |
|---|---|
| Withhold the head until release — i.e. a buffering transport | The first two cases fail, with the message above |
| Send the whole body at once, hold nothing | The third case fails — it asserts the tail is *not* visible early |

The third case is what stops the first two passing vacuously if the server ever stops actually holding anything.

### Notes

- **`vite` was not added as a dependency.** The test imports the marker lines from the server module, which would drag its imports into `packages/netgrep`'s typecheck — where `vite` does not exist. The plugin type is described structurally in nine lines instead.
- The 64 KB head is sized past any plausible socket-buffering threshold, so a failure means what it says rather than "the chunk was too small to surface".
- Covers `Netgrep.search` since that is what is on `main`. Once #48 lands, `grep()` gets the same treatment for free — it shares the loop.
- Separate commit adds `.vitest-attachments/` and `__screenshots__/` to `.gitignore`. A failing browser run writes both, neither was ignored, and they appear exactly when someone is already debugging and would stage them by accident. I hit it while mutation-testing.

183 tests (180 + 3). `pnpm lint`, `typecheck`, `test` and `docs:sync --check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
