### PR TITLE
fix(example): one wordmark fade across the lockup, as in the artwork

### DIFF
--- a/assets/header.svg
+++ b/assets/header.svg
@@ -15,7 +15,10 @@
   </defs>
   <rect width="1800" height="520" rx="48" fill="url(#glow)" />
   <text font-family="JetBrains Mono" font-weight="700" font-size="170" text-anchor="middle" x="900" y="248">
-    <tspan fill="url(#fade)">net</tspan><tspan fill="#2ee0c9"> | </tspan><tspan fill="url(#fade)">grep</tspan>
+    <!-- No spaces around the pipe: rsvg-convert, which renders the PNG beside
+         this file, strips them under xml:space="default", so the committed
+         artwork is `net|grep` and the spaces only ever showed in a browser. -->
+    <tspan fill="url(#fade)">net</tspan><tspan fill="#2ee0c9">|</tspan><tspan fill="url(#fade)">grep</tspan>
   </text>
   <text font-family="-apple-system, 'SF Pro Display', 'Helvetica Neue', sans-serif" font-weight="500" font-size="48" text-anchor="middle" x="900" y="368" xml:space="preserve">
     <tspan fill="#c9d1ce">grep over HTTP, </tspan><tspan fill="#2ee0c9">running in the browser.</tspan>

--- a/assets/social-preview.svg
+++ b/assets/social-preview.svg
@@ -14,7 +14,8 @@
   </defs>
   <rect width="2000" height="1000" fill="url(#glow)" />
   <text font-family="JetBrains Mono" font-weight="700" font-size="150" text-anchor="middle" x="1000" y="470">
-    <tspan fill="url(#fade)">net</tspan><tspan fill="#2ee0c9"> | </tspan><tspan fill="url(#fade)">grep</tspan>
+    <!-- No spaces around the pipe — see the note in header.svg. -->
+    <tspan fill="url(#fade)">net</tspan><tspan fill="#2ee0c9">|</tspan><tspan fill="url(#fade)">grep</tspan>
   </text>
   <text font-family="-apple-system, 'SF Pro Display', 'Helvetica Neue', sans-serif" font-weight="500" font-size="52" text-anchor="middle" x="1000" y="590" xml:space="preserve">
     <tspan fill="#c9d1ce">grep over HTTP, </tspan><tspan fill="#2ee0c9">running in the browser.</tspan>

--- a/packages/example/plugins/guide-render.ts
+++ b/packages/example/plugins/guide-render.ts
@@ -209,8 +209,9 @@ export function renderNav(current: 'demo' | 'docs', base: string): string {
   // one the eye had to rule out.
   const docsCurrent = current === 'docs' ? ' aria-current="page"' : '';
 
-  // A small version of the hero's `net | grep` wordmark (see hero.tsx):
-  // gradient name either side of a primary-coloured pipe, at nav size. Plain
+  // A small version of the hero's `net | grep` wordmark (see hero.tsx): one
+  // gradient across the anchor, showing through the two transparent name spans
+  // either side of a primary-coloured pipe, at nav size. Plain
   // classes rather than Tailwind utilities: this HTML is generated at build
   // time, outside Tailwind's scanner, so utilities here would work in dev and
   // vanish from the production build. Styled in index.css beside .site-nav.

--- a/packages/example/plugins/guide-render.ts
+++ b/packages/example/plugins/guide-render.ts
@@ -209,13 +209,14 @@ export function renderNav(current: 'demo' | 'docs', base: string): string {
   // one the eye had to rule out.
   const docsCurrent = current === 'docs' ? ' aria-current="page"' : '';
 
-  // A small version of the hero's `net | grep` wordmark (see hero.tsx): one
-  // gradient across the anchor, showing through the two transparent name spans
-  // either side of a primary-coloured pipe, at nav size. Plain
-  // classes rather than Tailwind utilities: this HTML is generated at build
-  // time, outside Tailwind's scanner, so utilities here would work in dev and
-  // vanish from the production build. Styled in index.css beside .site-nav.
-  const mark = `<a class="site-nav-mark" href="${base}"><span class="site-nav-mark-name">net</span><span class="site-nav-mark-pipe"> | </span><span class="site-nav-mark-name">grep</span></a>`;
+  // A small version of the hero's `net|grep` wordmark (see hero.tsx): one
+  // gradient across the lockup span, with a primary-coloured pipe painting
+  // over it, at nav size. No spaces around the pipe — the artwork has none.
+  // Plain classes rather than Tailwind utilities: this HTML is generated at
+  // build time, outside Tailwind's scanner, so utilities here would work in
+  // dev and vanish from the production build. Styled in index.css beside
+  // .site-nav.
+  const mark = `<a class="site-nav-mark" href="${base}"><span class="site-nav-mark-lockup">net<span class="site-nav-mark-pipe">|</span>grep</span></a>`;
 
   return `<header class="site-nav">
   ${mark}

--- a/packages/example/src/components/hero.tsx
+++ b/packages/example/src/components/hero.tsx
@@ -29,12 +29,20 @@ export function Hero() {
         instead. Must agree with assets/header.svg and the nav mark in
         plugins/guide-render.ts.
 
-        `text-gradient` sits on the <h1> so one fade crosses the whole lockup,
-        as it does in the image: white through `net`, the accent by `grep`. On
-        the spans it was two fades, and `grep` started over at white.
+        `text-gradient` wraps the whole lockup so one fade crosses it, as it
+        does in the image: white through `net`, the accent by `grep`. On the
+        two name spans it was two fades, and `grep` started over at white. The
+        carrier has to be this inline span and not the <h1>: `text-6xl` sets
+        line-height 1, so the block box is 1em tall and clips the background
+        off the descenders of `g` and `p`, while an inline box is sized from
+        the font's own metrics.
+
+        No spaces around the pipe — the artwork has none, and a monospace
+        pipe's side bearings are the gap.
       */}
-      <h1 className="text-gradient font-mono text-5xl font-semibold tracking-tight sm:text-6xl">
-        net<span className="text-primary">{' | '}</span>grep
+      <h1 className="font-mono text-5xl font-semibold tracking-tight sm:text-6xl">
+        {/* biome-ignore format: spaces here would land in the wordmark */}
+        <span className="text-gradient">net<span className="text-primary">|</span>grep</span>
       </h1>
 
       <p className="text-foreground/90 mt-6 max-w-2xl text-xl leading-relaxed text-balance sm:text-2xl">

--- a/packages/example/src/components/hero.tsx
+++ b/packages/example/src/components/hero.tsx
@@ -28,11 +28,13 @@ export function Hero() {
         API rewrite deleted the class; the pipe states the shell heritage
         instead. Must agree with assets/header.svg and the nav mark in
         plugins/guide-render.ts.
+
+        `text-gradient` sits on the <h1> so one fade crosses the whole lockup,
+        as it does in the image: white through `net`, the accent by `grep`. On
+        the spans it was two fades, and `grep` started over at white.
       */}
-      <h1 className="font-mono text-5xl font-semibold tracking-tight sm:text-6xl">
-        <span className="text-gradient">net</span>
-        <span className="text-primary">{' | '}</span>
-        <span className="text-gradient">grep</span>
+      <h1 className="text-gradient font-mono text-5xl font-semibold tracking-tight sm:text-6xl">
+        net<span className="text-primary">{' | '}</span>grep
       </h1>
 
       <p className="text-foreground/90 mt-6 max-w-2xl text-xl leading-relaxed text-balance sm:text-2xl">

--- a/packages/example/src/index.css
+++ b/packages/example/src/index.css
@@ -91,9 +91,11 @@
    *
    * Geometry copied from assets/header.svg, which is the wordmark of record:
    * horizontal, `net` held white to 40%, full teal by 80% so `grep` lands on
-   * the accent. Both carriers must paint this across the WHOLE `net | grep`
+   * the accent. Both carriers must paint this across the WHOLE `net|grep`
    * lockup — put it on the two name spans instead and the fade restarts on
-   * `grep`, which is what made the site disagree with the image.
+   * `grep`, which is what made the site disagree with the image. Carry it on
+   * an INLINE box: a block one is only as tall as its line-height, which crops
+   * the background off the descenders.
    */
   --wordmark-gradient: linear-gradient(
     to right,
@@ -181,22 +183,21 @@
  * comment in App.tsx — and two stacked sticky bars need offset coordination
  * that buys nothing on a page you scroll once.
  */
-/* The nav's small `net | grep` mark — see renderNav's comment for why this is
-   plain CSS rather than Tailwind utilities. Same composition as the hero's
-   <h1>, just subordinate in size: the gradient spans the whole lockup, and the
-   anchor is a flex item of .site-nav, so its box is exactly the mark's width. */
 .site-nav-mark {
   font-family: var(--font-mono);
   font-weight: 600;
   font-size: 1rem;
-  background-image: var(--wordmark-gradient);
-  background-clip: text;
 }
 
-/* The transparency stays on the spans rather than the anchor: `.site-nav a`
-   and its :hover both set a colour, and either would outrank a rule on
-   .site-nav-mark and paint the gradient over. */
-.site-nav-mark-name {
+/* The nav's small `net|grep` mark — see renderNav's comment for why this is
+   plain CSS rather than Tailwind utilities. Same composition as the hero's
+   <h1>, just subordinate in size: one fade across an inline span wrapping the
+   whole lockup. Not the anchor — that is a flex item of .site-nav, so it
+   blockifies, and `.site-nav a` and its :hover would both outrank a colour
+   set on it. */
+.site-nav-mark-lockup {
+  background-image: var(--wordmark-gradient);
+  background-clip: text;
   color: transparent;
 }
 
@@ -222,10 +223,9 @@
 @utility text-gradient {
   /* Wordmark treatment: white falling off to teal. The README banner is a
      screenshot of it, so this rule is the wordmark rather than a copy of one.
-     Goes on the element holding the whole lockup — the hero <h1>, whose box is
-     the mark's width because it is a centred flex item — not on the names
-     inside it. The gradient itself lives in --wordmark-gradient on :root,
-     shared with the nav mark. */
+     Goes on the inline span holding the whole lockup, not on the names inside
+     it, and not on the <h1> — see --wordmark-gradient on :root for both
+     reasons. The gradient itself lives there too, shared with the nav mark. */
   background-image: var(--wordmark-gradient);
   background-clip: text;
   color: transparent;

--- a/packages/example/src/index.css
+++ b/packages/example/src/index.css
@@ -86,13 +86,19 @@
 
   /*
    * The wordmark treatment: white falling off to teal. Defined once here so
-   * the hero's `.text-gradient` utility and the nav mark's `.site-nav-mark-name`
-   * below share one definition instead of two copies drifting apart.
+   * the hero's `.text-gradient` utility and the nav mark below share one
+   * definition instead of two copies drifting apart.
+   *
+   * Geometry copied from assets/header.svg, which is the wordmark of record:
+   * horizontal, `net` held white to 40%, full teal by 80% so `grep` lands on
+   * the accent. Both carriers must paint this across the WHOLE `net | grep`
+   * lockup — put it on the two name spans instead and the fade restarts on
+   * `grep`, which is what made the site disagree with the image.
    */
   --wordmark-gradient: linear-gradient(
-    100deg,
-    oklch(0.99 0 0) 20%,
-    oklch(0.812 0.128 181) 85%
+    to right,
+    oklch(0.99 0 0) 40%,
+    var(--primary) 80%
   );
 }
 
@@ -175,18 +181,22 @@
  * comment in App.tsx — and two stacked sticky bars need offset coordination
  * that buys nothing on a page you scroll once.
  */
+/* The nav's small `net | grep` mark — see renderNav's comment for why this is
+   plain CSS rather than Tailwind utilities. Same composition as the hero's
+   <h1>, just subordinate in size: the gradient spans the whole lockup, and the
+   anchor is a flex item of .site-nav, so its box is exactly the mark's width. */
 .site-nav-mark {
   font-family: var(--font-mono);
   font-weight: 600;
   font-size: 1rem;
-}
-
-/* The nav's small `net | grep` mark — see renderNav's comment for why this is
-   plain CSS rather than Tailwind utilities. Same composition as the hero's
-   <h1>, just subordinate in size. */
-.site-nav-mark-name {
   background-image: var(--wordmark-gradient);
   background-clip: text;
+}
+
+/* The transparency stays on the spans rather than the anchor: `.site-nav a`
+   and its :hover both set a colour, and either would outrank a rule on
+   .site-nav-mark and paint the gradient over. */
+.site-nav-mark-name {
   color: transparent;
 }
 
@@ -212,8 +222,10 @@
 @utility text-gradient {
   /* Wordmark treatment: white falling off to teal. The README banner is a
      screenshot of it, so this rule is the wordmark rather than a copy of one.
-     The gradient itself lives in --wordmark-gradient on :root, shared with
-     the nav mark's .site-nav-mark-name. */
+     Goes on the element holding the whole lockup — the hero <h1>, whose box is
+     the mark's width because it is a centred flex item — not on the names
+     inside it. The gradient itself lives in --wordmark-gradient on :root,
+     shared with the nav mark. */
   background-image: var(--wordmark-gradient);
   background-clip: text;
   color: transparent;


### PR DESCRIPTION
The site's `net|grep` did not look like `assets/header.svg`. Three things were wrong; all are fixed here.

**1. The fade restarted mid-word.** The hero `<h1>` and the `/docs` nav mark carried the gradient on **each of the two name spans**, so `background-clip: text` painted a separate gradient per span — white-to-teal ran once inside `net`, then **started over at white on `grep`**. The artwork fades once across the whole mark. The gradient was also angled (`100deg`) where the SVG's is horizontal.

**2. Too much space around the pipe.** The lockup was set as `net | grep`, with two real spaces. The committed PNGs have none: `rsvg-convert` renders them, and under SVG 1.1's `xml:space="default"` it strips the spaces around the pipe tspan. Measuring `assets/header.png` confirms it — eight character cells at 102px, not ten, with 64px between the `t` and the pipe where a space would have put 166. The visible gap is just a monospace pipe's side bearings.

**3. `g` and `p` were cropped.** `text-6xl` carries `line-height: 1`, so a gradient on the block `<h1>` had a box one em tall and no background to give the descenders.

## Changes

- **`src/index.css`** — `--wordmark-gradient` takes the SVG's geometry: `to right`, `net` held white to 40%, full teal by 80%.
- **`src/components/hero.tsx`**, **`plugins/guide-render.ts`** + CSS — the treatment rides one **inline** span wrapping the whole lockup, whose box comes from the font's metrics rather than the line box, with the pipe painting over it and no spaces beside it. The nav mark uses the same span instead of the gradient-on-the-anchor arrangement, which removes the specificity problem that rule had with `.site-nav a:hover` rather than working around it.
- **`assets/header.svg`**, **`assets/social-preview.svg`** — say `|` outright rather than ` | `. This changes no committed pixel; it settles which of two renderings is the artwork, since the sources render as the PNGs beside them under `rsvg-convert` but keep the spaces in a browser.

One judgment call worth a reviewer's eye: **the gradient's teal endpoint is `var(--primary)`, not the SVG's literal `#2ee0c9`** — `rgb(71,220,198)` vs `rgb(46,224,201)`, so `grep` is a hair paler than the PNG. The pipe is already `--primary`, and hardcoding the hex would put two different teals in a wordmark the artwork sets in one. Matching pixel-exactly is really a question about retuning `--primary`; happy to do that instead.

Follows #54, which brought the text to `net | grep` but left the per-span treatment in place. The PNGs and JPG are untouched — this brings the site to the artwork.

## Verification

Compared against `assets/header.png` at matched wordmark width: same gap either side of the pipe, same single fade, descenders whole. Hero and docs nav, the latter at rest and hovered. The remaining difference is the typeface — the site loads no webfont by design, so it renders in the system monospace rather than JetBrains Mono.

`pnpm test` — 212 passed (16 files). `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)